### PR TITLE
Fix object reactivity when changing panel type

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -175,7 +175,7 @@ export default class EditorV extends Vue {
                                     type: 'slideshow',
                                     images: [slide.panel[1]]
                                 };
-                                slide.panel[1] = Object.assign({}, newSlide);
+                                Vue.set(slide.panel, 1, newSlide);
                             }
                         });
 

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -35,10 +35,6 @@
                             @change="changePanelType(currentSlide.panel[panelIndex].type, $event.target.value)"
                             :value="currentSlide.panel[panelIndex].type"
                         >
-                            <!-- <select
-                            @change="currentSlide.panel[panelIndex].type = $event.target.value"
-                            v-model="currentSlide.panel[panelIndex].type"
-                        > -->
                             <option
                                 v-for="thing in Object.keys(editors).filter(
                                     (editor) => editor !== 'slideshow' && editor !== 'loading'
@@ -111,8 +107,6 @@ export default class SlideEditorV extends Vue {
     };
 
     changePanelType(prevType: string, newType: string): void {
-        this.currentSlide.panel[this.panelIndex].type = newType;
-
         if (confirm(this.$t('editor.slides.changeSlide.confirm') as string)) {
             const startingConfig: DefaultConfigs = {
                 text: {
@@ -146,20 +140,17 @@ export default class SlideEditorV extends Vue {
             // When switching to a dynamic panel, remove the secondary panel.
             if (newType === 'dynamic') {
                 this.panelIndex = 0;
-                this.currentSlide.panel = [Object.assign({}, startingConfig[newType as keyof DefaultConfigs])];
+                Vue.set(this.currentSlide, 'panel', [startingConfig[newType as keyof DefaultConfigs]]);
             } else {
                 // When switching from a dynamic panel, add back the secondary panel.
                 if (prevType === 'dynamic') {
-                    this.currentSlide.panel = [
+                    Vue.set(this.currentSlide, 'panel', [
                         Object.assign({}, startingConfig['text' as keyof DefaultConfigs]),
                         Object.assign({}, startingConfig[newType as keyof DefaultConfigs])
-                    ];
+                    ]);
                 } else {
                     // Switching panel type when dynamic panels are not involved.
-                    this.currentSlide.panel[this.panelIndex] = Object.assign(
-                        {},
-                        startingConfig[newType as keyof DefaultConfigs]
-                    );
+                    Vue.set(this.currentSlide.panel, this.panelIndex, startingConfig[newType as keyof DefaultConfigs]);
                 }
             }
         }

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -92,7 +92,7 @@ export default class SlideTocV extends Vue {
                 this.slideIndex = undefined;
                 this.$emit('slide-change', this.slideIndex);
             }
-            this.slides.splice(index, 1) as any;
+            this.slides.splice(index, 1);
         }
     }
 


### PR DESCRIPTION
Closes #37 

Fix Vue 2 object property reactivity issues when changing between panel types. Also, I think an issue that can be logged after is having an option to restore previous config content for a multimedia panel for the case when a user changes panel type unintentionally (currently switching back to an old panel type will just start from scratch).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/61)
<!-- Reviewable:end -->
