### PR TITLE
New Metadata Fields

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -210,6 +210,8 @@ export default class EditorV extends Vue {
     $modals: any;
     metadata = {
         title: '',
+        introTitle: '',
+        introSubtitle: '',
         logoPreview: '',
         logoName: '',
         contextLink: '',
@@ -258,10 +260,14 @@ export default class EditorV extends Vue {
         // Generate a new configuration file and populate required fields.
         this.config = this.configHelper();
         this.config.title = this.metadata.title;
+        this.config.introSlide.title = this.metadata.introTitle;
+        this.config.introSlide.subtitle = this.metadata.introSubtitle;
         this.config.slides = this.slides;
 
         // Set the source of the product logo
-        if (!this.metadata.logoName.includes('http')) {
+        if (!this.metadata.logoName) {
+            this.config.introSlide.logo.src = '';
+        } else if (!this.metadata.logoName.includes('http')) {
             this.config.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
         } else {
             this.config.introSlide.logo.src = this.metadata.logoName;
@@ -288,7 +294,8 @@ export default class EditorV extends Vue {
                 logo: {
                     src: ''
                 },
-                title: 'Test Config Intro Slide'
+                title: '',
+                subtitle: ''
             },
             slides: [],
             contextLabel: this.metadata.contextLabel,
@@ -420,6 +427,8 @@ export default class EditorV extends Vue {
                 // Load in project data.
                 if (this.config) {
                     this.metadata.title = this.config.title;
+                    this.metadata.introTitle = this.config.introSlide.title;
+                    this.metadata.introSubtitle = this.config.introSlide.subtitle;
                     this.metadata.contextLink = this.config.contextLink;
                     this.metadata.contextLabel = this.config.contextLabel;
                     this.metadata.dateModified = this.config.dateModified;
@@ -498,7 +507,10 @@ export default class EditorV extends Vue {
         return this.configFileStructure;
     }
 
-    updateMetadata(key: 'title' | 'contextLink' | 'contextLabel' | 'dateModified', value: string): void {
+    updateMetadata(
+        key: 'title' | 'introTitle' | 'introSubtitle' | 'contextLink' | 'contextLabel' | 'dateModified',
+        value: string
+    ): void {
         this.metadata[key] = value;
     }
 
@@ -510,12 +522,16 @@ export default class EditorV extends Vue {
         // update metadata content to existing config only if it has been successfully loaded
         if (this.config !== undefined) {
             this.config.title = this.metadata.title;
+            this.config.introSlide.title = this.metadata.introTitle;
+            this.config.introSlide.subtitle = this.metadata.introSubtitle;
             this.config.contextLink = this.metadata.contextLink;
             this.config.contextLabel = this.metadata.contextLabel;
             this.config.dateModified = this.metadata.dateModified;
 
             // If the logo doesn't include HTTP, assume it's a local file.
-            if (!this.metadata.logoName.includes('http')) {
+            if (!this.metadata.logoName) {
+                this.config.introSlide.logo.src = '';
+            } else if (!this.metadata.logoName.includes('http')) {
                 this.config.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
                 this.configFileStructure.assets[this.lang].file(this.logoImage?.name, this.logoImage);
             } else {

--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -1,12 +1,17 @@
 <template>
     <div>
         <label class="mb-5">{{ $t('editor.title') }}:</label>
+        <input type="text" name="title" :value="metadata.title" @change="metadataChanged" class="w-1/3" />
+        <br />
+        <label class="mb-5">Intro Title:</label>
+        <input type="text" name="introTitle" :value="metadata.introTitle" @change="metadataChanged" class="w-1/4" />
+        <label class="mb-5">Intro Subtitle:</label>
         <input
             type="text"
-            name="title"
-            :value="metadata.title"
-            @change="$emit('metadata-changed', $event.target.name, $event.target.value)"
-            class="w-1/3"
+            name="introSubtitle"
+            :value="metadata.introSubtitle"
+            @change="metadataChanged"
+            class="w-1/4"
         />
         <br />
         <!-- only display an image preview if one is provided.-->
@@ -26,6 +31,9 @@
         <button @click.stop="openFileSelector" class="bg-black text-white hover:bg-gray-800">
             {{ $t('editor.browse') }}
         </button>
+        <button v-if="metadata.logoName || metadata.logoPreview" @click.stop="removeLogo" class="border border-black">
+            Remove
+        </button>
         <!-- hide the actual file input -->
         <input
             type="file"
@@ -36,13 +44,7 @@
         />
         <br />
         <label>{{ $t('editor.contextLink') }}:</label>
-        <input
-            type="text"
-            name="contextLink"
-            :value="metadata.contextLink"
-            @change="$emit('metadata-changed', $event.target.name, $event.target.value)"
-            class="w-2/3"
-        />
+        <input type="text" name="contextLink" :value="metadata.contextLink" @change="metadataChanged" class="w-2/3" />
         <br />
         <label class="mb-5"></label>
         <p class="inline-block">
@@ -52,13 +54,7 @@
         </p>
         <br />
         <label>{{ $t('editor.contextLabel') }}:</label>
-        <input
-            type="text"
-            name="contextLabel"
-            :value="metadata.contextLabel"
-            @change="$emit('metadata-changed', $event.target.name, $event.target.value)"
-            class="w-2/3"
-        />
+        <input type="text" name="contextLabel" :value="metadata.contextLabel" @change="metadataChanged" class="w-2/3" />
         <br />
         <label class="mb-5"></label>
         <p class="inline-block">
@@ -66,12 +62,7 @@
         </p>
         <br />
         <label class="mb-5">{{ $t('editor.dateModified') }}:</label>
-        <input
-            type="date"
-            name="dateModified"
-            :value="metadata.dateModified"
-            @change="$emit('metadata-changed', $event.target.name, $event.target.value)"
-        />
+        <input type="date" name="dateModified" :value="metadata.dateModified" @change="metadataChanged" />
         <br /><br />
     </div>
 </template>
@@ -85,6 +76,8 @@ import { Component, Prop, Vue } from 'vue-property-decorator';
 export default class MetadataEditorV extends Vue {
     @Prop() metadata!: {
         title: string;
+        introTitle: string;
+        introSubtitle: string;
         logoName: string;
         logoPreview: string;
         contextLink: string;
@@ -94,6 +87,15 @@ export default class MetadataEditorV extends Vue {
 
     openFileSelector(): void {
         document.getElementById('logoUpload')?.click();
+    }
+
+    metadataChanged(event: any): void {
+        this.$emit('metadata-changed', event.target.name, event.target.value);
+    }
+
+    removeLogo(): void {
+        this.metadata.logoName = '';
+        this.metadata.logoPreview = '';
     }
 }
 </script>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -75,7 +75,7 @@ export interface Intro {
         altText?: string;
     };
     title: string;
-    subtitle?: string;
+    subtitle: string;
     blurb?: string;
 }
 


### PR DESCRIPTION
Closes #91, #98.

### Changes
- Intro slide title and subtitle can be configured via the metadata panel
- Intro slide logo can now be removed from metadata
- Logo source will no longer load as `undefined`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/113)
<!-- Reviewable:end -->
