### PR TITLE
load both lang configs, allow copying between langs

### DIFF
--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -183,7 +183,7 @@ export default class DynamicEditorV extends Vue {
             case 'map':
                 this.sourceCounts[panel.config] -= 1;
                 if (this.sourceCounts[panel.config] === 0) {
-                    this.configFileStructure.config.remove(`${panel.config.substring(panel.config.indexOf('/') + 1)}`);
+                    this.configFileStructure.zip.remove(`${panel.config.substring(panel.config.indexOf('/') + 1)}`);
                 }
                 break;
 
@@ -191,7 +191,7 @@ export default class DynamicEditorV extends Vue {
                 panel.charts.forEach((chart: any) => {
                     this.sourceCounts[chart.src] -= 1;
                     if (this.sourceCounts[chart.src] === 0) {
-                        this.configFileStructure.config.remove(`${chart.src.substring(chart.src.indexOf('/') + 1)}`);
+                        this.configFileStructure.zip.remove(`${chart.src.substring(chart.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;
@@ -200,7 +200,7 @@ export default class DynamicEditorV extends Vue {
                 panel.images.forEach((image: any) => {
                     this.sourceCounts[image.src] -= 1;
                     if (this.sourceCounts[image.src] === 0) {
-                        this.configFileStructure.config.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
+                        this.configFileStructure.zip.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -689,6 +689,7 @@ export default class EditorV extends Vue {
     swapLang(): void {
         this.lang = this.lang === 'en' ? 'fr' : 'en';
         this.loadConfig();
+        this.selectSlide(-1);
     }
 
     /**

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -7,7 +7,7 @@
                     <div class="flex text-2xl font-bold mb-5">
                         {{ editExisting ? $t('editor.editProduct') : $t('editor.createProduct') }}
                     </div>
-                    <button v-if="config" @click="swapLang">
+                    <button @click="swapLang">
                         {{ lang === 'en' ? $t('editor.frenchConfig') : $t('editor.englishConfig') }}
                     </button>
                 </div>
@@ -115,10 +115,14 @@
                         <span class="align-center inline-block select-none">Unsaved Changes</span>
                     </span>
                 </transition>
+                <button @click.stop="unsavedChanges ? $modals.show(`change-lang`) : swapLang()">
+                    {{ lang === 'en' ? $t('editor.frenchConfig') : $t('editor.englishConfig') }}
+                </button>
+                <confirmation-modal :name="`change-lang`" :message="$t('editor.changeLang.modal')" @Ok="swapLang()" />
                 <router-link
                     :to="{
                         name: 'preview',
-                        params: { conf: config, configFileStructure: configFileStructure }
+                        params: { conf: configs[lang], configFileStructure: configFileStructure }
                     }"
                 >
                     <button @click="preview" class="bg-white border border-black hover:bg-gray-100">
@@ -225,9 +229,11 @@ import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
 import SlideEditorV from './slide-editor.vue';
 import SlideTocV from './slide-toc.vue';
 import MetadataEditorV from './metadata-editor.vue';
+import ConfirmationModalV from './helpers/confirmation-modal.vue';
 
 @Component({
     components: {
+        'confirmation-modal': ConfirmationModalV,
         'metadata-editor': MetadataEditorV,
         spinner: Circle2,
         'slide-editor': SlideEditorV,
@@ -237,7 +243,9 @@ import MetadataEditorV from './metadata-editor.vue';
 export default class EditorV extends Vue {
     @Prop({ default: true }) editExisting!: boolean; // true if editing existing storylines product, false if new product
 
-    config: StoryRampConfig | undefined = undefined;
+    configs: {
+        [key: string]: StoryRampConfig | undefined;
+    } = { en: undefined, fr: undefined };
     configFileStructure: any = undefined;
     loadStatus = 'waiting';
     error = false; // whether an error has occurred
@@ -282,7 +290,7 @@ export default class EditorV extends Vue {
         this.lang = this.$route.params.lang ? this.$route.params.lang : 'en';
 
         // Initialize Storylines config and the configuration structure.
-        this.config = undefined;
+        this.configs = { en: undefined, fr: undefined };
         this.configFileStructure = undefined;
 
         // If a product UUID is provided, fetch the contents from the server.
@@ -302,26 +310,33 @@ export default class EditorV extends Vue {
         const configZip = new JSZip();
 
         // Generate a new configuration file and populate required fields.
-        this.config = this.configHelper();
-        this.config.title = this.metadata.title;
-        this.config.introSlide.title = this.metadata.introTitle;
-        this.config.introSlide.subtitle = this.metadata.introSubtitle;
-        this.config.slides = this.slides;
+        this.configs[this.lang] = this.configHelper();
+        this.configs[this.lang]!.title = this.metadata.title;
+        this.configs[this.lang]!.introSlide.title = this.metadata.introTitle;
+        this.configs[this.lang]!.introSlide.subtitle = this.metadata.introSubtitle;
+        this.configs[this.lang]!.slides = this.slides;
 
         // Set the source of the product logo
         if (!this.metadata.logoName) {
-            this.config.introSlide.logo.src = '';
+            this.configs[this.lang]!.introSlide.logo.src = '';
         } else if (!this.metadata.logoName.includes('http')) {
-            this.config.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
+            this.configs[this.lang]!.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
         } else {
-            this.config.introSlide.logo.src = this.metadata.logoName;
+            this.configs[this.lang]!.introSlide.logo.src = this.metadata.logoName;
         }
+
+        const otherLang = this.lang === 'en' ? 'fr' : 'en';
+
+        this.configs[otherLang] = this.configs[this.lang];
+        this.configs[otherLang]!.lang = otherLang;
 
         // Add the newly generated Storylines configuration file to the ZIP file.
         const fileName = `${this.uuid}_${this.lang}.json`;
-        const formattedConfigFile = JSON.stringify(this.config, null, 4);
+        const formattedConfigFile = JSON.stringify(this.configs[this.lang], null, 4);
+        const formattedOtherLangConfig = JSON.stringify(this.configs[otherLang], null, 4);
 
         configZip.file(fileName, formattedConfigFile);
+        configZip.file(`${this.uuid}_${otherLang}.json`, formattedOtherLangConfig);
 
         // Generate the file structure, defer uploading the image until the structure is created.
         this.configFileStructureHelper(configZip, this.logoImage);
@@ -374,12 +389,13 @@ export default class EditorV extends Vue {
         });
     }
 
-    findSources(config: StoryRampConfig): void {
-        this.incrementSourceCount(config.introSlide.logo.src);
-
-        config.slides.forEach((slide) => {
-            slide.panel.forEach((panel) => {
-                this.panelSourceHelper(panel);
+    findSources(configs: { [key: string]: StoryRampConfig | undefined }): void {
+        ['en', 'fr'].forEach((lang) => {
+            this.incrementSourceCount(configs[lang]!.introSlide.logo.src);
+            configs[lang]!.slides.forEach((slide) => {
+                slide.panel.forEach((panel) => {
+                    this.panelSourceHelper(panel);
+                });
             });
         });
     }
@@ -433,7 +449,8 @@ export default class EditorV extends Vue {
 
         this.configFileStructure = {
             uuid: this.uuid,
-            config: configZip,
+            zip: configZip,
+            configs: this.configs,
             assets: {
                 en: assetsFolder.folder('en'),
                 fr: assetsFolder.folder('fr')
@@ -460,67 +477,83 @@ export default class EditorV extends Vue {
      * Loads a configuration file from the product folder, and sets application data
      * as needed.
      */
-    loadConfig(): void {
+    async loadConfig(config?: StoryRampConfig): Promise<void> {
         const configPath = `${this.uuid}_${this.lang}.json`;
 
-        this.configFileStructure.config
-            .file(configPath)
+        if (config) {
+            this.useConfig(config);
+            return;
+        }
+
+        await this.configFileStructure.zip
+            .file(`${this.uuid}_en.json`)
             .async('string')
             .then((res: any) => {
-                this.config = JSON.parse(res);
-                this.editExisting ? (this.loadStatus = 'waiting') : (this.loadStatus = 'loaded');
+                this.configs['en'] = JSON.parse(res);
+            });
+        await this.configFileStructure.zip
+            .file(`${this.uuid}_fr.json`)
+            .async('string')
+            .then((res: any) => {
+                this.configs['fr'] = JSON.parse(res);
+            });
 
-                // Load in project data.
-                if (this.config) {
-                    this.metadata.title = this.config.title;
-                    this.metadata.introTitle = this.config.introSlide.title;
-                    this.metadata.introSubtitle = this.config.introSlide.subtitle;
-                    this.metadata.contextLink = this.config.contextLink;
-                    this.metadata.contextLabel = this.config.contextLabel;
-                    this.metadata.dateModified = this.config.dateModified;
-                    const logo = this.config.introSlide.logo.src;
+        this.editExisting ? (this.loadStatus = 'waiting') : (this.loadStatus = 'loaded');
 
-                    // Fetch the logo from the folder (if it exists).
-                    const logoSrc = `${logo.substring(logo.indexOf('/') + 1)}`;
-                    const logoName = `${logo.split('/')[logo.split('/').length - 1]}`;
+        // Load in project data.
+        if (this.configs[this.lang]) {
+            this.useConfig(this.configs[this.lang]!);
 
-                    if (this.configFileStructure.config.file(logoSrc)) {
-                        this.configFileStructure.config
-                            .file(logoSrc)
-                            .async('blob')
-                            .then((img: any) => {
-                                this.logoImage = new File([img], logoName);
-                                this.metadata.logoPreview = URL.createObjectURL(img);
-                                this.metadata.logoName = logoName;
-                            });
-                    } else {
-                        // If it doesn't exist, maybe it's a remote file?
-                        fetch(logo).then((data: any) => {
-                            if (data.status !== 404) {
-                                this.logoImage = new File([data], logoName);
-                                this.metadata.logoPreview = logo;
-                            }
-                        });
+            this.findSources(this.configs);
+        }
+    }
 
-                        // Fill in the field with this value whether it exists or not.
-                        this.metadata.logoName = logo;
-                    }
+    useConfig(config: StoryRampConfig) {
+        this.metadata.title = config.title;
+        this.metadata.introTitle = config.introSlide.title;
+        this.metadata.introSubtitle = config.introSlide.subtitle;
+        this.metadata.contextLink = config.contextLink;
+        this.metadata.contextLabel = config.contextLabel;
+        this.metadata.dateModified = config.dateModified;
+        const logo = config.introSlide.logo.src;
 
-                    this.slides = this.config.slides;
-                    // conversion for individual image panels to slideshow for gallery display
-                    this.slides.forEach((slide: Slide) => {
-                        if (slide.panel.length === 2 && slide.panel[1].type === 'image') {
-                            const newSlide = {
-                                type: 'slideshow',
-                                images: [slide.panel[1]]
-                            };
-                            Vue.set(slide.panel, 1, newSlide);
-                        }
-                    });
+        // Fetch the logo from the folder (if it exists).
+        const logoSrc = `${logo.substring(logo.indexOf('/') + 1)}`;
+        const logoName = `${logo.split('/')[logo.split('/').length - 1]}`;
 
-                    this.findSources(this.config);
+        if (this.configFileStructure.zip.file(logoSrc)) {
+            this.configFileStructure.zip
+                .file(logoSrc)
+                .async('blob')
+                .then((img: any) => {
+                    this.logoImage = new File([img], logoName);
+                    this.metadata.logoPreview = URL.createObjectURL(img);
+                    this.metadata.logoName = logoName;
+                });
+        } else {
+            // If it doesn't exist, maybe it's a remote file?
+            fetch(logo).then((data: any) => {
+                if (data.status !== 404) {
+                    this.logoImage = new File([data], logoName);
+                    this.metadata.logoPreview = logo;
                 }
             });
+
+            // Fill in the field with this value whether it exists or not.
+            this.metadata.logoName = logo;
+        }
+
+        this.slides = config.slides;
+        // conversion for individual image panels to slideshow for gallery display
+        this.slides.forEach((slide: Slide) => {
+            if (slide.panel.length === 2 && slide.panel[1].type === 'image') {
+                const newSlide = {
+                    type: 'slideshow',
+                    images: [slide.panel[1]]
+                };
+                Vue.set(slide.panel, 1, newSlide);
+            }
+        });
     }
 
     /**
@@ -536,12 +569,12 @@ export default class EditorV extends Vue {
 
         // Update the configuration file.
         const fileName = `${this.uuid}_${this.lang}.json`;
-        const formattedConfigFile = JSON.stringify(this.config, null, 4);
+        const formattedConfigFile = JSON.stringify(this.configs[this.lang], null, 4);
 
-        this.configFileStructure.config.file(fileName, formattedConfigFile);
+        this.configFileStructure.zip.file(fileName, formattedConfigFile);
 
         // Upload the ZIP file.
-        this.configFileStructure.config.generateAsync({ type: 'blob' }).then((content: any) => {
+        this.configFileStructure.zip.generateAsync({ type: 'blob' }).then((content: any) => {
             const formData = new FormData();
             formData.append('data', content, `${this.uuid}.zip`);
             const headers = { 'Content-Type': 'multipart/form-data' };
@@ -581,22 +614,24 @@ export default class EditorV extends Vue {
      */
     saveMetadata(): void {
         // update metadata content to existing config only if it has been successfully loaded
-        if (this.config !== undefined) {
-            this.config.title = this.metadata.title;
-            this.config.introSlide.title = this.metadata.introTitle;
-            this.config.introSlide.subtitle = this.metadata.introSubtitle;
-            this.config.contextLink = this.metadata.contextLink;
-            this.config.contextLabel = this.metadata.contextLabel;
-            this.config.dateModified = this.metadata.dateModified;
+        if (this.configs[this.lang] !== undefined) {
+            this.configs[this.lang]!.title = this.metadata.title;
+            this.configs[this.lang]!.introSlide.title = this.metadata.introTitle;
+            this.configs[this.lang]!.introSlide.subtitle = this.metadata.introSubtitle;
+            this.configs[this.lang]!.contextLink = this.metadata.contextLink;
+            this.configs[this.lang]!.contextLabel = this.metadata.contextLabel;
+            this.configs[this.lang]!.dateModified = this.metadata.dateModified;
 
             // If the logo doesn't include HTTP, assume it's a local file.
             if (!this.metadata.logoName) {
-                this.config.introSlide.logo.src = '';
+                this.configs[this.lang]!.introSlide.logo.src = '';
             } else if (!this.metadata.logoName.includes('http')) {
-                this.config.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
+                this.configs[
+                    this.lang
+                ]!.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
                 this.configFileStructure.assets[this.lang].file(this.logoImage?.name, this.logoImage);
             } else {
-                this.config.introSlide.logo.src = this.metadata.logoName;
+                this.configs[this.lang]!.introSlide.logo.src = this.metadata.logoName;
             }
         }
         if (this.$modals.isActive('metadata-edit-modal')) {
@@ -638,7 +673,7 @@ export default class EditorV extends Vue {
      */
     continueToEditor(): void {
         if (this.editExisting) {
-            this.config !== undefined
+            this.configs[this.lang] !== undefined
                 ? (this.loadStatus = 'loaded')
                 : this.$message.error('No config exists for storylines product.');
             this.unsavedChanges = false;
@@ -653,7 +688,7 @@ export default class EditorV extends Vue {
      */
     swapLang(): void {
         this.lang = this.lang === 'en' ? 'fr' : 'en';
-        this.generateRemoteConfig();
+        this.loadConfig();
     }
 
     /**

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -97,7 +97,7 @@ export default class ImageEditorV extends Vue {
                 const filename = image.src.replace(/^.*[\\/]/, '');
 
                 this.imagePreviewPromises.push(
-                    this.configFileStructure.config
+                    this.configFileStructure.zip
                         .file(assetSrc)
                         .async('blob')
                         .then((res: any) => {

--- a/src/components/editor/map-editor.vue
+++ b/src/components/editor/map-editor.vue
@@ -118,8 +118,8 @@ export default class MapEditorV extends Vue {
             // Check if the config file exists in the ZIP folder first.
             const assetSrc = `${this.panel.config.substring(this.panel.config.indexOf('/') + 1)}`;
 
-            if (this.configFileStructure.config.file(assetSrc)) {
-                this.configFileStructure.config
+            if (this.configFileStructure.zip.file(assetSrc)) {
+                this.configFileStructure.zip
                     .file(assetSrc)
                     .async('string')
                     .then((res: any) => {

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -31,7 +31,7 @@
                     </button>
                     <span class="text-lg font-bold my-6"> {{ $t('or') }} </span>
                     <div class="flex">
-                        <select v-model="selectedForCopying">
+                        <select v-model="selectedForCopying" class="overflow-ellipsis copy-select">
                             <option
                                 v-for="(slide, index) in configFileStructure.configs[lang === 'en' ? 'fr' : 'en']
                                     .slides"
@@ -256,5 +256,9 @@ export default class SlideTocV extends Vue {
 
 .toc-slide button:hover {
     background: none !important;
+}
+
+.copy-select {
+    width: 450px;
 }
 </style>

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -12,6 +12,48 @@
                 </span>
                 <span class="align-middle inline-block">{{ $t('editor.slides.addSlide') }}</span>
             </button>
+            <button @click.stop="$modals.show(`copy-from-other-lang`)">
+                <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24">
+                    <path
+                        d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
+                    />
+                </svg>
+                <tippy delay="200" placement="right">{{ $t('editor.slides.copyFromLang') }}</tippy>
+            </button>
+            <vue-modal :name="`copy-from-other-lang`">
+                <h2 slot="header" class="text-xl font-bold">{{ $t('editor.slides.copyFromLang') }}</h2>
+                <div class="flex flex-col">
+                    <button
+                        class="w-32 h-12 ml-0"
+                        @click="copyAllFromOtherLang(configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides)"
+                    >
+                        Copy All
+                    </button>
+                    <span class="text-lg font-bold my-6"> {{ $t('or') }} </span>
+                    <div class="flex">
+                        <select v-model="selectedForCopying">
+                            <option
+                                v-for="(slide, index) in configFileStructure.configs[lang === 'en' ? 'fr' : 'en']
+                                    .slides"
+                                :value="index"
+                                :key="slide.title + index"
+                            >
+                                Slide {{ index + ': ' + slide.title }}
+                            </option>
+                        </select>
+
+                        <button
+                            @click="
+                                copyFromOtherLang(
+                                    configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides[selectedForCopying]
+                                )
+                            "
+                        >
+                            Copy
+                        </button>
+                    </div>
+                </div>
+            </vue-modal>
         </div>
         <ul>
             <li
@@ -99,6 +141,7 @@ export default class SlideTocV extends Vue {
 
     total = 0;
     $modals: any;
+    selectedForCopying = 0;
 
     selectSlide(index: number): void {
         this.$emit('slide-change', index);
@@ -124,8 +167,19 @@ export default class SlideTocV extends Vue {
         this.total++;
     }
 
+    copyFromOtherLang(slide: any) {
+        this.slides.splice(this.slides.length, 0, cloneDeep(slide));
+        this.$emit('slides-updated', this.slides);
+    }
+
+    copyAllFromOtherLang(slides: any[]) {
+        this.slides.splice(this.slides.length, 0, ...slides.map((slide) => cloneDeep(slide)));
+        this.$emit('slides-updated', this.slides);
+    }
+
     copySlide(index: number): void {
         this.slides.splice(index + 1, 0, cloneDeep(this.slides[index]));
+        this.$emit('slides-updated', this.slides);
     }
 
     removeSlide(index: number): void {

--- a/src/components/panels/helpers/chart.vue
+++ b/src/components/panels/helpers/chart.vue
@@ -64,9 +64,9 @@ export default class ChartV extends Vue {
             const assetSrc = `${this.config.src.substring(this.config.src.indexOf('/') + 1)}`;
 
             if (extension === 'json') {
-                if (this.configFileStructure && this.configFileStructure.config.file(assetSrc)) {
+                if (this.configFileStructure && this.configFileStructure.zip.file(assetSrc)) {
                     // First attempt to fetch the configuration file from the ZIP folder.
-                    this.configFileStructure.config
+                    this.configFileStructure.zip
                         .file(assetSrc)
                         .async('string')
                         .then((res: any) => {
@@ -94,9 +94,9 @@ export default class ChartV extends Vue {
                     });
                 }
             } else if (extension === 'csv') {
-                if (this.configFileStructure && this.configFileStructure.config.file(assetSrc)) {
+                if (this.configFileStructure && this.configFileStructure.zip.file(assetSrc)) {
                     // First attempt to fetch the configuration file from the ZIP folder.
-                    this.configFileStructure.config
+                    this.configFileStructure.zip
                         .file(assetSrc)
                         .async('blob')
                         .then((res: any) => {

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -40,8 +40,8 @@ export default class ImagePanelV extends Vue {
         // obtain image file from ZIP folder in editor preview mode
         if (this.configFileStructure) {
             const assetSrc = `${this.config.src.substring(this.config.src.indexOf('/') + 1)}`;
-            if (this.configFileStructure.config.file(assetSrc)) {
-                this.configFileStructure.config
+            if (this.configFileStructure.zip.file(assetSrc)) {
+                this.configFileStructure.zip
                     .file(assetSrc)
                     .async('blob')
                     .then((res: any) => {

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -41,8 +41,8 @@ export default class MapPanelV extends Vue {
     mounted(): void {
         // Check if the config file exists in the ZIP folder first
         const assetSrc = `${this.config.config.substring(this.config.config.indexOf('/') + 1)}`;
-        if (this.configFileStructure && this.configFileStructure.config.file(assetSrc)) {
-            this.configFileStructure.config
+        if (this.configFileStructure && this.configFileStructure.zip.file(assetSrc)) {
+            this.configFileStructure.zip
                 .file(assetSrc)
                 .async('string')
                 .then((res: any) => {

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -61,8 +61,8 @@ export default class SlideshowPanelV extends Vue {
         if (this.configFileStructure) {
             this.config.images.forEach((image) => {
                 const assetSrc = `${image.src.substring(image.src.indexOf('/') + 1)}`;
-                if (this.configFileStructure.config.file(assetSrc)) {
-                    this.configFileStructure.config
+                if (this.configFileStructure.zip.file(assetSrc)) {
+                    this.configFileStructure.zip
                         .file(assetSrc)
                         .async('blob')
                         .then((res: any) => {

--- a/src/components/story/introduction.vue
+++ b/src/components/story/introduction.vue
@@ -81,8 +81,8 @@ export default class IntroV extends Vue {
         // obtain logo from ZIP file if it exists
         if (this.configFileStructure) {
             const logoSrc = `${this.config.logo.src.substring(this.config.logo.src.indexOf('/') + 1)}`;
-            if (this.configFileStructure.config.file(logoSrc)) {
-                this.configFileStructure.config
+            if (this.configFileStructure.zip.file(logoSrc)) {
+                this.configFileStructure.zip
                     .file(logoSrc)
                     .async('blob')
                     .then((res: any) => {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -31,6 +31,7 @@ editor.next,Next,1,Suivant,1
 editor.preview,Preview,1,Aperçu,0
 editor.saveChanges,Save Changes,1,Sauvegarder les Modifications,0
 editor.savingChanges,Saving...,1,Sauver...,0
+editor.changeLang.modal,"Are you sure you want to switch languages? All unsaved changes will be lost.",1,"Are you sure you want to switch languages? All unsaved changes will be lost.",0
 editor.frenchConfig,View French Config,1,Afficher la configuration française,0
 editor.englishConfig,View English Config,1,Afficher la configuration en anglais,0
 editor.returnToLanding,Return to Landing,1,Return to Landing,0
@@ -50,6 +51,8 @@ editor.map.label.create,Create New Configuration File,1,Create New Configuration
 editor.map.label.edit,Edit Map Configuration,1,Edit Map Configuration,0
 editor.slides.title,SLIDES,1,SLIDES,0
 editor.slides.addSlide,"New Slide",1,"New Slide",0
+editor.slides.copyFromLang,"Copy slides from the other language",1,"Copy slides from the other language",0
 editor.slides.deleteSlide.confirm,"Are you sure you want to delete the slide {title}?",1,"Are you sure you want to delete the slide {title}?",0
 editor.slides.changeSlide.confirm,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",1,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",0
 dynamic.back,Back,1,Retour,0
+or,Or,1,Ou,1


### PR DESCRIPTION
Closes #69 #70 

Both configs are loaded at the start and stored in `this.configs` `.en` and `.fr`.
`configFileStructure.config` renamed to `configFileStructure.zip` and the configs are now passed around under `configFileStructure.configs`.

Added a button that opens a modal for copying slides from the other language, either all at once or one at a time.

Switching langs currently runs into the router "bug" where it shows the metadata edit page rather than staying on the main editor, clicking next brings you to the proper view.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/140)
<!-- Reviewable:end -->
