### PR TITLE
Revamp landing and metadata page

### DIFF
--- a/src/components/editor/landing.vue
+++ b/src/components/editor/landing.vue
@@ -1,0 +1,36 @@
+<template>
+    <div class="flex justify-center">
+        <div class="home-btn-container border-4 border-gray-400 border-solid m-24">
+            <router-link
+                :to="{ name: 'metadata', params: { editExisting: false } }"
+                class="flex justify-center h-full w-full"
+                target
+            >
+                <button class="text-2xl font-bold">+ {{ $t('editor.createProduct') }}</button>
+            </router-link>
+        </div>
+        <div class="home-btn-container border-4 border-gray-400 border-solid m-24">
+            <router-link
+                :to="{ name: 'metadata', params: { editExisting: true } }"
+                class="flex justify-center h-full w-full"
+                target
+            >
+                <button class="text-2xl font-bold">{{ $t('editor.editProduct') }}</button>
+            </router-link>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+
+@Component({})
+export default class LandingV extends Vue {}
+</script>
+
+<style lang="scss">
+.home-btn-container {
+    height: 60vh;
+    width: 40vh;
+}
+</style>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -22,6 +22,8 @@ editor.contextLabel,Context Label,1,Libellé de contexte,0
 editor.dateModified,Date Modified,1,Date modifiée,0
 editor.load,Load,1,Charger,0
 editor.browse,Browse,1,Parcourir,0
+editor.back,Back,1,Retour,1
+editor.next,Next,1,Suivant,1
 editor.frenchConfig,View French Config,1,Afficher la configuration française,0
 editor.englishConfig,View English Config,1,Afficher la configuration en anglais,0
 editor.image.delete,Delete Image,1,Supprimer l'image,0

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import StoryV from '@/components/story/story.vue';
+import LandingV from '@/components/editor/landing.vue';
 import EditorV from '@/components/editor/editor.vue';
 import Router, { Route } from 'vue-router';
 
@@ -12,10 +13,18 @@ const routes = [
     },
     {
         path: '/:lang/editor',
-        component: EditorV
+        name: 'home',
+        component: LandingV
+    },
+    {
+        path: '/:lang/editor-metadata',
+        name: 'metadata',
+        component: EditorV,
+        props: true
     },
     {
         path: '/:lang/editor/:uid',
+        name: 'editor',
         component: EditorV
     },
     {


### PR DESCRIPTION
Closes #65 

Adds a new landing page to select between creating a new product or editing an existing product. This will direct to the current metadata page. Made some small styling adjustments but mainly added two routing buttons to replace the `TESTING CONFIG` instance that will either take the user back to the home page or to the editor itself. The user may only proceed to the editor when they are either creating a new product or editing an existing product and provided a valid UID with a successfully fetched config. The `Load` button will now fetch config and populate the metadata content fields rather than directly moving to the editor.

Feel free to make any UI suggestions and I can make changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/75)
<!-- Reviewable:end -->
