### PR TITLE
add server garbage collection; more sourceCount updating

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ var bodyParser = require('body-parser'); //connects bodyParsing middleware
 var formidable = require('formidable');
 var path = require('path'); //used for file path
 var fs = require('fs-extra'); //File System-needed for renaming file etc
+var recursiveRead = require('recursive-readdir');
 var cors = require('cors');
 const decompress = require('decompress');
 const archiver = require('archiver');
@@ -61,6 +62,35 @@ app.route('/upload').post(function (req, res, next) {
         // Unzip the contents of the uploaded zip file into the target directory. Will overwrite
         // old files in the folder.
         decompress(secureFilename, fileName).then((files) => {
+            // Below is some logic to remove items from the server directory that are no longer used.
+
+            // Retrieve the existing files in the directory and change the path.
+            const existingFiles = recursiveRead(fileName).then((existing) => {
+                return existing.map((item) => {
+                    item = item.replace(/\\/g, '/');
+                    return item.substring(item.indexOf('/', item.indexOf('/', 2) + 1) + 1);
+                });
+            });
+
+            // Once the existing files are retrieved, parse the new files being uploaded
+            // and check to see if any of the existing files have been removed from the
+            // project (if they've been removed, they won't be in the new file list).
+            existingFiles.then((existing) => {
+                var newFiles = files.filter((x) => x.type == 'file').map((i) => i.path);
+
+                let difference = existing
+                    .filter((x) => !newFiles.includes(x))
+                    .concat(newFiles.filter((x) => !existing.includes(x)));
+
+                // Delete the file if it doesn't exist in the newly uploaded product.
+                difference.forEach((file) => {
+                    // TODO: remove this, but leaving it in for now just in case something was
+                    // overlooked and files start randomly disappearing.
+                    console.log(`[DEBUG] Removing ${file} because it no longer exists in the project.`);
+                    fs.rm(fileName + '/' + file);
+                });
+            });
+
             // SECURITY FEATURE: delete all files in the folder that don't have one of the following extensions:
             // .json, .jpg, .jpeg, .gif, .png, .csv
             // TODO: Disabled until I can find a better regex

--- a/server/package.json
+++ b/server/package.json
@@ -16,6 +16,7 @@
         "express": "^4.18.2",
         "formidable": "^2.1.1",
         "fs-extra": "^11.1.0",
-        "path": "^0.12.7"
+        "path": "^0.12.7",
+        "recursive-readdir": "^2.2.3"
     }
 }

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -166,6 +166,7 @@
                         @slides-updated="updateSlides"
                         :configFileStructure="configFileStructure"
                         :lang="lang"
+                        :sourceCounts="sourceCounts"
                     ></slide-toc>
                 </div>
                 <slide-editor

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -124,15 +124,16 @@ export default class ImageEditorV extends Vue {
         this.imagePreviews.push(
             ...filelist.map((file: File) => {
                 // Add the uploaded images to the product ZIP file.
+                const uploadSource = `${this.configFileStructure.uuid}/assets/${this.lang}/${file.name}`;
                 this.configFileStructure.assets[this.lang].file(file.name, file);
 
-                let imageSrc = URL.createObjectURL(file);
-                if (this.sourceCounts[imageSrc]) {
-                    this.sourceCounts[imageSrc] += 1;
+                if (this.sourceCounts[uploadSource]) {
+                    this.sourceCounts[uploadSource] += 1;
                 } else {
-                    this.sourceCounts[imageSrc] = 1;
+                    this.sourceCounts[uploadSource] = 1;
                 }
 
+                let imageSrc = URL.createObjectURL(file);
                 return {
                     id: file.name,
                     altText: '',
@@ -149,14 +150,16 @@ export default class ImageEditorV extends Vue {
             this.imagePreviews.push(
                 ...files.map((file: File) => {
                     // Add the uploaded images to the product ZIP file.
+                    const uploadSource = `${this.configFileStructure.uuid}/assets/${this.lang}/${file.name}`;
                     this.configFileStructure.assets[this.lang].file(file.name, file);
-                    let imageSrc = URL.createObjectURL(file);
-                    if (this.sourceCounts[imageSrc]) {
-                        this.sourceCounts[imageSrc] += 1;
+
+                    if (this.sourceCounts[uploadSource]) {
+                        this.sourceCounts[uploadSource] += 1;
                     } else {
-                        this.sourceCounts[imageSrc] = 1;
+                        this.sourceCounts[uploadSource] = 1;
                     }
 
+                    let imageSrc = URL.createObjectURL(file);
                     return {
                         id: file.name,
                         altText: '',
@@ -172,9 +175,11 @@ export default class ImageEditorV extends Vue {
     deleteImage(img: ImageFile): void {
         const idx = this.imagePreviews.findIndex((file: ImageFile) => file.id === img.id);
         if (idx !== -1) {
+            const fileSource = `${this.configFileStructure.uuid}/assets/${this.lang}/${this.imagePreviews[idx].id}`;
+
             // Remove the image from the product ZIP file.
-            this.sourceCounts[this.imagePreviews[idx].src] -= 1;
-            if (this.sourceCounts[this.imagePreviews[idx].src] === 0) {
+            this.sourceCounts[fileSource] -= 1;
+            if (this.sourceCounts[fileSource] === 0) {
                 this.configFileStructure.assets[this.lang].remove(this.imagePreviews[idx].id);
                 URL.revokeObjectURL(this.imagePreviews[idx].src);
             }


### PR DESCRIPTION
Closes #111 

This PR adds garbage collection to the server. When the ZIP is sent to the server, it will look at the files currently in the file system and compare them with the new files being uploaded through the ZIP (this should contain all of the up-to-date, active files) and will delete the files that aren't in the newly uploaded ZIP.

**I've done some thorough testing, but please do your best to see if you can come up with any edge cases or any way to break this since it does deal with deleting files and we don't want people to lose any work.**

## Changes

Editor Changes:
- When changing the right panel type, sources will be updated accordingly before clearing the panel config.
- Fix source counting not working correctly for slideshows (the counter was using the blob URL, not the actual file URL)
- When deleting an entire slide, panel sources will be updated correctly

Server Changes:
- Items removed from the product will now be removed from the server directory as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/134)
<!-- Reviewable:end -->
