### PR TITLE
fix long names in ToC

### DIFF
--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -14,16 +14,18 @@
             </button>
         </div>
         <ul>
-            <li class="flex toc-slide border-t" v-for="(slide, index) in slides" :key="slide.title + index">
-                <div
-                    class="flex px-2 cursor-pointer hover:bg-gray-100"
-                    :class="currentSlide === slide ? 'bg-gray-100' : ''"
-                    @click="selectSlide(index)"
-                >
-                    <span class="self-center overflow-ellipsis whitespace-nowrap overflow-hidden flex-shrink-0 ml-2"
-                        >Slide {{ index + 1 }}: <span class="font-bold">{{ slide.title || '' }}</span></span
-                    >
-                    <span class="ml-auto flex-grow"></span>
+            <li
+                class="toc-slide border-t flex px-2 cursor-pointer hover:bg-gray-100"
+                :class="currentSlide === slide ? 'bg-gray-100' : ''"
+                @click="selectSlide(index)"
+                v-for="(slide, index) in slides"
+                :key="slide.title + index"
+            >
+                <tippy delay="200" placement="right">{{ slide.title }}</tippy>
+                <div class="self-center overflow-ellipsis whitespace-nowrap overflow-hidden flex-grow ml-2">
+                    Slide {{ index + 1 }}: <span class="font-bold overflow-hidden">{{ slide.title || '' }}</span>
+                </div>
+                <div class="flex">
                     <button @click.stop="removeSlide(index)">
                         <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24">
                             <path


### PR DESCRIPTION
Closes #81

Long names in the table of contents will now be properly cut-off if they are too long, and tooltips now appear when hovering over names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/86)
<!-- Reviewable:end -->
