### PR TITLE
Unsaved changes indicator

### DIFF
--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -62,6 +62,8 @@ export default class ChartEditorV extends Vue {
     @Prop() lang!: string;
     @Prop() sourceCounts!: any;
 
+    edited = false;
+
     chartConfigs = [] as Array<ChartConfig>;
     modalEditor = {} as any;
 
@@ -134,6 +136,7 @@ export default class ChartEditorV extends Vue {
 
             this.chartConfigs.push(chartConfig);
         }
+        this.onChartsEdited();
     }
 
     editChart(chartInfo: { oldChart: ChartConfig; newChart: ChartConfig }): void {
@@ -160,6 +163,7 @@ export default class ChartEditorV extends Vue {
             chartInfo.newChart.src = `${this.configFileStructure.uuid}/charts/en/${chartInfo.newChart.name}.json`;
             this.chartConfigs[idx] = chartInfo.newChart;
         }
+        this.onChartsEdited();
     }
 
     deleteChart(chart: ChartConfig): void {
@@ -172,10 +176,19 @@ export default class ChartEditorV extends Vue {
             }
             this.chartConfigs.splice(idx, 1);
         }
+        this.onChartsEdited();
     }
 
     saveChanges(): void {
-        this.panel.charts = this.chartConfigs; // option to delete config property as is redundant
+        if (this.edited) {
+            this.panel.charts = this.chartConfigs; // option to delete config property as is redundant
+        }
+        this.edited = false;
+    }
+
+    onChartsEdited() {
+        this.edited = true;
+        this.$parent.$emit('slide-edit');
     }
 }
 </script>

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -229,6 +229,8 @@ export default class EditorV extends Vue {
     }
 
     created(): void {
+        window.addEventListener('beforeunload', this.beforeWindowUnload);
+
         // Generate UUID for new product
         this.uuid = this.$route.params.uid ?? (this.editExisting ? undefined : uuidv4());
         this.lang = this.$route.params.lang ? this.$route.params.lang : 'en';
@@ -241,6 +243,10 @@ export default class EditorV extends Vue {
         if (this.$route.params.uid) {
             this.generateRemoteConfig();
         }
+    }
+
+    beforeDestroy() {
+        window.removeEventListener('beforeunload', this.beforeWindowUnload);
     }
 
     /**
@@ -616,6 +622,14 @@ export default class EditorV extends Vue {
         // Generate an image preview.
         this.metadata.logoPreview = URL.createObjectURL(uploadedFile);
         this.metadata.logoName = uploadedFile.name;
+    }
+
+    beforeWindowUnload(e: any) {
+        // show popup if when leaving page with unsaved changes
+        if (this.unsavedChanges && !window.confirm()) {
+            e.preventDefault();
+            e.returnValue = '';
+        }
     }
 }
 </script>

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -77,9 +77,32 @@
         </template>
 
         <template v-if="loadStatus === 'loaded'">
-            <div class="flex border-b border-black bg-gray-200 py-2 px-2">
+            <div class="sticky top-0 z-50 flex border-b border-black bg-gray-200 py-2 px-2">
                 <span class="m-1 font-semibold text-lg">{{ config.title }}</span>
                 <span class="ml-auto"></span>
+                <transition name="fade">
+                    <span v-if="unsavedChanges" class="border-2 border-red-700 text-red-700 rounded p-1 mr-2">
+                        <span class="align-middle inline-block mr-1 pb-1 fill-current"
+                            ><svg
+                                clip-rule="evenodd"
+                                fill-rule="evenodd"
+                                class="fill-red-600"
+                                width="18"
+                                height="18"
+                                stroke-linejoin="round"
+                                stroke-miterlimit="2"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                            >
+                                <path
+                                    d="m12.002 21.534c5.518 0 9.998-4.48 9.998-9.998s-4.48-9.997-9.998-9.997c-5.517 0-9.997 4.479-9.997 9.997s4.48 9.998 9.997 9.998zm0-1.5c-4.69 0-8.497-3.808-8.497-8.498s3.807-8.497 8.497-8.497 8.498 3.807 8.498 8.497-3.808 8.498-8.498 8.498zm0-6.5c-.414 0-.75-.336-.75-.75v-5.5c0-.414.336-.75.75-.75s.75.336.75.75v5.5c0 .414-.336.75-.75.75zm-.002 3c.552 0 1-.448 1-1s-.448-1-1-1-1 .448-1 1 .448 1 1 1z"
+                                    fill-rule="nonzero"
+                                />
+                            </svg>
+                        </span>
+                        <span class="align-center inline-block select-none">Unsaved Changes</span>
+                    </span>
+                </transition>
                 <button class="bg-white border border-black hover:bg-gray-100">Preview</button>
                 <button @click="generateConfig" class="bg-black text-white hover:bg-gray-900">Save Changes</button>
             </div>
@@ -126,6 +149,7 @@
                     :isLast="slideIndex === slides.length - 1"
                     :uid="uuid"
                     @slide-change="selectSlide"
+                    @slide-edit="onSlidesEdited"
                     :sourceCounts="sourceCounts"
                 ></slide-editor>
             </div>
@@ -146,7 +170,7 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Component, Vue, Prop, Watch } from 'vue-property-decorator';
 import { Route } from 'vue-router';
 import { StoryRampConfig, Slide } from '@/definitions';
 
@@ -175,6 +199,7 @@ export default class EditorV extends Vue {
     loadStatus = 'waiting';
     errorMessage = ''; // error message if the user requested to load a UID that does not exist or tried to load editor without UID.
     lang = 'en';
+    unsavedChanges = false;
 
     // Form properties.
     uuid = '';
@@ -192,6 +217,16 @@ export default class EditorV extends Vue {
         dateModified: ''
     };
     sourceCounts: any = {};
+
+    @Watch('slides', { deep: true })
+    onSlidesEdited() {
+        this.unsavedChanges = true;
+    }
+
+    @Watch('metadata', { deep: true })
+    onMetadataEdited() {
+        this.unsavedChanges = true;
+    }
 
     created(): void {
         // Generate UUID for new product
@@ -234,6 +269,8 @@ export default class EditorV extends Vue {
 
         // Generate the file structure, defer uploading the image until the structure is created.
         this.configFileStructureHelper(configZip, this.logoImage);
+
+        this.unsavedChanges = false;
     }
 
     configHelper(): StoryRampConfig {
@@ -448,6 +485,7 @@ export default class EditorV extends Vue {
             axios.post('http://localhost:6040/upload', formData, { headers }).then((res: any) => {
                 res.data.files; // binary representation of the file
                 res.status; // HTTP status
+                this.unsavedChanges = false;
             });
         });
 
@@ -523,6 +561,7 @@ export default class EditorV extends Vue {
             this.config !== undefined
                 ? (this.loadStatus = 'loaded')
                 : (this.errorMessage = 'No config loaded for existing Storylines product!');
+            this.unsavedChanges = false;
         } else {
             // TODO: check for non-empty required metadata fields
             this.generateNewConfig();
@@ -658,6 +697,16 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         max-width: 150px;
         max-height: 150px;
         display: inline;
+    }
+
+    .fade-enter-active,
+    .fade-leave-active {
+        transition: opacity 0.2s;
+    }
+
+    .fade-enter,
+    .fade-leave-to {
+        opacity: 0;
     }
 }
 </style>

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -39,6 +39,7 @@
             v-model="imagePreviews"
             v-show="!imagePreviewsLoading && imagePreviews.length"
             class="flex flex-wrap list-none"
+            @update="onImagesEdited"
         >
             <ImagePreview v-for="(image, idx) in imagePreviews" :key="idx" :imageFile="image" @delete="deleteImage">
                 <div class="flex mt-4 items-center">
@@ -69,6 +70,7 @@ export default class ImageEditorV extends Vue {
     @Prop() sourceCounts!: any;
 
     dragging = false;
+    edited = false;
 
     imagePreviewsLoading = false;
     imagePreviewPromises = [] as Array<Promise<ImageFile>>;
@@ -133,6 +135,7 @@ export default class ImageEditorV extends Vue {
                 };
             })
         );
+        this.onImagesEdited();
     }
 
     dropImages(e: DragEvent): void {
@@ -158,6 +161,7 @@ export default class ImageEditorV extends Vue {
             );
             this.dragging = false;
         }
+        this.onImagesEdited();
     }
 
     deleteImage(img: ImageFile): void {
@@ -171,15 +175,24 @@ export default class ImageEditorV extends Vue {
             }
             this.imagePreviews.splice(idx, 1);
         }
+        this.onImagesEdited();
     }
 
     saveChanges(): void {
-        this.panel.images = this.imagePreviews.map((imageFile: ImageFile) => {
-            return {
-                ...imageFile,
-                src: `${this.configFileStructure.uuid}/assets/en/${imageFile.id}`
-            };
-        });
+        if (this.edited) {
+            this.panel.images = this.imagePreviews.map((imageFile: ImageFile) => {
+                return {
+                    ...imageFile,
+                    src: `${this.configFileStructure.uuid}/assets/en/${imageFile.id}`
+                };
+            });
+        }
+        this.edited = false;
+    }
+
+    onImagesEdited() {
+        this.edited = true;
+        this.$parent.$emit('slide-edit');
     }
 }
 </script>

--- a/src/components/editor/map-editor.vue
+++ b/src/components/editor/map-editor.vue
@@ -155,6 +155,8 @@ export default class MapEditorV extends Vue {
             `${this.strippedFileName}.json`,
             JSON.stringify(JSON.parse(localStorage.RAMPconfig), null, 4)
         );
+
+        this.$parent.$emit('slide-edit');
     }
 }
 </script>


### PR DESCRIPTION
Closes #88.

### Changes
- 'Unsaved Changes' indicator appears whenever a change is made to the config before saving to the server
    - includes adding/deleting/reordering slides, changing slide title, changing content within a panel, editing metadata, etc.
- the top bar containing the 'Preview' and 'Save Changes' buttons now sticks to the top of the page

Edit: also closes #92. 
- user gets a popup when attempting to leave the page with unsaved work
    - this only occurs when navigating away from the root url, it can be updated to work within the editor when the routing is sorted out in #89.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/103)
<!-- Reviewable:end -->
