### PR TITLE
Fix charts button styling and default starting editor options

### DIFF
--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -118,6 +118,12 @@ export default class ChartEditorV extends Vue {
         this.modalEditor.editor.chart.options.setAll({
             title: {
                 text: `Chart ${this.chartConfigs.length + 1}`
+            },
+            subtitle: {
+                text: ''
+            },
+            credits: {
+                enabled: false
             }
         });
         this.modalEditor.editor.chart.data.clear();

--- a/src/components/editor/helpers/chart-preview.vue
+++ b/src/components/editor/helpers/chart-preview.vue
@@ -2,10 +2,18 @@
     <li class="chart-item items-center mt-8 mx-5 overflow-hidden">
         <div class="relative border-solid border-2 items-center justify-center text-center w-full">
             <button
-                class="bg-white absolute h-6 w-6 leading-5 rounded-full top-2 left-0 z-10 cursor-pointer"
+                class="bg-white absolute h-6 w-6 leading-5 rounded-full top-2 left-0 p-0 z-10 cursor-pointer"
                 @click="() => $emit('delete', chart)"
+                :content="$t('editor.chart.delete')"
+                v-tippy="{ placement: 'top', hideOnClick: false }"
             >
-                <svg height="22px" width="22px" viewBox="0 0 352 512" xmlns="http://www.w3.org/2000/svg">
+                <svg
+                    class="absolute transform -translate-x-1/2 -translate-y-1/2"
+                    height="22px"
+                    width="22px"
+                    viewBox="0 0 352 512"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
                     <path
                         d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
                     />

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -36,6 +36,7 @@ editor.image.label.drag,Drag your images here,1,Faites glisser vos images ici,0
 editor.image.label.or,or,1,ou,1
 editor.image.label.browse,browse,1,feuilleter,0
 editor.image.label.upload,to upload,1,télécharger,0
+editor.chart.delete,Delete Chart,1,Supprimer le graphique,0
 editor.chart.label.name,Name,1,Nom,1
 editor.chart.label.edit,Edit,1,Éditer,1
 editor.chart.label.empty,Empty,1,Vide,1


### PR DESCRIPTION
Closes #121, #132

Changes default chart editor options to turn off credits and add an empty subtitle rather than having some default text. Also adjusts close button to be centered within parent button.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/133)
<!-- Reviewable:end -->
