### PR TITLE
normalize file saving between slides; add server files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 node_modules
 /dist
+server/node_modules
 
 
 # local env files

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+public/*

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,142 @@
+var express = require('express'); //Express Web Server
+var bodyParser = require('body-parser'); //connects bodyParsing middleware
+var formidable = require('formidable');
+var path = require('path'); //used for file path
+var fs = require('fs-extra'); //File System-needed for renaming file etc
+var cors = require('cors');
+const decompress = require('decompress');
+const archiver = require('archiver');
+
+// CONFIGURATION
+PORT = 6040; // the Express server will run on this port.
+UPLOAD_PATH = './files'; // files uploaded from the app will be uploaded to this folder (deleted after processing)
+TARGET_PATH = './public'; // ZIP files in the UPLOAD_PATH folder will be extracted here.
+
+// Create express app.
+var app = express();
+
+// Express middleware.
+app.use(express.static(path.join(__dirname, 'public')));
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+app.use(cors());
+
+// POST requests made to /upload will be handled here.
+app.route('/upload').post(function (req, res, next) {
+    const options = {
+        uploadDir: UPLOAD_PATH,
+        keepExtensions: true
+    };
+
+    const form = new formidable.IncomingForm(options);
+
+    // Project zip must match this or it will be rejected. Commented out because CWS didn't want to use the UUID system.
+    // We have a temporary solution for now, but I'm not sure how we want to handle this in the future.
+    //const projectNameRegex = /[a-zA-Z0-9]{8}(-[a-zA-Z0-9]{4}){3}-[a-zA-Z0-9]{12}/g;
+
+    // Upload the file to the server, into the /files/ folder.
+    form.parse(req, function (err, field, file) {
+        const fileName = `${TARGET_PATH}/${file.data.originalFilename.split('.zip')[0]}`;
+        const secureFilename = `${UPLOAD_PATH}/${file.data.newFilename}`;
+
+        // SECURITY FEATURE (?): Check if the uploaded filename matches our Storylines UUID format. Prevents overwriting
+        // other folders.
+        //if (!projectNameRegex.test(fileName)) {
+
+        // SECURITY FEATURE (temporary): Make sure the project name isn't `scripts`, or `help`, and doesn't contain . or / in order to prevent overwriting folders.
+        if (fileName !== 'scripts' && fileName !== 'help' && !fileName.includes('/') && !fileName.includes('.')) {
+            console.error('ABORTING: file does not match Storylines UUID standards.');
+
+            // Delete the uploaded zip file.
+            safeRM(secureFilename, UPLOAD_PATH);
+            res.end();
+            return;
+        }
+
+        // Before unzipping, create the product folder in /public/ if it doesn't exist already.
+        if (!fs.existsSync(fileName)) {
+            fs.mkdirSync(fileName);
+        }
+
+        // Unzip the contents of the uploaded zip file into the target directory. Will overwrite
+        // old files in the folder.
+        decompress(secureFilename, fileName).then((files) => {
+            // SECURITY FEATURE: delete all files in the folder that don't have one of the following extensions:
+            // .json, .jpg, .jpeg, .gif, .png, .csv
+            // TODO: Disabled until I can find a better regex
+            // files.forEach((file) => {
+            //     validateFile(file, fileName);
+            // });
+        });
+
+        // Finally, delete the uploaded zip file.
+        safeRM(secureFilename, UPLOAD_PATH);
+
+        // Send a response back to the client.
+        res.end();
+    });
+});
+
+// GET requests made to /retrieve/ID will be handled here.
+app.route('/retrieve/:id').get(function (req, res, next) {
+    var archive = archiver('zip');
+    const PRODUCT_PATH = `${TARGET_PATH}/${req.params.id}`;
+
+    // Check if the product exists.
+    if (
+        fs.access(PRODUCT_PATH, (error) => {
+            if (!error) {
+                // Tell the browser that this is a zip file.
+                res.writeHead(200, {
+                    'Content-Type': 'application/zip',
+                    'Content-disposition': `attachment; filename=${req.params.id}.zip`
+                });
+
+                // Send the ZIP contents to the client.
+                archive.pipe(res);
+                archive.directory(PRODUCT_PATH, false);
+                archive.finalize().then(() => {
+                    res.end();
+                });
+            } else {
+                res.status(404).send({ status: 'Not Found' });
+            }
+        })
+    );
+});
+
+/*
+ * Verifies that the file has a valid extension. If it's not valid, the file is removed.
+ *
+ * fileObj {Object} object returned by decompress, contains file path and file type.
+ * path {String} the path to the file
+ */
+function validateFile(fileObj, path) {
+    const fullPath = path + '/' + fileObj.path;
+
+    // Files within the project must match this or will be deleted.
+    const filenameRegex = /((?!\/)(?!\\).)+.(jpg|jpeg|png|gif|json|csv|md|html)/g;
+
+    // If the provided object is a file, check to see if it has a valid file extension.
+    if (fileObj.type === 'file' && !filenameRegex.test(fileObj.path)) {
+        console.error(`Validation of ${fileObj.path} failed. Deleting.`);
+        safeRM(fullPath, path);
+    }
+}
+
+/*
+ * SECURITY FEATURE: In order to ensure that the wrong files are never deleted. Makes sure that `path` contains the `folder`.
+ *
+ * path {String} The full path to delete. Equivalent to calling `rm path`.
+ * path {String} The folder that `path` should be in.
+ */
+function safeRM(path, folder) {
+    if (path.includes(folder)) {
+        fs.rm(path);
+    }
+}
+
+// Run the express app on port 6040.
+var server = app.listen(6040, function () {
+    console.log('Listening on port %d', server.address().port);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,21 @@
+{
+    "name": "storylines-upload",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "",
+    "license": "ISC",
+    "dependencies": {
+        "archiver": "^5.3.1",
+        "body-parser": "^1.20.1",
+        "cors": "^2.8.5",
+        "decompress": "^4.2.1",
+        "express": "^4.18.2",
+        "formidable": "^2.1.1",
+        "fs-extra": "^11.1.0",
+        "path": "^0.12.7"
+    }
+}

--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -36,6 +36,7 @@
                 v-for="(chart, idx) in chartConfigs"
                 :key="idx"
                 :chart="chart"
+                :configFileStructure="configFileStructure"
                 @delete="deleteChart"
                 @edit="editChart"
             ></ChartPreview>
@@ -116,8 +117,7 @@ export default class ChartEditorV extends Vue {
         } else {
             const chartConfig = {
                 name: chart.title.text,
-                src: `${this.configFileStructure.uuid}/charts/en/${chart.title.text}.json`,
-                config: chart
+                src: `${this.configFileStructure.uuid}/charts/en/${chart.title.text}.json`
             };
 
             // Add chart config to ZIP file.
@@ -137,6 +137,7 @@ export default class ChartEditorV extends Vue {
                 JSON.stringify(chartInfo.newChart.config, null, 4)
             );
 
+            chartInfo.newChart.src = `${this.configFileStructure.uuid}/charts/en/${chartInfo.newChart.name}.json`;
             this.chartConfigs[idx] = chartInfo.newChart;
         }
     }

--- a/src/components/editor/helpers/chart-preview.vue
+++ b/src/components/editor/helpers/chart-preview.vue
@@ -16,6 +16,7 @@
                 class="w-full h-full"
                 :config="chartConfig"
                 :key="chartIdx"
+                :configFileStructure="configFileStructure"
                 @loaded="loadChart"
                 v-if="!loading"
             ></dqv-chart>
@@ -54,6 +55,7 @@ import ChartV from '@/components/panels/helpers/chart.vue';
 })
 export default class ChartPreviewV extends Vue {
     @Prop() chart!: ChartConfig;
+    @Prop() configFileStructure!: any;
 
     loading = true;
     chartIdx = 0;

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -12,9 +12,24 @@
             </div>
             <br />
             <div class="flex">
-                <button @click="panelIndex = 0" :class="panelIndex == 0 ? 'font-extrabold' : ''">Left Panel</button>
                 <button
-                    @click="panelIndex = 1"
+                    @click="
+                        () => {
+                            panelIndex = 0;
+                            saveChanges();
+                        }
+                    "
+                    :class="panelIndex == 0 ? 'font-extrabold' : ''"
+                >
+                    Left Panel
+                </button>
+                <button
+                    @click="
+                        () => {
+                            panelIndex = 1;
+                            saveChanges();
+                        }
+                    "
                     :class="panelIndex == 1 ? 'font-extrabold' : ''"
                     v-if="currentSlide.panel[panelIndex].type !== 'dynamic'"
                 >

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -7,7 +7,7 @@
             :lang="lang"
         />
 
-        <Scrollama class="relative story-scrollama" @step-enter="stepEnter">
+        <Scrollama class="relative story-scrollama w-full" @step-enter="stepEnter">
             <div
                 v-for="(slide, idx) in config.slides"
                 class="flex pt-24"


### PR DESCRIPTION
Closes #54, #51, and #63

# Changes in this PR
* #54: The editor now relies on the Express server for downloading and saving data.
* Added the Express server code to the repo 
* As discussed in #60: Normalized how our current slide editors save data. All media and configuration files are now saved in the ZIP file, and can be easily accessed if needed.
* #51: If a UID is requested and does not exist on the server, an error is displayed.
* #63: Swapping between left and right panels will save contents before switching.

# Set-up
Since the editor now requires the server to be running to work, I've included the code in the repo. 

To set up this server, go into the `server` directory and run `npm i`, then run `node index.js`. This should launch the server locally at `localhost:6040`.

You can then serve the Storylines editor locally as usual, with `npm run serve`. Just use a different terminal window so you can have both running at once.

The editor will access products from (and will save them to) the `server/public/` directory. The `TARGET_PATH` variable in the server code can be modified to change the target directory to the main `public/` folder, but this causes the whole app to reload due to the automatic refresh on code change which is why I didn't do this myself.


If there's any confusion with the ZIP file or the server stuff, feel free to ask me!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/64)
<!-- Reviewable:end -->
