### PR TITLE
Fix charts failing to load data in table when editing

### DIFF
--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -178,8 +178,7 @@
                             "src": "00000000-0000-0000-0000-000000000000/charts/en/Criteria air contaminant releases from oil sands mines_3.csv",
                             "options": {
                                 "title": "Syncrude Canada Ltd., Aurora North Mine Site 2019 Tailings (Tonnes)",
-                                "subtitle": "",
-                                "type": "pie"
+                                "subtitle": ""
                             }
                         },
                         {
@@ -194,8 +193,7 @@
                             "src": "00000000-0000-0000-0000-000000000000/charts/en/NPRI releases from thermal in-situ facilities_1.csv",
                             "options": {
                                 "title": "Canadian Natural Resources Limited, Horizon Oil Sands Processing Plant and Mine 2019 Tailings (Tonnes)",
-                                "subtitle": "",
-                                "type": "pie"
+                                "subtitle": ""
                             }
                         }
                     ]
@@ -423,15 +421,6 @@
                         },
                         {
                             "src": "ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene.glycol.release.trends.by.sector.2010-2019.tonnes.csv"
-                        },
-                        {
-                            "src": "410b88da-0ed1-4749-903f-5e76c24e2e5f/charts/en/tailings/2.Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings.csv",
-                            "options": {
-                                "title": "Fort Hill Energy L.P., Fort Hills Oil Sands 2019 Tailings (Tonnes)",
-                                "subtitle": "",
-                                "type": "pie",
-                                "colours": ["green", "#FAEBD7", "indigo", "#FFD700", "orange", "red"]
-                            }
                         }
                     ]
                 }
@@ -449,8 +438,7 @@
                     "type": "chart",
                     "charts": [
                         {
-                            "src": "ea24000c-7dc3-49a9-baac-c55d28dcaeb9/charts/en/Ethlyene.glycol.release.trends.by.sector.2010-2019.tonnes.csv",
-
+                            "src": "00000000-0000-0000-0000-000000000000/charts/en/NPRI releases from thermal in-situ facilities_1.csv",
                             "options": {
                                 "xAxisLabel": "X Axis Test From Config",
                                 "yAxisLabel": "Y Axis Test From Config",

--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -85,11 +85,13 @@ export default class ChartEditorV extends Vue {
                 'modal-btn',
                 {
                     allowDone: true,
-                    features: 'import templates customize'
+                    features: 'import templates customize done',
+                    importer: {
+                        options: 'plugins csv json'
+                    }
                 },
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 (chart: any) => {
-                    // const saved = this.modalEditor.editor.chart.saveProject();
                     this.createNewChart(chart.toString());
                 }
             );
@@ -115,12 +117,16 @@ export default class ChartEditorV extends Vue {
     }
 
     clearEditor(): void {
+        // reset to clear modal editor options
+        this.modalEditor.chartOptions = {};
         this.modalEditor.editor.chart.options.setAll({
             title: {
                 text: `Chart ${this.chartConfigs.length + 1}`
             }
         });
-        this.modalEditor.editor.chart.data.clear();
+
+        // clear data section
+        this.modalEditor.editor.dataTable.clear();
     }
 
     createNewChart(chartInfo: string): void {
@@ -197,7 +203,7 @@ export default class ChartEditorV extends Vue {
         this.edited = false;
     }
 
-    onChartsEdited() {
+    onChartsEdited(): void {
         this.edited = true;
         this.$parent.$emit('slide-edit');
     }

--- a/src/components/editor/helpers/chart-preview.vue
+++ b/src/components/editor/helpers/chart-preview.vue
@@ -45,7 +45,7 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
-import { ChartConfig, DQVChartConfig } from '@/definitions';
+import { ChartConfig, DQVChartConfig, PieSeriesData, PieDataRow, LineSeriesData } from '@/definitions';
 import ChartV from '@/components/panels/helpers/chart.vue';
 
 @Component({
@@ -69,6 +69,9 @@ export default class ChartPreviewV extends Vue {
         this.loading = false;
     }
 
+    /**
+     * Save initial set of chart options used to create chart.
+     */
     loadChart(chartOptions: DQVChartConfig): void {
         // initialize higcharts editor and link to edit summoner node
         if (this.modalEditor) {
@@ -79,7 +82,11 @@ export default class ChartPreviewV extends Vue {
             `edit-${this.chartName}-btn`,
             {
                 allowDone: true,
-                features: 'import templates customize'
+                features: 'import templates customize done',
+                importer: {
+                    options: 'plugins csv json'
+                },
+                defaultChartOptions: chartOptions
             },
             (newChart: any) => {
                 const chart = JSON.parse(newChart);
@@ -95,8 +102,56 @@ export default class ChartPreviewV extends Vue {
             }
         );
 
+        // restore CSV data if exists
+        if (chartOptions.data?.csv !== undefined) {
+            const csvData = chartOptions.data.csv;
+            this.modalEditor.editor.dataTable.loadCSV({ csv: csvData });
+        } else {
+            this.convertSeriesToCSV(chartOptions);
+        }
+
         this.modalEditor.editor.chart.options.setAll(chartOptions);
-        // modalEditor.editor.chart.loadProject(chartOptions);
+    }
+
+    /*
+     * Convert series data into formatted csvData string for charts created without using editor
+     * so that the datatable when re-opening modal is properly populated.
+     */
+    convertSeriesToCSV(chartOptions: DQVChartConfig): void {
+        if (chartOptions.chart?.type === 'pie') {
+            const seriesData = (chartOptions?.series as PieSeriesData).data;
+            if (seriesData) {
+                // pie charts only have one set of series data with the name;y format
+                const csvData = [
+                    // first row is attempt to extract data labels if exists
+                    `${(chartOptions?.series as PieSeriesData).name};${chartOptions?.yAxis?.title.text}`,
+                    ...seriesData.map((row: PieDataRow) => `${row.name};${row.y}`)
+                ];
+
+                // load formatted CSV string into datatable
+                this.modalEditor.editor.dataTable.loadCSV({ csv: csvData.join('\n') });
+            }
+        } else {
+            if (chartOptions?.series && (chartOptions?.series as LineSeriesData[]).length) {
+                // other chart types may have multiple sets of series data along with x-axis categories
+                // append series data name to its data set
+                let seriesData = (chartOptions?.series as LineSeriesData[]).map((series: LineSeriesData) => [
+                    series.name,
+                    ...series.data
+                ]);
+                if (chartOptions.xAxis !== undefined) {
+                    // add xAxis categories to series data if it exists
+                    const catoData = [chartOptions.xAxis?.title?.text].concat(chartOptions.xAxis?.categories);
+                    seriesData.unshift(catoData);
+                }
+
+                // join series data together
+                let csvData = seriesData[0].map((_, idx) => seriesData.map((data) => data[idx]).join(';'));
+
+                // load formatted CSV string into datatable
+                this.modalEditor.editor.dataTable.loadCSV({ csv: csvData.join('\n') });
+            }
+        }
     }
 }
 </script>

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -14,7 +14,7 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
-import { ChartConfig, DQVChartConfig, SeriesData } from '@/definitions';
+import { ChartConfig, DQVChartConfig, PieSeriesData, LineSeriesData } from '@/definitions';
 
 import { Chart } from 'highcharts-vue';
 import Highcharts from 'highcharts';
@@ -171,11 +171,13 @@ export default class ChartV extends Vue {
     /**
      * Parse chart data content and return a highcharts formatted series object for a pie chart.
      */
-    makePieChart(data: any, defaultOptions: any): void {
-        let series: { data: SeriesData[] } = { data: [] };
+    makePieChart(csvData: any, defaultOptions: any): void {
+        let series: PieSeriesData = { name: '', data: [] };
 
         // construct series data
-        data.forEach((slice: any) => {
+        series.name = csvData[0][0];
+        const ylabel = csvData[0][1];
+        csvData.slice(1).forEach((slice: any) => {
             series.data.push({
                 name: slice[0],
                 // in case of strings being passed in such as '10%'
@@ -200,7 +202,12 @@ export default class ChartV extends Vue {
         this.chartOptions = {
             ...defaultOptions,
             plotOptions: plotOptions,
-            series: series
+            series: series,
+            yAxis: {
+                title: {
+                    text: ylabel
+                }
+            }
         };
         this.$emit('loaded', this.chartOptions);
     }
@@ -208,7 +215,7 @@ export default class ChartV extends Vue {
     /**
      * Parse chart data content and return a highcharts formatted series object for a line/bar chart.
      */
-    makeLineChart(fields: string[], data: any, defaultOptions: any): void {
+    makeLineChart(fields: string[], csvData: any, defaultOptions: any): void {
         const dqvOptions = this.config.options;
         // find xAxis categories for line/bar charts
         const cato = fields.shift() as string;
@@ -216,13 +223,13 @@ export default class ChartV extends Vue {
             title: {
                 text: dqvOptions?.xAxisLabel ? dqvOptions?.xAxisLabel : ''
             },
-            categories: data.map((row: any) => row[cato])
+            categories: csvData.map((row: any) => row[cato])
         };
 
         // construct series data
-        let series: SeriesData[] = [];
+        let series: LineSeriesData[] = [];
         fields.forEach((f: string) => {
-            const colData = data.map((row: any) => row[f]);
+            const colData = csvData.map((row: any) => row[f]);
             series.push({
                 name: f,
                 data: colData

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -21,11 +21,19 @@ export interface DQVOptions {
     type: string;
 }
 
-export interface SeriesData {
+export interface PieSeriesData {
+    name: string;
+    data: PieDataRow[];
+}
+
+export interface PieDataRow {
     name: string;
     y?: number;
-    data?: number[];
-    type?: string;
+}
+
+export interface LineSeriesData {
+    name: string;
+    data: number[];
 }
 
 export interface DQVChartConfig {
@@ -55,6 +63,7 @@ export interface DQVChartConfig {
     data?: {
         csvURL: string;
         enablePolling: boolean;
+        csv?: string;
     };
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     plotOptions?: any;
@@ -66,7 +75,7 @@ export interface DQVChartConfig {
         };
         enabled: boolean;
     };
-    series?: SeriesData[] | { data: SeriesData[] };
+    series?: PieSeriesData | LineSeriesData[];
 }
 
 export interface Intro {


### PR DESCRIPTION
Closes #97, #1.

Modified chart options to properly load existing charts and its data when opening modal for editing. The bulk of this logic is dealing with charts that were created without using the editor, as the data would need to parsed into a formatted `csvData` string to be passed into `editor.dataTable.loadCSV()`. For testing purposes, any newly-created charts should be able to retain all its information and display them when opening the modal again in edit mode.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/122)
<!-- Reviewable:end -->
