### PR TITLE
Provide option to make single panel the full slide

### DIFF
--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -22,10 +22,20 @@
                             Next Slide
                         </button>
                     </div>
+                    <div class="flex mt-3">
+                        <span class="mx-2 font-bold">Make the right panel the full slide</span>
+                        <input
+                            type="checkbox"
+                            class="rounded-none cursor-pointer w-4 h-4"
+                            v-model="rightOnly"
+                            :disabled="rightOnly && currentSlide.panel[panelIndex].type === 'dynamic'"
+                            @change.stop="$modals.show(`right-only-${slideIndex}`)"
+                        />
+                    </div>
                 </div>
             </div>
             <br />
-            <div class="flex border-b border-black">
+            <div class="flex border-b border-black" v-if="currentSlide.panel.length === 2">
                 <button
                     @click="
                         () => {
@@ -81,7 +91,6 @@
                     "
                     class="border-t border-l border-r"
                     :class="panelIndex == 1 ? 'border-black' : 'border-white'"
-                    v-if="currentSlide.panel[panelIndex].type !== 'dynamic'"
                 >
                     <span class="align-middle inline-block">
                         <svg
@@ -121,14 +130,58 @@
                     <span class="align-middle inline-block pl-1">Right Panel</span>
                 </button>
             </div>
+            <div v-else class="border-b border-black">
+                <button
+                    @click="
+                        () => {
+                            saveChanges();
+                        }
+                    "
+                    class="border-t border-l border-r border-black"
+                >
+                    <span class="align-middle inline-block">
+                        <svg
+                            clip-rule="evenodd"
+                            fill-rule="evenodd"
+                            width="15"
+                            height="15"
+                            stroke-linejoin="round"
+                            stroke-miterlimit="2"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="m21 4c0-.478-.379-1-1-1h-16c-.62 0-1 .519-1 1v16c0 .621.52 1 1 1h16c.478 0 1-.379 1-1z"
+                                fill-rule="nonzero"
+                            />
+                        </svg>
+                    </span>
+                    <span class="align-middle inline-block">
+                        <svg
+                            clip-rule="evenodd"
+                            fill-rule="evenodd"
+                            width="15"
+                            height="15"
+                            stroke-linejoin="round"
+                            stroke-miterlimit="2"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="m21 4c0-.478-.379-1-1-1h-16c-.62 0-1 .519-1 1v16c0 .621.52 1 1 1h16c.478 0 1-.379 1-1z"
+                                fill-rule="nonzero"
+                            />
+                        </svg>
+                    </span>
+
+                    <span class="align-middle inline-block pl-1">Fullscreen Panel</span>
+                </button>
+            </div>
             <div>
                 <div class="flex mt-4">
                     <span class="font-bold text-xl">Content:</span>
                     <span class="ml-auto flex-grow"></span>
-                    <div
-                        v-if="panelIndex === 1 || currentSlide.panel[panelIndex].type === 'dynamic'"
-                        class="flex flex-col mr-8"
-                    >
+                    <div v-if="panelIndex === 1 || rightOnly" class="flex flex-col mr-8">
                         <label class="text-left text-lg">Content type:</label>
                         <select
                             ref="typeSelector"
@@ -171,11 +224,17 @@
             @Ok="changePanelType(currentSlide.panel[panelIndex].type, newType)"
             @Cancel="cancelTypeChange"
         />
+        <confirmation-modal
+            :name="`right-only-${slideIndex}`"
+            :message="$t('editor.slides.changeSlide.confirm', { title: currentSlide.title })"
+            @Ok="toggleRightOnly()"
+            @Cancel="rightOnly = !rightOnly"
+        />
     </div>
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Component, Vue, Prop, Watch } from 'vue-property-decorator';
 import { StoryRampConfig, DefaultConfigs, PanelType } from '@/definitions';
 
 import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
@@ -213,6 +272,7 @@ export default class SlideEditorV extends Vue {
 
     panelIndex = 0;
     newType = '';
+    rightOnly = false;
 
     editors = {
         text: 'text-editor',
@@ -223,6 +283,11 @@ export default class SlideEditorV extends Vue {
         loading: 'loading-page',
         dynamic: 'dynamic-editor'
     };
+
+    @Watch('currentSlide', { deep: true })
+    onSlideChange() {
+        this.currentSlide ? (this.rightOnly = this.currentSlide.panel.length === 1) : false;
+    }
 
     changePanelType(prevType: string, newType: string): void {
         const startingConfig: DefaultConfigs = {
@@ -259,16 +324,8 @@ export default class SlideEditorV extends Vue {
             this.panelIndex = 0;
             Vue.set(this.currentSlide, 'panel', [startingConfig[newType as keyof DefaultConfigs]]);
         } else {
-            // When switching from a dynamic panel, add back the secondary panel.
-            if (prevType === 'dynamic') {
-                Vue.set(this.currentSlide, 'panel', [
-                    Object.assign({}, startingConfig['text' as keyof DefaultConfigs]),
-                    Object.assign({}, startingConfig[newType as keyof DefaultConfigs])
-                ]);
-            } else {
-                // Switching panel type when dynamic panels are not involved.
-                Vue.set(this.currentSlide.panel, this.panelIndex, startingConfig[newType as keyof DefaultConfigs]);
-            }
+            // Switching panel type when dynamic panels are not involved.
+            Vue.set(this.currentSlide.panel, this.panelIndex, startingConfig[newType as keyof DefaultConfigs]);
         }
     }
 
@@ -285,6 +342,26 @@ export default class SlideEditorV extends Vue {
     cancelTypeChange() {
         (this.$refs.typeSelector as HTMLSelectElement).value = this.currentSlide.panel[this.panelIndex].type;
     }
+
+    toggleRightOnly(): void {
+        this.saveChanges();
+        if (this.rightOnly) {
+            this.panelIndex = 0;
+            Vue.set(this.currentSlide, 'panel', [this.currentSlide.panel[1]]);
+        } else {
+            Vue.set(this.currentSlide, 'panel', [
+                Object.assign(
+                    {},
+                    {
+                        type: PanelType.Text,
+                        title: '',
+                        content: ''
+                    }
+                ),
+                Object.assign({}, this.currentSlide.panel[0])
+            ]);
+        }
+    }
 }
 </script>
 
@@ -292,6 +369,11 @@ export default class SlideEditorV extends Vue {
 label {
     text-align: left !important;
     margin-left: 0.5rem;
+}
+
+input[type='checkbox']:checked {
+    accent-color: black;
+    color: white;
 }
 
 select {


### PR DESCRIPTION
Closes #100.

You can now make the right panel the full slide via a checkmark which is located in the slide editor just below the title input. This introduced some edge cases with dynamic panels, which I have handled as follows:
* When you have two panels and the right panel is made dynamic, you will automatically make the right panel take up the full slide as before, and the checkbox will be checked.
* When you have one panel that is dynamic, the checkbox is disabled so you cannot go to two panels.
* When you have one panel that is dynamic and you change it to another type, you no longer go back to two panels automatically, and you need to toggle the checkbox manually. This was done to avoid the case where the user chooses to have one panel, but changing from dynamic to something else undoes their choice. To be able to get both behaviours (i.e. dynamic panel makes two panels but only if the user didn't hit the box), we'd essentially need to store "user wants one panel" somewhere in the config/file system to remember that info. An extra click didn't feel worth the effort to me, so I went with this behaviour.

Feel free to let me know if any changes are needed to the behaviour above.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/110)
<!-- Reviewable:end -->
