### PR TITLE
copy over text contents when switching to dynamic panel

### DIFF
--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -299,9 +299,9 @@ export default class SlideEditorV extends Vue {
             },
             dynamic: {
                 type: PanelType.Dynamic,
-                title: '',
+                title: this.currentSlide.panel[0] && prevType === 'text' ? this.currentSlide.panel[0].title : '',
                 titleTag: '',
-                content: '',
+                content: this.currentSlide.panel[0] && prevType === 'text' ? this.currentSlide.panel[0].content : '',
                 children: []
             },
             slideshow: {


### PR DESCRIPTION
Closes #131 

If you have typed something into the left panel `text` section and then switch the type to a dynamic panel, the contents are transferred over.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/138)
<!-- Reviewable:end -->
