### PR TITLE
fix data updates when switching between slides

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -88,7 +88,7 @@ export default class EditorV extends Vue {
     contextLabel = '';
     dateModified = '';
     slides: any[] = [];
-    currentSlide = '';
+    currentSlide: any = '';
     slideIndex: number | undefined = undefined;
 
     created(): void {
@@ -108,9 +108,16 @@ export default class EditorV extends Vue {
         if (this.$refs.slide !== undefined) {
             (this.$refs.slide as any).saveChanges();
         }
-        this.currentSlide = this.slides[index];
-        this.slideIndex = index;
-        // console.log('NEW SELECTED SLIDE: ', this.currentSlide);
+
+        // Quickly swap to loading page, and then swap to new slide. Allows Vue to re-draw page correctly.
+        this.currentSlide = {
+            panel: [{ type: 'loading-page' }, { type: 'loading-page' }]
+        };
+
+        setTimeout(() => {
+            this.currentSlide = this.slides[index];
+            this.slideIndex = index;
+        }, 5);
     }
 
     newConfig(): void {

--- a/src/components/editor/helpers/loading-page.vue
+++ b/src/components/editor/helpers/loading-page.vue
@@ -1,0 +1,19 @@
+<template>
+    <div class="block py-20 align-middle text-center h-full" style="margin: 0 auto">
+        <spinner size="120px" background="#00D2D3" color="#009cd1" stroke="10px" style="margin: 0 auto"></spinner>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
+
+@Component({
+    components: {
+        spinner: Circle2
+    }
+})
+export default class LoadingPageV extends Vue {}
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -31,7 +31,9 @@
                             v-model="currentSlide.panel[panelIndex].type"
                         > -->
                             <option
-                                v-for="thing in Object.keys(editors).filter((editor) => editor !== 'slideshow')"
+                                v-for="thing in Object.keys(editors).filter(
+                                    (editor) => editor !== 'slideshow' && editor !== 'loading'
+                                )"
                                 :key="thing"
                                 :value="thing === 'image' ? 'slideshow' : thing"
                             >
@@ -66,6 +68,7 @@ import ChartEditorV from './chart-editor.vue';
 import ImageEditorV from './image-editor.vue';
 import TextEditorV from './text-editor.vue';
 import MapEditorV from './map-editor.vue';
+import LoadingPageV from './helpers/loading-page.vue';
 
 @Component({
     components: {
@@ -73,7 +76,8 @@ import MapEditorV from './map-editor.vue';
         'chart-editor': ChartEditorV,
         'image-editor': ImageEditorV,
         'text-editor': TextEditorV,
-        'map-editor': MapEditorV
+        'map-editor': MapEditorV,
+        'loading-page': LoadingPageV
     }
 })
 export default class SlideEditorV extends Vue {
@@ -90,7 +94,8 @@ export default class SlideEditorV extends Vue {
         image: 'image-editor',
         slideshow: 'image-editor',
         chart: 'chart-editor',
-        map: 'map-editor'
+        map: 'map-editor',
+        loading: 'loading-page'
     };
 
     changePanelType(type: string): void {


### PR DESCRIPTION
Closes #31 

Switching between slides will now correctly update the contents of the panels, even if switching between two of the same panel types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/33)
<!-- Reviewable:end -->
