### PR TITLE
Save indicator and slide switching

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -101,7 +101,18 @@
                     </span>
                 </transition>
                 <button class="bg-white border border-black hover:bg-gray-100">Preview</button>
-                <button @click="generateConfig" class="bg-black text-white hover:bg-gray-900">Save Changes</button>
+                <button @click="generateConfig" class="bg-black text-white hover:bg-gray-900" :disabled="saving">
+                    <span class="inline-block">{{ saving ? 'Saving...' : 'Save Changes' }}</span>
+                    <span v-if="saving" class="align-middle inline-block px-1"
+                        ><spinner
+                            size="16px"
+                            background="#6B7280"
+                            color="#FFFFFF"
+                            stroke="2px"
+                            class="ml-1 mb-1"
+                        ></spinner>
+                    </span>
+                </button>
             </div>
             <div class="flex">
                 <div class="w-80 flex-shrink-0 border-r border-black editor-toc">
@@ -197,6 +208,7 @@ export default class EditorV extends Vue {
     error = false; // whether an error has occurred
     lang = 'en';
     unsavedChanges = false;
+    saving = false;
 
     // Form properties.
     uuid = '';
@@ -481,6 +493,7 @@ export default class EditorV extends Vue {
      * with the new changes, then generates and submits the product file to the server.
      */
     generateConfig(): StoryRampConfig {
+        this.saving = true;
         // save current slide final changes before generating config file
         (this.$refs.slide as any).saveChanges();
 
@@ -506,6 +519,12 @@ export default class EditorV extends Vue {
                 })
                 .catch(() => {
                     this.$message.error('Failed to save changes.');
+                })
+                .finally(() => {
+                    // padding to prevent save button from being clicked rapidly
+                    setTimeout(() => {
+                        this.saving = false;
+                    }, 500);
                 });
         });
 
@@ -565,11 +584,8 @@ export default class EditorV extends Vue {
         setTimeout(() => {
             this.currentSlide = index === -1 ? '' : this.slides[index];
             this.slideIndex = index;
-        }, 5);
-
-        if (index !== -1 && this.slides[index].panel[0].type === 'dynamic') {
             (this.$refs.slide as any).panelIndex = 0;
-        }
+        }, 5);
     }
 
     /**


### PR DESCRIPTION
Closes #127 and #128.

- Switching to a new slide opens the left panel by default
- Save button is disabled and displays a spinner while saving to the server

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/136)
<!-- Reviewable:end -->
