### PR TITLE
Display UUID in editor, Update tab titles

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -5,10 +5,17 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue } from 'vue-property-decorator';
+import { Component, Vue, Watch } from 'vue-property-decorator';
+import { Route } from 'vue-router';
 
 @Component({})
-export default class App extends Vue {}
+export default class App extends Vue {
+    @Watch('$route', { immediate: true })
+    onRouteUpdate(to: Route, from: Route) {
+        this.$i18n.locale = to.params.lang ?? 'en';
+        document.title = this.$t(to.meta?.title).toString();
+    }
+}
 </script>
 
 <style lang="scss">

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -87,7 +87,10 @@
                         <tippy delay="200" placement="right">{{ $t('editor.returnToLanding') }}</tippy>
                     </router-link>
                 </span>
-                <span class="m-1 font-semibold text-lg">{{ config.title }}</span>
+                <div class="ml-3 flex flex-col">
+                    <span class="font-semibold text-lg">{{ metadata.title }}</span>
+                    <span :class="metadata.title ? 'text-xs' : ''">UUID: {{ uuid }}</span>
+                </div>
                 <span class="ml-auto"></span>
                 <transition name="fade">
                     <span v-if="unsavedChanges" class="border-2 border-red-700 text-red-700 rounded p-1 mr-2">

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -3,6 +3,7 @@ chapters.title,Chapters,1,Chapitres,1
 chapters.return,Return to top,1,Retournez en haut,1
 chapters.menu,Toggle menu,1,Menu bascule,0
 scrollguard.desc,Use ctrl + scroll to zoom the map,1,Utilisez les touches Ctrl et + pour faire un zoom de la carte,1
+story.window.title,RAMP Storylines,1,RAMP Storylines,0
 story.date,Date modified:,1,Date de modification:,1
 story.error,An error occurred while loading this Storylines product. See developer console for more information.,1,Une erreur est survenue pendant le chargement ce synopsis produit. Voir la console du promoteur pour obtenir de plus amples renseignements.,1
 image.fullscreen,Full Screen,1,Plein Écran,1
@@ -12,6 +13,7 @@ timeslider.play,Play,1,Lire,0
 timeslider.pause,Pause,1,Pause,0
 fullscreen.activate,Enter Fullscreen,1,Entrer en plein écran,0
 fullscreen.deactivate,Exit Fullscreen,1,Sortie plein écran,0
+editor.window.title,RAMP Storylines Editor,1,RAMP Storylines Editor,0
 editor.createProduct,Create New Storylines Product,1,Créer un nouveau produit Storylines,0
 editor.editProduct,Edit Existing Storylines Product,1,Modifier le produit Storylines existant,0
 editor.editMetadata,Edit Project Metadata,1,Modifier les Métadonnées du Projet,0

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -10,41 +10,49 @@ Vue.use(Router);
 const routes = [
     {
         path: '/',
-        component: StoryV
+        component: StoryV,
+        meta: { title: 'story.window.title' }
     },
     {
         path: '/:lang/editor',
         name: 'home',
-        component: LandingV
+        component: LandingV,
+        meta: { title: 'editor.window.title' }
     },
     {
         path: '/:lang/editor-metadata',
         name: 'metadata',
         component: EditorV,
-        props: true
+        props: true,
+        meta: { title: 'editor.window.title' }
     },
     {
         path: '/:lang/editor/:uid',
         name: 'editor',
-        component: EditorV
+        component: EditorV,
+        meta: { title: 'editor.window.title' }
     },
     {
         path: '/:lang/editor-preview',
         component: StoryPreviewV,
         name: 'preview',
-        props: true
+        props: true,
+        meta: { title: 'story.window.title' }
     },
     {
         path: '/:lang/editor-preview/:uid',
-        component: StoryPreviewV
+        component: StoryPreviewV,
+        meta: { title: 'story.window.title' }
     },
     {
         path: '/:uid',
-        component: StoryV
+        component: StoryV,
+        meta: { title: 'story.window.title' }
     },
     {
         path: '/:lang/:uid',
-        component: StoryV
+        component: StoryV,
+        meta: { title: 'story.window.title' }
     }
 ];
 


### PR DESCRIPTION
Closes #130.
Closes #125.

The UUID should now be visible in the editor and the tab title should now be "RAMP Storylines Editor" for all the editor routes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/141)
<!-- Reviewable:end -->
