### PR TITLE
Implement preview storylines feature

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -105,6 +105,29 @@ app.route('/retrieve/:id').get(function (req, res, next) {
     );
 });
 
+// GET requests made to /retrieve/ID/LANG will be handled here.
+app.route('/retrieve/:id/:lang').get(function (req, res) {
+    const CONFIG_PATH = `${TARGET_PATH}/${req.params.id}/${req.params.id}_${req.params.lang}.json`;
+    // obtain requested config file if it exists
+    if (
+        fs.access(CONFIG_PATH, (error) => {
+            if (!error) {
+                fs.readFile(CONFIG_PATH, (err, data) => {
+                    if (!err) {
+                        // return JSON config file as response
+                        const configJson = JSON.parse(data.toString());
+                        res.json(configJson);
+                    } else {
+                        res.status(err.status);
+                    }
+                });
+            } else {
+                res.status(404).send({ status: 'Not Found' });
+            }
+        })
+    );
+});
+
 /*
  * Verifies that the file has a valid extension. If it's not valid, the file is removed.
  *

--- a/src/components/editor/map-editor.vue
+++ b/src/components/editor/map-editor.vue
@@ -76,7 +76,7 @@ export default class MapEditorV extends Vue {
     status = this.panel.config !== '' ? 'default' : 'creating';
     strippedFileName = this.panel.config !== '' ? this.panel.config.split('/')[3].split('.')[0] : '';
 
-    mounted() {
+    mounted(): void {
         // If a message is received, it means the map save button was pressed.
         window.addEventListener('message', (event) => {
             if (event.data === 'mapSaved') {
@@ -85,7 +85,7 @@ export default class MapEditorV extends Vue {
         });
     }
 
-    createNewConfig() {
+    createNewConfig(): void {
         // Update the path to the new file.
         // TODO: ensure that this is not a name already in use?
         this.panel.config = `${this.configFileStructure.uuid}/ramp-config/${this.lang}/${this.newFileName}.json`;
@@ -107,7 +107,7 @@ export default class MapEditorV extends Vue {
         this.status = 'default';
     }
 
-    openEditor() {
+    openEditor(): void {
         if (this.panel.config === '') {
             return;
         }
@@ -124,10 +124,11 @@ export default class MapEditorV extends Vue {
                     .async('string')
                     .then((res: any) => {
                         window.config = res;
-                        (document.getElementById('RAMPeditorframe') as HTMLIFrameElement).contentWindow!.config = res;
-                        (document.getElementById(
-                            'RAMPeditorframe'
-                        ) as HTMLIFrameElement).contentWindow!.configname = this.strippedFileName;
+                        const iframe = document.getElementById('RAMPeditorframe') as HTMLIFrameElement;
+                        if (iframe.contentWindow) {
+                            iframe.contentWindow.config = res;
+                            iframe.contentWindow.configname = this.strippedFileName;
+                        }
                     });
             } else {
                 // If it does not exist in the ZIP folder, try and fetch from server.
@@ -136,19 +137,18 @@ export default class MapEditorV extends Vue {
                         let stringResponse = JSON.stringify(res);
 
                         window.config = stringResponse;
-                        (document.getElementById(
-                            'RAMPeditorframe'
-                        ) as HTMLIFrameElement).contentWindow!.config = stringResponse;
-                        (document.getElementById(
-                            'RAMPeditorframe'
-                        ) as HTMLIFrameElement).contentWindow!.configname = this.strippedFileName;
+                        const iframe = document.getElementById('RAMPeditorframe') as HTMLIFrameElement;
+                        if (iframe.contentWindow) {
+                            iframe.contentWindow.config = stringResponse;
+                            iframe.contentWindow.configname = this.strippedFileName;
+                        }
                     });
                 });
             }
         }
     }
 
-    saveEditor() {
+    saveEditor(): void {
         this.status = 'default';
 
         // Add chart config to ZIP file.

--- a/src/components/editor/preview.vue
+++ b/src/components/editor/preview.vue
@@ -1,0 +1,152 @@
+<template>
+    <!-- If the configuration file is being fetched, display a spinner to indicate loading. -->
+    <div v-if="loadStatus === 'loading'">
+        <div class="block py-20 align-middle text-center h-full" style="margin: 0 auto">
+            <spinner size="120px" background="#00D2D3" color="#009cd1" stroke="10px" style="margin: 0 auto"></spinner>
+        </div>
+    </div>
+
+    <div v-else-if="loadStatus === 'loaded'">
+        <div class="storyramp-app bg-white" v-if="config !== undefined">
+            <header class="sticky top-0 z-50 flex border-b border-black bg-gray-200 py-2 px-2 justify-between">
+                <span class="font-semibold text-lg m-1">{{ config.title }}</span>
+                <!-- TODO: change this route back to the main editor (complete along with #89) -->
+                <router-link :to="{ name: 'home' }" target v-if="!savedProduct">
+                    <button class="bg-white border border-black font-bold hover:bg-gray-100 px-4 py-2">
+                        {{ $t('editor.back') }}
+                    </button>
+                </router-link>
+            </header>
+
+            <introduction :config="config.introSlide" :configFileStructure="configFileStructure"></introduction>
+
+            <div class="w-full mx-auto pb-10" id="story">
+                <StoryContentV
+                    :config="config"
+                    :configFileStructure="configFileStructure"
+                    :lang="lang"
+                    @step="updateActiveIndex"
+                />
+            </div>
+
+            <footer class="p-8 pt-2 text-right text-sm">
+                Context:
+                <a class="text-blue-700 font-semibold" :href="config.contextLink" target="_NEW">{{
+                    config.contextLabel
+                }}</a>
+                |
+                <a
+                    href="https://github.com/ramp4-pcar4/storylines-editor"
+                    target="_NEW"
+                    class="font-semibold text-blue-700"
+                    >ramp4-pcar4/storylines-editor</a
+                >
+            </footer>
+
+            <div class="storyramp-modified" v-if="config.dateModified">
+                {{ $t('story.date') }}
+                {{ config.dateModified }}
+            </div>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import { StoryRampConfig } from '@/definitions';
+
+import StoryContentV from '@/components/story/story-content.vue';
+import IntroV from '@/components/story/introduction.vue';
+import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
+
+@Component({
+    components: {
+        StoryContentV,
+        introduction: IntroV,
+        spinner: Circle2
+    }
+})
+export default class StoryPreviewV extends Vue {
+    @Prop() conf!: StoryRampConfig | undefined;
+    @Prop() configFileStructure!: any;
+
+    config: StoryRampConfig | undefined = undefined;
+    savedProduct = false;
+    loadStatus = 'loading';
+    activeChapterIndex = -1;
+    lang = 'en';
+
+    created(): void {
+        const uid = this.$route.params.uid;
+        const lang = this.$route.params.lang;
+        if (uid) {
+            this.savedProduct = true;
+            // attempt to fetch saved config file from the server (TODO: setup as express route?)
+            fetch(`http://localhost:6040/retrieve/${uid}/${lang}`).then((res: any) => {
+                if (res.status === 404) {
+                    console.error(`There does not exist a saved product with UID ${uid}.`);
+                    // redirect to canada.ca 404 page on invalid URL params
+                    // window.location.href = 'https://www.canada.ca/errors/404.html';
+                } else {
+                    res.json().then((config: StoryRampConfig) => {
+                        this.config = config;
+                        this.loadStatus = 'loaded';
+                        document.title = this.config.title + ' - Canada.ca';
+                    });
+                }
+            });
+        } else if (this.conf) {
+            this.config = this.conf;
+            this.loadStatus = 'loaded';
+        }
+
+        // set page lang
+        const html = document.documentElement;
+        html.setAttribute('lang', this.lang);
+        this.$i18n.locale = this.lang;
+    }
+
+    updateActiveIndex(idx: number): void {
+        this.activeChapterIndex = idx;
+    }
+}
+</script>
+
+<style lang="scss">
+$font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+
+.storyramp-app {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .h1,
+    .h2,
+    .h3,
+    .h4,
+    .h5,
+    .h6 {
+        font-family: $font-list;
+        line-height: 1.5;
+        border-bottom: 0px;
+    }
+
+    .storyramp-modified {
+        max-width: 1536px;
+        margin: 0 auto;
+        padding-left: 15px;
+        padding-top: 1em;
+        padding-bottom: 1em;
+    }
+
+    .prose a {
+        font-weight: bold;
+    }
+
+    .prose a:not([panel])::after {
+        content: url('../../assets/popout.svg');
+    }
+}
+</style>

--- a/src/components/panels/chart-panel.vue
+++ b/src/components/panels/chart-panel.vue
@@ -12,7 +12,7 @@
                 :index="index"
                 class="self-center"
             >
-                <dqv-chart :config="chartConfig" />
+                <dqv-chart :config="chartConfig" :configFileStructure="configFileStructure" />
             </slide>
 
             <hooper-navigation slot="hooper-addons"></hooper-navigation>
@@ -20,7 +20,7 @@
         </hooper>
 
         <div v-else-if="width !== -1">
-            <dqv-chart :config="config.charts[0]" />
+            <dqv-chart :config="config.charts[0]" :configFileStructure="configFileStructure" />
         </div>
     </div>
 </template>
@@ -44,6 +44,7 @@ import ChartV from '@/components/panels/helpers/chart.vue';
 })
 export default class ChartPanelV extends Vue {
     @Prop() config!: ChartPanel;
+    @Prop() configFileStructure!: any;
 
     width = -1;
 

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -64,7 +64,7 @@ export default class ChartV extends Vue {
             const assetSrc = `${this.config.src.substring(this.config.src.indexOf('/') + 1)}`;
 
             if (extension === 'json') {
-                if (this.configFileStructure.config.file(assetSrc)) {
+                if (this.configFileStructure && this.configFileStructure.config.file(assetSrc)) {
                     // First attempt to fetch the configuration file from the ZIP folder.
                     this.configFileStructure.config
                         .file(assetSrc)
@@ -94,7 +94,7 @@ export default class ChartV extends Vue {
                     });
                 }
             } else if (extension === 'csv') {
-                if (this.configFileStructure.config.file(assetSrc)) {
+                if (this.configFileStructure && this.configFileStructure.config.file(assetSrc)) {
                     // First attempt to fetch the configuration file from the ZIP folder.
                     this.configFileStructure.config
                         .file(assetSrc)

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -32,8 +32,24 @@ import FullscreenV from '@/components/panels/helpers/fullscreen.vue';
 })
 export default class ImagePanelV extends Vue {
     @Prop() config!: ImagePanel;
+    @Prop() configFileStructure!: any;
 
     md = new MarkdownIt({ html: true });
+
+    mounted(): void {
+        // obtain image file from ZIP folder in editor preview mode
+        if (this.configFileStructure) {
+            const assetSrc = `${this.config.src.substring(this.config.src.indexOf('/') + 1)}`;
+            if (this.configFileStructure.config.file(assetSrc)) {
+                this.configFileStructure.config
+                    .file(assetSrc)
+                    .async('blob')
+                    .then((res: any) => {
+                        this.config.src = URL.createObjectURL(res);
+                    });
+            }
+        }
+    }
 }
 </script>
 

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -32,12 +32,24 @@ export default class MapPanelV extends Vue {
     @Prop() config!: MapPanel;
     @Prop() slideIdx!: number;
     @Prop() lang!: string;
+    @Prop() configFileStructure!: any;
 
     intersectTimeoutHandle = -1;
     scrollguardOpen = false;
     mapComponent: Element | undefined = undefined;
 
     mounted(): void {
+        // Check if the config file exists in the ZIP folder first
+        const assetSrc = `${this.config.config.substring(this.config.config.indexOf('/') + 1)}`;
+        if (this.configFileStructure && this.configFileStructure.config.file(assetSrc)) {
+            this.configFileStructure.config
+                .file(assetSrc)
+                .async('string')
+                .then((res: any) => {
+                    this.config.config = res;
+                });
+        }
+
         const observer = new IntersectionObserver(
             ([e]) => {
                 if (e.isIntersecting) {

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -8,7 +8,13 @@
         class="flex-col relative"
     >
         <slot></slot>
-        <component :is="getTemplate()" :config="config" :slideIdx="slideIdx" :lang="lang"></component>
+        <component
+            :is="getTemplate()"
+            :config="config"
+            :configFileStructure="configFileStructure"
+            :slideIdx="slideIdx"
+            :lang="lang"
+        ></component>
     </div>
 </template>
 
@@ -33,6 +39,7 @@ import LoadingPanelV from './loading-panel.vue';
 })
 export default class PanelV extends Vue {
     @Prop() config!: BasePanel;
+    @Prop() configFileStructure!: any;
     @Prop() ratio!: boolean;
     @Prop() slideIdx!: number;
     @Prop() lang!: string;

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -1,6 +1,6 @@
 <template>
     <div v-if="config.images.length === 1">
-        <image-panel :config="config.images[0]"></image-panel>
+        <image-panel :config="config.images[0]" :configFileStructure="configFileStructure"></image-panel>
     </div>
     <div v-else class="carousel self-start px-10 my-8 bg-gray-200_ h-28_" :style="{ width: `${width}px` }">
         <full-screen :expandable="config.fullscreen" :type="config.type">
@@ -46,6 +46,7 @@ import ImagePanelV from '@/components/panels/image-panel.vue';
 })
 export default class SlideshowPanelV extends Vue {
     @Prop() config!: SlideshowPanel;
+    @Prop() configFileStructure!: any;
 
     width = -1;
 
@@ -55,6 +56,21 @@ export default class SlideshowPanelV extends Vue {
         setTimeout(() => {
             this.width = this.$el.clientWidth;
         }, 100);
+
+        // obtain image files from ZIP folder in editor preview mode
+        if (this.configFileStructure) {
+            this.config.images.forEach((image) => {
+                const assetSrc = `${image.src.substring(image.src.indexOf('/') + 1)}`;
+                if (this.configFileStructure.config.file(assetSrc)) {
+                    this.configFileStructure.config
+                        .file(assetSrc)
+                        .async('blob')
+                        .then((res: any) => {
+                            image.src = URL.createObjectURL(res);
+                        });
+                }
+            });
+        }
     }
 }
 </script>

--- a/src/components/story/chapter-menu.vue
+++ b/src/components/story/chapter-menu.vue
@@ -36,11 +36,37 @@
         <ul class="nav-content menu">
             <li>
                 <tippy to="menu-options-tippy" delay="200" placement="right">{{ $t('chapters.return') }}</tippy>
+                <button
+                    :name="`menu-options-tippy`"
+                    class="flex items-center px-2 py-1 mx-1"
+                    @click="scrollToChapter('intro')"
+                    v-if="editor"
+                >
+                    <svg
+                        class="flex-shrink-0"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="#fff"
+                        stroke="#878787"
+                    >
+                        <path
+                            d="m19.325 16.229c-2.4415 1.4096-4.8829 2.8191-7.3244 4.2286-2.4415-1.4096-4.883-2.8192-7.3245-4.2288-3.55e-5 -2.8191-7.1e-5 -5.6383-1.066e-4 -8.4574 2.4415-1.4096 4.8829-2.8191 7.3244-4.2286 2.4415 1.4096 4.883 2.8192 7.3245 4.2288 3.7e-5 2.8191 7.4e-5 5.6383 1.1e-4 8.4574z"
+                            stroke-width=".93974"
+                        />
+                    </svg>
+                    <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
+                        $t('chapters.return')
+                    }}</span>
+                </button>
+
                 <router-link
                     name="menu-options-tippy"
                     :to="{ hash: '#intro' }"
                     class="flex items-center px-2 py-1 mx-1"
                     target
+                    v-else
                 >
                     <svg
                         class="flex-shrink-0"
@@ -63,11 +89,39 @@
             </li>
             <li v-for="(slide, idx) in slides" :key="idx" :class="{ 'is-active': activeChapterIndex === idx }">
                 <tippy :to="`menu-options-tippy-${idx}`" delay="200" placement="right">{{ slide.title }}</tippy>
+
+                <!-- using router-link causes a page refresh which breaks editor preview mode -->
+                <button
+                    :name="`menu-options-tippy-${idx}`"
+                    class="flex items-center px-2 py-1 mx-1"
+                    @click="scrollToChapter(`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`)"
+                    v-if="editor"
+                >
+                    <svg
+                        class="flex-shrink-0"
+                        width="24"
+                        height="24"
+                        viewBox="0 0 24 24"
+                        xmlns="http://www.w3.org/2000/svg"
+                        fill="#fff"
+                        stroke="#878787"
+                    >
+                        <path
+                            d="m19.325 16.229c-2.4415 1.4096-4.8829 2.8191-7.3244 4.2286-2.4415-1.4096-4.883-2.8192-7.3245-4.2288-3.55e-5 -2.8191-7.1e-5 -5.6383-1.066e-4 -8.4574 2.4415-1.4096 4.8829-2.8191 7.3244-4.2286 2.4415 1.4096 4.883 2.8192 7.3245 4.2288 3.7e-5 2.8191 7.4e-5 5.6383 1.1e-4 8.4574z"
+                            stroke-width=".93974"
+                        />
+                    </svg>
+                    <span class="flex-1 ml-4 overflow-hidden leading-normal overflow-ellipsis whitespace-nowrap">{{
+                        slide.title
+                    }}</span>
+                </button>
+
                 <router-link
                     :name="`menu-options-tippy-${idx}`"
                     :to="{ hash: `#${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}` }"
                     class="flex items-center px-2 py-1 mx-1"
                     target
+                    v-else
                 >
                     <svg
                         class="flex-shrink-0"
@@ -102,8 +156,16 @@ export default class ChapterMenuV extends Vue {
     @Prop() slides!: Slide[];
     @Prop() activeChapterIndex!: number;
     @Prop() lang!: string;
+    @Prop() editor!: boolean;
 
     isMenuOpen = false;
+
+    scrollToChapter(id: string): void {
+        const el = document.getElementById(id);
+        if (el) {
+            el.scrollIntoView({ behavior: 'smooth' });
+        }
+    }
 }
 </script>
 

--- a/src/components/story/introduction.vue
+++ b/src/components/story/introduction.vue
@@ -9,7 +9,39 @@
             {{ config.subtitle }}
         </p>
 
-        <router-link :to="{ hash: '#story' }" class="inline-block mt-10 scroll-arrow" title="scroll to story" target>
+        <!-- using router-link causes a page refresh which breaks editor preview mode -->
+        <button @click="scrollToStory" v-if="!!configFileStructure">
+            <svg
+                class="w-auto h-24 m-auto"
+                width="90"
+                height="104.84"
+                viewBox="0 0 90 104.83"
+                xmlns="http://www.w3.org/2000/svg"
+            >
+                <path
+                    d="m89.51 77.659-44.51 25.698-44.51-25.698 3.86e-4 -51.395 44.51-25.698 44.51 25.698z"
+                    fill="#fff"
+                    stroke="#00d2d3"
+                    stroke-dasharray="4.8960465, 4.8960465"
+                    stroke-dashoffset="2.7"
+                    stroke-width=".5"
+                />
+                <path
+                    d="m45 104.27-44.51-25.697v-10.646l44.51 25.697 44.51-25.697v10.646z"
+                    fill="#00d2d3"
+                    stroke="#00d2d3"
+                    stroke-width=".97921"
+                />
+            </svg>
+        </button>
+
+        <router-link
+            :to="{ hash: '#story' }"
+            class="inline-block mt-10 scroll-arrow"
+            title="scroll to story"
+            target
+            v-else
+        >
             <svg
                 class="w-auto h-24 m-auto"
                 width="90"
@@ -43,6 +75,30 @@ import { Component, Vue, Prop } from 'vue-property-decorator';
 @Component({})
 export default class IntroV extends Vue {
     @Prop() config!: Intro;
+    @Prop() configFileStructure!: any;
+
+    mounted(): void {
+        // obtain logo from ZIP file if it exists
+        if (this.configFileStructure) {
+            const logoSrc = `${this.config.logo.src.substring(this.config.logo.src.indexOf('/') + 1)}`;
+            if (this.configFileStructure.config.file(logoSrc)) {
+                this.configFileStructure.config
+                    .file(logoSrc)
+                    .async('blob')
+                    .then((res: any) => {
+                        this.config.logo.src = URL.createObjectURL(res);
+                        this.$forceUpdate();
+                    });
+            }
+        }
+    }
+
+    scrollToStory(): void {
+        const el = document.getElementById('story');
+        if (el) {
+            el.scrollIntoView({ behavior: 'smooth' });
+        }
+    }
 }
 </script>
 

--- a/src/components/story/slide.vue
+++ b/src/components/story/slide.vue
@@ -4,6 +4,7 @@
             v-for="(panel, idx) in config.panel"
             :key="idx"
             :config="panel"
+            :configFileStructure="configFileStructure"
             :index="idx"
             :ratio="defaultRatio"
             :slideIdx="slideIdx"
@@ -25,6 +26,7 @@ import { PanelType, Slide } from '@/definitions';
 })
 export default class SlideV extends Vue {
     @Prop() config!: Slide;
+    @Prop() configFileStructure!: any;
     @Prop() slideIdx!: number;
     @Prop() lang!: string;
 

--- a/src/components/story/story-content.vue
+++ b/src/components/story/story-content.vue
@@ -4,6 +4,7 @@
             class="side-menu"
             :active-chapter-index="activeChapterIndex"
             :slides="config.slides"
+            :editor="!!configFileStructure"
             :lang="lang"
         />
 
@@ -16,7 +17,7 @@
                 :id="`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`"
                 :name="`${idx}-${slide.title.toLowerCase().replaceAll(' ', '-')}`"
             >
-                <slide :config="slide" :slideIdx="idx" :lang="lang"></slide>
+                <slide :config="slide" :configFileStructure="configFileStructure" :slideIdx="idx" :lang="lang"></slide>
             </div>
         </Scrollama>
     </div>
@@ -40,6 +41,7 @@ import { StoryRampConfig } from '@/definitions';
 })
 export default class StoryContentV extends Vue {
     @Prop() config!: StoryRampConfig;
+    @Prop() configFileStructure!: any;
     @Prop() lang!: string;
 
     activeChapterIndex = -1;

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -14,6 +14,7 @@ fullscreen.activate,Enter Fullscreen,1,Entrer en plein écran,0
 fullscreen.deactivate,Exit Fullscreen,1,Sortie plein écran,0
 editor.createProduct,Create New Storylines Product,1,Créer un nouveau produit Storylines,0
 editor.editProduct,Edit Existing Storylines Product,1,Modifier le produit Storylines existant,0
+editor.editMetadata,Edit Project Metadata,1,Modifier les Métadonnées du Projet,0
 editor.uuid,UUID,1,UUID,0
 editor.title,Title,1,Titre,0
 editor.logo,Logo,1,Logo,0
@@ -25,6 +26,8 @@ editor.load,Load,1,Charger,0
 editor.browse,Browse,1,Parcourir,0
 editor.back,Back,1,Retour,1
 editor.next,Next,1,Suivant,1
+editor.preview,Preview,1,Aperçu,0
+editor.saveChanges,Save Changes,1,Sauvegarder les Modifications,0
 editor.frenchConfig,View French Config,1,Afficher la configuration française,0
 editor.englishConfig,View English Config,1,Afficher la configuration en anglais,0
 editor.image.delete,Delete Image,1,Supprimer l'image,0

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -2,6 +2,7 @@ import Vue from 'vue';
 import StoryV from '@/components/story/story.vue';
 import LandingV from '@/components/editor/landing.vue';
 import EditorV from '@/components/editor/editor.vue';
+import StoryPreviewV from '@/components/editor/preview.vue';
 import Router, { Route } from 'vue-router';
 
 Vue.use(Router);
@@ -26,6 +27,16 @@ const routes = [
         path: '/:lang/editor/:uid',
         name: 'editor',
         component: EditorV
+    },
+    {
+        path: '/:lang/editor-preview',
+        component: StoryPreviewV,
+        name: 'preview',
+        props: true
+    },
+    {
+        path: '/:lang/editor-preview/:uid',
+        component: StoryPreviewV
     },
     {
         path: '/:uid',


### PR DESCRIPTION
Closes #7 

Haven't had the time to thoroughly test every edge case but seems to work on most cases. The feature is meant to be for previewing unsaved changes before committing to any saves to server. One issue that still needs to be addressed is how to store the `configFileStructure` object so that it can be preserved and the preview mode can be opened in a new tab (can be opened as separate issue after).

[Demo](https://ramp4-pcar4.github.io/storylines-editor/preview-storylines/#/en/editor)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/104)
<!-- Reviewable:end -->
