### PR TITLE
 Save indicator and slide switching

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -122,8 +122,19 @@
                         {{ $t('editor.preview') }}
                     </button>
                 </router-link>
-                <button @click="generateConfig" class="bg-black text-white hover:bg-gray-900">
-                    {{ $t('editor.saveChanges') }}
+                <button @click="generateConfig" class="bg-black text-white hover:bg-gray-900" :disabled="saving">
+                    <span class="inline-block">{{
+                        saving ? $t('editor.savingChanges') : $t('editor.saveChanges')
+                    }}</span>
+                    <span v-if="saving" class="align-middle inline-block px-1"
+                        ><spinner
+                            size="16px"
+                            background="#6B7280"
+                            color="#FFFFFF"
+                            stroke="2px"
+                            class="ml-1 mb-1"
+                        ></spinner>
+                    </span>
                 </button>
                 <router-link
                     :to="{
@@ -228,6 +239,7 @@ export default class EditorV extends Vue {
     error = false; // whether an error has occurred
     lang = 'en';
     unsavedChanges = false;
+    saving = false;
 
     // Form properties.
     uuid = '';
@@ -512,6 +524,7 @@ export default class EditorV extends Vue {
      * with the new changes, then generates and submits the product file to the server.
      */
     generateConfig(): StoryRampConfig {
+        this.saving = true;
         // save current slide final changes before generating config file
         if (this.$refs.slide !== undefined) {
             (this.$refs.slide as any).saveChanges();
@@ -539,6 +552,12 @@ export default class EditorV extends Vue {
                 })
                 .catch(() => {
                     this.$message.error('Failed to save changes.');
+                })
+                .finally(() => {
+                    // padding to prevent save button from being clicked rapidly
+                    setTimeout(() => {
+                        this.saving = false;
+                    }, 500);
                 });
         });
 
@@ -598,11 +617,8 @@ export default class EditorV extends Vue {
         setTimeout(() => {
             this.currentSlide = index === -1 ? '' : this.slides[index];
             this.slideIndex = index;
-        }, 5);
-
-        if (index !== -1 && this.slides[index].panel[0].type === 'dynamic') {
             (this.$refs.slide as any).panelIndex = 0;
-        }
+        }, 5);
     }
 
     /**

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -28,6 +28,7 @@ editor.back,Back,1,Retour,1
 editor.next,Next,1,Suivant,1
 editor.preview,Preview,1,Aperçu,0
 editor.saveChanges,Save Changes,1,Sauvegarder les Modifications,0
+editor.savingChanges,Saving...,1,Sauver...,0
 editor.frenchConfig,View French Config,1,Afficher la configuration française,0
 editor.englishConfig,View English Config,1,Afficher la configuration en anglais,0
 editor.returnToLanding,Return to Landing,1,Return to Landing,0


### PR DESCRIPTION
Closes #127 and #128.

- Switching to a new slide opens the left panel by default
- Save button is disabled and displays a spinner while saving to the server