### PR TITLE
Slide editor and TOC styling

### DIFF
--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -2,14 +2,21 @@
     <div class="block">
         <!-- left and right panel buttons for dynamic panels -->
         <div class="flex">
-            <button @click="() => changePanel('text')" :class="editingStatus === 'text' ? 'font-extrabold' : ''">
+            <button
+                @click="() => changePanel('text')"
+                class="border hover:bg-gray-100"
+                :class="editingStatus === 'text' ? 'border-black' : 'border-gray-300'"
+            >
                 Text Section
             </button>
-            <button @click="() => changePanel('panels')" :class="editingStatus !== 'text' ? 'font-extrabold' : ''">
+            <button
+                @click="() => changePanel('panels')"
+                class="border hover:bg-gray-100"
+                :class="editingStatus !== 'text' ? 'border-black' : 'border-gray-300'"
+            >
                 Panel Collection
             </button>
         </div>
-        <br />
         <!-- Text Section -->
         <div v-if="editingStatus === 'text'">
             <component
@@ -21,7 +28,7 @@
             ></component>
         </div>
         <div v-if="editingStatus === 'panels'">
-            <table class="w-2/3">
+            <table class="w-2/3 mt-5">
                 <tr class="table-header">
                     <th>Panel ID</th>
                     <th>Panel Type</th>

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -2,33 +2,76 @@
     <!-- If the configuration file is being fetched, display a spinner to indicate loading. -->
     <div class="editor-container">
         <template v-if="(loadStatus === 'waiting') | 'error'">
-            <div class="flex">
-                <div class="flex text-2xl font-bold mb-5">
-                    {{ config ? $t('editor.editProduct') : $t('editor.createProduct') }}
+            <div class="px-20 py-5">
+                <div class="flex">
+                    <div class="flex text-2xl font-bold mb-5">
+                        {{ config ? $t('editor.editProduct') : $t('editor.createProduct') }}
+                    </div>
+                    <button v-if="config" @click="swapLang">
+                        {{ lang === 'en' ? $t('editor.frenchConfig') : $t('editor.englishConfig') }}
+                    </button>
                 </div>
-                <button v-if="config" @click="swapLang">
-                    {{ lang === 'en' ? $t('editor.frenchConfig') : $t('editor.englishConfig') }}
+
+                <div class="border py-5 w-5/6">
+                    <label>{{ $t('editor.uuid') }}:</label>
+                    <input
+                        type="text"
+                        @input="uidError = false"
+                        v-model="uuid"
+                        class="w-1/3"
+                        :class="uidError ? 'input-error' : ''"
+                    />
+                    <button
+                        v-on:click="generateRemoteConfig"
+                        class="bg-gray-500 text-white hover:bg-gray-600"
+                        :class="uidError ? 'input-error' : ''"
+                    >
+                        {{ $t('editor.load') }}
+                    </button>
+                    <span v-if="uidError">The requested UID "{{ uuid }}" does not exist.</span>
+                </div>
+
+                <br />
+
+                <div class="mb-4">
+                    <h3>Storylines product details</h3>
+                    <p>
+                        Fill in metadata details about your new Storyline. Use the “Preview” button to see what your
+                        slides will look like.
+                    </p>
+                </div>
+
+                <label class="mb-5">{{ $t('editor.title') }}:</label>
+                <input type="text" v-model="title" class="w-1/3" /> <br />
+                <label class="mb-5">{{ $t('editor.logo') }}:</label><input type="text" v-model="logo" class="w-1/4" />
+                <button v-on:click="generateRemoteConfig" class="bg-black text-white hover:bg-gray-800">
+                    {{ $t('editor.browse') }}
                 </button>
+                <br />
+                <label>{{ $t('editor.contextLink') }}:</label>
+                <input type="text" v-model="contextLink" class="w-2/3" />
+                <br />
+                <label class="mb-5"></label>
+                <p class="inline-block">
+                    <i>
+                        Context link shows up at the bottom of the page to provide additional resources for interested
+                        users
+                    </i>
+                </p>
+                <br />
+                <label>{{ $t('editor.contextLabel') }}:</label>
+                <input type="text" v-model="contextLabel" class="w-2/3" />
+                <br />
+                <label class="mb-5"></label>
+                <p class="inline-block">
+                    <i> Context label shows up before the context link to explain what the link is for </i>
+                </p>
+                <br />
+                <label class="mb-5">{{ $t('editor.dateModified') }}:</label>
+                <input type="date" v-model="dateModified" /> <br /><br />
+
+                <button v-on:click="generateNewConfig">TESTING CONFIG</button>
             </div>
-
-            <label>{{ $t('editor.uuid') }}:</label>
-            <input type="text" @input="uidError = false" v-model="uuid" :class="uidError ? 'input-error' : ''" />
-            <button v-on:click="generateRemoteConfig" :class="uidError ? 'input-error' : ''">
-                {{ $t('editor.load') }}
-            </button>
-            <span v-if="uidError">The requested UID "{{ uuid }}" does not exist.</span>
-
-            <br />
-
-            <label>{{ $t('editor.title') }}:</label> <input type="text" v-model="title" /> <br />
-            <label>{{ $t('editor.logo') }}:</label> <input type="text" v-model="logo" />
-            <button v-on:click="generateRemoteConfig">{{ $t('editor.browse') }}</button>
-            <br />
-            <label>{{ $t('editor.contextLink') }}:</label> <input type="text" v-model="contextLink" /> <br />
-            <label>{{ $t('editor.contextLabel') }}:</label> <input type="text" v-model="contextLabel" /> <br />
-            <label>{{ $t('editor.dateModified') }}:</label> <input type="date" v-model="dateModified" /> <br /><br />
-
-            <button v-on:click="generateNewConfig">TESTING CONFIG</button>
         </template>
 
         <!-- If config is loading, display a small spinner. -->
@@ -37,16 +80,39 @@
         </div>
 
         <template v-if="loadStatus === 'loaded'">
-            <div class="flex">
-                <span>{{ config.title }}</span
-                ><span class="ml-auto"></span><button>Preview</button
-                ><button @click="generateConfig">Save Changes</button>
+            <div class="flex border-b border-black bg-gray-200 py-2 px-2">
+                <span class="m-1 font-semibold text-lg">{{ config.title }}</span>
+                <span class="ml-auto"></span>
+                <button class="bg-white border border-black hover:bg-gray-100">Preview</button>
+                <button @click="generateConfig" class="bg-black text-white hover:bg-gray-900">Save Changes</button>
             </div>
             <div class="flex">
-                <div class="w-60 flex-shrink-0">
-                    <button>Edit Project Metadata</button>
+                <div class="w-80 flex-shrink-0 border-r border-black editor-toc">
+                    <div class="flex items-center justify-center border-b p-2">
+                        <button>
+                            <span class="align-middle inline-block px-1"
+                                ><svg
+                                    clip-rule="evenodd"
+                                    fill-rule="evenodd"
+                                    width="16"
+                                    height="16"
+                                    stroke-linejoin="round"
+                                    stroke-miterlimit="2"
+                                    viewBox="0 0 24 24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                >
+                                    <path
+                                        d="m4.481 15.659c-1.334 3.916-1.48 4.232-1.48 4.587 0 .528.46.749.749.749.352 0 .668-.137 4.574-1.492zm1.06-1.061 3.846 3.846 11.321-11.311c.195-.195.293-.45.293-.707 0-.255-.098-.51-.293-.706-.692-.691-1.742-1.74-2.435-2.432-.195-.195-.451-.293-.707-.293-.254 0-.51.098-.706.293z"
+                                        fill-rule="nonzero"
+                                    />
+                                </svg>
+                            </span>
+                            <span class="align-middle inline-block">Edit Project Metadata</span>
+                        </button>
+                    </div>
                     <slide-toc
                         :slides="slides"
+                        :currentSlide="currentSlide"
                         :slideIndex="slideIndex"
                         @slide-change="selectSlide"
                         @slides-updated="updateSlides"
@@ -349,17 +415,20 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     }
 
     .editor-container label {
-        width: 10vw;
+        width: 8vw;
         text-align: right;
         margin-right: 15px;
         display: inline-block;
     }
 
+    .editor-container h3 {
+        font-size: larger;
+    }
+
     .editor-container input {
         padding: 5px 10px;
-        margin: 2px;
+        margin-top: 5px;
         border: 1px solid black;
-        width: 20vw;
     }
 
     .editor-container .input-error {
@@ -367,15 +436,29 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     }
 
     .editor-container button {
-        padding: 5px 10px;
-        margin: 2px;
-        border: 1px solid black;
+        padding: 5px 12px;
+        margin: 0px 10px;
+        font-weight: 600;
+        transition-duration: 0.2s;
+    }
+
+    .editor-container button:hover:enabled {
+        background-color: #dbdbdb;
+        color: black;
     }
 
     .editor-container button:disabled {
         border: 1px solid gray;
         color: gray;
         cursor: not-allowed;
+    }
+
+    .editor-toc button {
+        background-color: #f3f4f6;
+        color: black;
+        border: none !important;
+        transition-duration: 0.2s;
+        padding: 0.25 0.25em !important;
     }
 }
 </style>

--- a/src/components/editor/helpers/chart-preview.vue
+++ b/src/components/editor/helpers/chart-preview.vue
@@ -1,8 +1,8 @@
 <template>
-    <li class="chart-item items-center my-8 mx-5 overflow-hidden">
+    <li class="chart-item items-center mt-8 mx-5 overflow-hidden">
         <div class="relative border-solid border-2 items-center justify-center text-center w-full">
             <button
-                class="bg-white absolute h-6 w-6 leading-5 rounded-full top-0 left-0 z-10 cursor-pointer"
+                class="bg-white absolute h-6 w-6 leading-5 rounded-full top-2 left-0 z-10 cursor-pointer"
                 @click="() => $emit('delete', chart)"
             >
                 <svg height="22px" width="22px" viewBox="0 0 352 512" xmlns="http://www.w3.org/2000/svg">
@@ -99,9 +99,5 @@ export default class ChartPreviewV extends Vue {
 <style lang="scss" scoped>
 .chart-item {
     width: 46%;
-
-    button {
-        padding: 0 !important;
-    }
 }
 </style>

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -2,22 +2,31 @@
     <div class="block">
         <!-- Upload images area -->
         <div
-            class="upload-image text-center m-5 p-12 bg-blue-100"
+            class="upload-image text-center m-5 p-12 bg-blue-100 border-4 border-dashed border-blue-300"
             :class="{ dragging: isDragging }"
             @dragover.prevent="() => (dragging = true)"
             @dragleave.prevent="() => (dragging = false)"
             @drop.prevent="dropImages($event)"
         >
-            <label class="drag-label cursor-pointer">
-                <span>
-                    <div>{{ $t('editor.image.label.drag') }}</div>
-                    <div>
-                        {{ $t('editor.image.label.or') }}
-                        <span class="text-blue-400 font-bold">{{ $t('editor.image.label.browse') }}</span>
-                        {{ $t('editor.image.label.upload') }}
-                    </div>
+            <label class="flex drag-label cursor-pointer">
+                <span class="align-middle inline-block pr-4">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24">
+                        <path
+                            d="M14 9l-2.519 4-2.481-1.96-5 6.96h16l-6-9zm8-5v16h-20v-16h20zm2-2h-24v20h24v-20zm-20 6c0-1.104.896-2 2-2s2 .896 2 2c0 1.105-.896 2-2 2s-2-.895-2-2z"
+                        />
+                    </svg>
                 </span>
-                <input type="file" class="cursor-pointer" @change="onFileChange" multiple="multiple" />
+                <span class="align-middle inline-block">
+                    <span>
+                        <div>{{ $t('editor.image.label.drag') }}</div>
+                        <div>
+                            {{ $t('editor.image.label.or') }}
+                            <span class="text-blue-400 font-bold">{{ $t('editor.image.label.browse') }}</span>
+                            {{ $t('editor.image.label.upload') }}
+                        </div>
+                    </span>
+                    <input type="file" class="cursor-pointer" @change="onFileChange" multiple="multiple" />
+                </span>
             </label>
         </div>
 

--- a/src/components/editor/map-editor.vue
+++ b/src/components/editor/map-editor.vue
@@ -4,32 +4,25 @@
         <input type="text" v-model="panel.title" />
 
         <div v-if="status === 'editing'">
-            <label class="text-left">Enable Scrollguard:</label>
-            <select @change="panel.scrollguard = $event.target.value" v-model="panel.scrollguard" selected="true">
-                <option>true</option>
-                <option>false</option>
-            </select>
+            <label class="mt-2">Enable Scrollguard:</label>
+            <input type="checkbox" @change="panel.scrollguard = $event.target.value" v-model="panel.scrollguard" />
+            <span class="ml-6"></span>
+            <label class="mt-2">Enable Time Slider:</label>
+            <input type="checkbox" @change="usingTimeSlider = $event.target.value" v-model="usingTimeSlider" />
             <br />
 
-            <label>Time Slider Enabled:</label>
-            <select @change="usingTimeSlider = $event.target.value" v-model="usingTimeSlider">
-                <option>true</option>
-                <option>false</option>
-            </select>
-            <br />
-
-            <label>Map Editor:</label>
-
-            <div
-                style="width: 70vw"
-                class="text-right cursor-pointer"
-                @click="
-                    () => {
-                        status = 'default';
-                    }
-                "
-            >
-                Cancel Editing
+            <div class="flex justify-between mb-4">
+                <label class="mt-2">Map Editor:</label>
+                <button
+                    class="border border-black hover:bg-gray-100"
+                    @click="
+                        () => {
+                            status = 'default';
+                        }
+                    "
+                >
+                    Cancel Editing
+                </button>
             </div>
             <iframe
                 src="scripts/ramp-editor/samples/fgpv-author.html"
@@ -38,10 +31,10 @@
             ></iframe>
         </div>
         <div v-if="status === 'creating'">
-            <label class="text-left">Map config name*:</label>
+            <label class="text-left mt-2">Map config name*:</label>
             <div class="flex flex-row items-center"><input type="text" v-model="newFileName" />.json</div>
 
-            <ul class="flex flex-wrap list-none" v-if="newFileName != ''">
+            <ul class="flex flex-wrap list-none justify-center" v-if="newFileName != ''">
                 <li class="map-item items-center my-8 mx-5 overflow-hidden" @click="createNewConfig">
                     <div class="add-map"></div>
                     {{ $t('editor.map.label.create') }}
@@ -49,8 +42,8 @@
             </ul>
         </div>
         <div v-if="status === 'default'">
-            <label class="text-left">Map Editor:</label>
-            <ul class="flex flex-wrap list-none">
+            <label class="text-left mt-2">Map Editor:</label>
+            <ul class="flex flex-wrap list-none justify-center">
                 <li class="map-item items-center my-8 mx-5 overflow-hidden" @click="openEditor">
                     <div class="edit-map"></div>
                     {{ $t('editor.map.label.edit') }}
@@ -162,6 +155,13 @@ export default class MapEditorV extends Vue {
 <style lang="scss" scoped>
 label {
     text-align: left !important;
+    width: fit-content !important;
+}
+
+select {
+    border: 1px black solid;
+    background: white;
+    padding: 0.25rem 0.5rem;
 }
 .map-item {
     width: 300px;

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -1,17 +1,31 @@
 <template>
-    <div class="flex-grow mx-5">
+    <div class="flex-grow m-5">
         <div v-if="currentSlide !== ''">
             <div class="flex">
                 <div class="flex flex-col">
                     <label>Slide title:</label>
-                    <input type="text" v-model="currentSlide.title" />
+                    <div class="flex">
+                        <input type="text" v-model="currentSlide.title" class="w-2/3" />
+                        <span class="ml-auto"></span>
+                        <button
+                            @click.stop="selectSlide(slideIndex - 1)"
+                            :disabled="slideIndex === 0"
+                            class="border border-black"
+                        >
+                            Previous Slide
+                        </button>
+                        <button
+                            @click.stop="selectSlide(slideIndex + 1)"
+                            :disabled="isLast"
+                            class="border border-black"
+                        >
+                            Next Slide
+                        </button>
+                    </div>
                 </div>
-                <span class="ml-auto"></span>
-                <button @click.stop="selectSlide(slideIndex - 1)" :disabled="slideIndex === 0">Previous Slide</button>
-                <button @click.stop="selectSlide(slideIndex + 1)" :disabled="isLast">Next Slide</button>
             </div>
             <br />
-            <div class="flex">
+            <div class="flex border-b border-black">
                 <button
                     @click="
                         () => {
@@ -19,9 +33,44 @@
                             saveChanges();
                         }
                     "
-                    :class="panelIndex == 0 ? 'font-extrabold' : ''"
+                    class="border-t border-l border-r"
+                    :class="panelIndex == 0 ? 'border-black' : 'border-white'"
                 >
-                    Left Panel
+                    <span class="align-middle inline-block">
+                        <svg
+                            clip-rule="evenodd"
+                            fill-rule="evenodd"
+                            width="15"
+                            height="15"
+                            stroke-linejoin="round"
+                            stroke-miterlimit="2"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="m21 4c0-.478-.379-1-1-1h-16c-.62 0-1 .519-1 1v16c0 .621.52 1 1 1h16c.478 0 1-.379 1-1z"
+                                fill-rule="nonzero"
+                            />
+                        </svg>
+                    </span>
+                    <span class="align-middle inline-block">
+                        <svg
+                            clip-rule="evenodd"
+                            fill-rule="evenodd"
+                            width="15"
+                            height="15"
+                            stroke-linejoin="round"
+                            stroke-miterlimit="2"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="m21 4c0-.478-.379-1-1-1h-16c-.62 0-1 .519-1 1v16c0 .621.52 1 1 1h16c.478 0 1-.379 1-1zm-16.5.5h15v15h-15z"
+                                fill-rule="nonzero"
+                            />
+                        </svg>
+                    </span>
+                    <span class="align-middle inline-block pl-1">Left Panel</span>
                 </button>
                 <button
                     @click="
@@ -30,22 +79,57 @@
                             saveChanges();
                         }
                     "
-                    :class="panelIndex == 1 ? 'font-extrabold' : ''"
+                    class="border-t border-l border-r"
+                    :class="panelIndex == 1 ? 'border-black' : 'border-white'"
                     v-if="currentSlide.panel[panelIndex].type !== 'dynamic'"
                 >
-                    Right Panel
+                    <span class="align-middle inline-block">
+                        <svg
+                            clip-rule="evenodd"
+                            fill-rule="evenodd"
+                            width="15"
+                            height="15"
+                            stroke-linejoin="round"
+                            stroke-miterlimit="2"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="m21 4c0-.478-.379-1-1-1h-16c-.62 0-1 .519-1 1v16c0 .621.52 1 1 1h16c.478 0 1-.379 1-1zm-16.5.5h15v15h-15z"
+                                fill-rule="nonzero"
+                            />
+                        </svg>
+                    </span>
+                    <span class="align-middle inline-block">
+                        <svg
+                            clip-rule="evenodd"
+                            fill-rule="evenodd"
+                            width="15"
+                            height="15"
+                            stroke-linejoin="round"
+                            stroke-miterlimit="2"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="m21 4c0-.478-.379-1-1-1h-16c-.62 0-1 .519-1 1v16c0 .621.52 1 1 1h16c.478 0 1-.379 1-1z"
+                                fill-rule="nonzero"
+                            />
+                        </svg>
+                    </span>
+
+                    <span class="align-middle inline-block pl-1">Right Panel</span>
                 </button>
             </div>
-            <br />
             <div>
-                <div class="flex">
+                <div class="flex mt-4">
                     <span class="font-bold text-xl">Content:</span>
                     <span class="ml-auto flex-grow"></span>
                     <div
                         v-if="panelIndex === 1 || currentSlide.panel[panelIndex].type === 'dynamic'"
-                        class="flex flex-col"
+                        class="flex flex-col mr-8"
                     >
-                        <label class="text-left text-xl">Content type:</label>
+                        <label class="text-left text-lg">Content type:</label>
                         <select
                             @change="changePanelType(currentSlide.panel[panelIndex].type, $event.target.value)"
                             :value="currentSlide.panel[panelIndex].type"
@@ -73,7 +157,7 @@
                 ></component>
             </div>
         </div>
-        <div v-else>
+        <div v-else class="flex h-full mt-4 justify-center text-gray-600 text-xl">
             <span>Please select a slide to edit.</span>
         </div>
     </div>
@@ -188,6 +272,13 @@ export default class SlideEditorV extends Vue {
 <style lang="scss" scoped>
 label {
     text-align: left !important;
+    margin-left: 0.5rem;
+}
+
+select {
+    border: 1px black solid;
+    background: white;
+    padding: 0.25rem 0.5rem;
 }
 
 .table-of-contents-slide button {

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -1,29 +1,37 @@
 <template>
     <div>
-        <div class="flex">
-            <span>{{ $t('editor.slides.title') }}</span>
+        <div class="flex toc-header p-2 mt-10">
+            <span class="flex items-center justify-center font-bold"> {{ $t('editor.slides.title') }}</span>
+            <span class="flex-1"></span>
             <span class="ml-auto"></span>
-            <button v-on:click="addNewSlide">{{ $t('editor.slides.addSlide') }}</button>
+            <button v-on:click="addNewSlide">
+                <span class="align-middle inline-block px-1"
+                    ><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24">
+                        <path d="M24 10h-10v-10h-4v10h-10v4h10v10h4v-10h10z" />
+                    </svg>
+                </span>
+                <span class="align-middle inline-block">{{ $t('editor.slides.addSlide') }}</span>
+            </button>
         </div>
         <ul>
-            <li class="flex toc-slide" v-for="(slide, index) in slides" :key="slide.title + index">
+            <li class="flex toc-slide border-t" v-for="(slide, index) in slides" :key="slide.title + index">
                 <div
-                    class="flex cursor-pointer pl-1"
-                    :class="{ 'bg-gray-400 font-bold': index === slideIndex }"
+                    class="flex px-2 cursor-pointer hover:bg-gray-100"
+                    :class="currentSlide === slide ? 'bg-gray-100' : ''"
                     @click="selectSlide(index)"
                 >
-                    <span class="self-center w-44 overflow-ellipsis whitespace-nowrap overflow-hidden flex-shrink-0"
-                        >Slide {{ index + 1 }}: {{ slide.title | '' }}</span
+                    <span class="self-center overflow-ellipsis whitespace-nowrap overflow-hidden flex-shrink-0 ml-2"
+                        >Slide {{ index + 1 }}: <span class="font-bold">{{ slide.title || '' }}</span></span
                     >
                     <span class="ml-auto flex-grow"></span>
                     <button @click.stop="removeSlide(index)">
-                        <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24">
                             <path
-                                d="M7 21q-.825 0-1.412-.587Q5 19.825 5 19V6H4V4h5V3h6v1h5v2h-1v13q0 .825-.587 1.413Q17.825 21 17 21Zm2-4h2V8H9Zm4 0h2V8h-2Z"
+                                d="M3 6l3 18h12l3-18h-18zm19-4v2h-20v-2h5.711c.9 0 1.631-1.099 1.631-2h5.316c0 .901.73 2 1.631 2h5.711z"
                             />
                         </svg>
                     </button>
-                    <div class="flex flex-col">
+                    <div class="flex flex-col mr-2 ml-1 my-1">
                         <button
                             :class="index == 0 ? 'text-gray-500 cursor-not-allowed' : ''"
                             @click.stop="moveUp(index)"
@@ -64,7 +72,9 @@ import SlideEditorV from './slide-editor.vue';
 })
 export default class SlideTocV extends Vue {
     @Prop() slides!: any[];
+    @Prop() currentSlide!: any;
     @Prop() slideIndex!: number;
+    total = 0;
 
     selectSlide(index: number): void {
         this.$emit('slide-change', index);
@@ -72,7 +82,7 @@ export default class SlideTocV extends Vue {
 
     addNewSlide(): void {
         this.slides.push({
-            title: 'New Slide',
+            title: `Untitled${this.total ? '(' + this.total + ')' : ''}`,
             panel: [
                 {
                     type: 'text',
@@ -87,6 +97,7 @@ export default class SlideTocV extends Vue {
             ]
         });
         this.$emit('slides-updated', this.slides);
+        this.total++;
     }
 
     removeSlide(index: number): void {
@@ -113,6 +124,12 @@ export default class SlideTocV extends Vue {
 <style lang="scss" scoped>
 .toc-slide button {
     border: none !important;
+    background: none !important;
     padding: 0 !important;
+    margin: 0 !important;
+}
+
+.toc-slide button:hover {
+    background: none !important;
 }
 </style>

--- a/src/components/editor/text-editor.vue
+++ b/src/components/editor/text-editor.vue
@@ -1,8 +1,8 @@
 <template>
-    <div class="flex flex-col">
+    <div class="flex flex-col mt-4">
         <label class="text-left">Panel title:</label>
         <input type="text" v-model="panel.title" />
-        <label class="text-left">Panel body:</label>
+        <label class="text-left mt-2">Panel body:</label>
         <v-md-editor
             v-model="panel.content"
             height="400px"

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -37,7 +37,7 @@ editor.chart.label.info,Interactive charts ({num}),1,Interactive charts ({num}),
 editor.map.label.create,Create New Configuration File,1,Create New Configuration File,0
 editor.map.label.edit,Edit Map Configuration,1,Edit Map Configuration,0
 editor.slides.title,SLIDES,1,SLIDES,0
-editor.slides.addSlide,"+ New Slide",1,"+ New Slide",0
+editor.slides.addSlide,"New Slide",1,"New Slide",0
 editor.slides.deleteSlide.confirm,"Are you sure you want to delete this slide?",1,"Are you sure you want to delete this slide?",0
 editor.slides.changeSlide.confirm,"Are you sure you want to change this slide? All unsaved progress will be lost.",1,"Are you sure you want to change this slide? All unsaved progress will be lost.",0
 dynamic.back,Back,1,Retour,0


### PR DESCRIPTION
Closes #5.

### Changes
- styling for metadata page, slide editor pages, and editor table of contents
- scrollguard and timeslider options for map editor now use checkbox instead of true/false dropdown

Styling changes made to follow the Figma: https://www.figma.com/file/4GXcYsMq3xbLNcX1R9HBZO/RAMP-Storylines-Editor-Wireframes?node-id=0%3A1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/79)
<!-- Reviewable:end -->
