### PR TITLE
Fix Vue routing to separate slide editor from metadata editor

### DIFF
--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -152,16 +152,16 @@ export default class DynamicEditorV extends Vue {
     newSlideName = '';
     newSlideType = 'text';
 
-    get idUsed() {
+    get idUsed(): any {
         return this.panel.children.some((ch: any) => ch.id === this.newSlideName);
     }
 
-    changePanel(target: string) {
+    changePanel(target: string): void {
         this.saveChanges();
         this.editingStatus = target;
     }
 
-    switchSlide(idx: number) {
+    switchSlide(idx: number): void {
         // Save slide changes if neccessary and switch to the newly selected slide.
         this.saveChanges();
         this.editingSlide = idx;
@@ -175,7 +175,7 @@ export default class DynamicEditorV extends Vue {
         }
     }
 
-    removeSlide(item: any) {
+    removeSlide(item: any): void {
         const panel = this.panel.children.find((panel: any, idx: number) => idx === item).panel;
 
         // Update source counts based on which panel is removed.
@@ -215,7 +215,7 @@ export default class DynamicEditorV extends Vue {
         }
     }
 
-    createNewSlide() {
+    createNewSlide(): void {
         if (!this.newSlideName) return;
 
         const newConfig = {
@@ -227,7 +227,7 @@ export default class DynamicEditorV extends Vue {
         this.panel.children.push(newConfig);
     }
 
-    saveChanges() {
+    saveChanges(): void {
         if (this.$refs.slide !== undefined && typeof (this.$refs.slide as any).saveChanges === 'function') {
             (this.$refs.slide as any).saveChanges();
         }

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -1,276 +1,168 @@
 <template>
     <!-- If the configuration file is being fetched, display a spinner to indicate loading. -->
     <div class="editor-container">
-        <template v-if="loadStatus === 'waiting' || loadStatus === 'loading'">
-            <div class="px-20 py-5">
-                <div class="flex">
-                    <div class="flex text-2xl font-bold mb-5">
-                        {{ editExisting ? $t('editor.editProduct') : $t('editor.createProduct') }}
-                    </div>
-                    <button @click="swapLang">
-                        {{ lang === 'en' ? $t('editor.frenchConfig') : $t('editor.englishConfig') }}
-                    </button>
-                </div>
-
-                <div class="border py-5 w-5/6">
-                    <label>{{ $t('editor.uuid') }}:</label>
-                    <input
-                        type="text"
-                        @input="error = false"
-                        v-model="uuid"
-                        class="w-1/3"
-                        :class="error ? 'input-error' : ''"
-                    />
-                    <button
-                        @click="generateRemoteConfig"
-                        class="bg-black text-white hover:bg-gray-800"
-                        :class="error ? 'input-error' : ''"
-                        v-if="editExisting"
-                    >
-                        {{ $t('editor.load') }}
-                    </button>
-
-                    <!-- If config is loading, display a small spinner. -->
-                    <div class="inline-flex" v-if="loadStatus === 'loading'">
-                        <spinner
-                            size="20px"
-                            background="#00D2D3"
-                            color="#009cd1"
-                            stroke="2px"
-                            class="mx-2 my-auto"
-                        ></spinner>
-                    </div>
-                </div>
-
-                <br />
-
-                <div class="mb-4">
-                    <h3>Storylines product details</h3>
-                    <p>
-                        Fill in metadata details about your new Storyline. Use the “Preview” button to see what your
-                        slides will look like.
-                    </p>
-                </div>
-
-                <metadata-editor
-                    :metadata="metadata"
-                    @metadata-changed="updateMetadata"
-                    @logo-changed="onFileChange"
-                    @logo-source-changed="onLogoSourceInput"
-                ></metadata-editor>
+        <div class="sticky top-0 z-50 flex items-center border-b border-black bg-gray-200 py-2 px-2">
+            <span class="mx-1">
+                <router-link :to="{ name: 'home' }" class="mt-1 flex justify-center h-full w-full" target>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18.001" viewBox="0 0 18 18.001">
+                        <path
+                            id="logout-Icon-SVG-098767893"
+                            d="M5.808,13.782v1.406A2.816,2.816,0,0,0,8.621,18h7.067A2.816,2.816,0,0,0,18.5,15.188V2.813A2.816,2.816,0,0,0,15.687,0H8.621A2.816,2.816,0,0,0,5.808,2.813V4.219a.7.7,0,0,0,1.406,0V2.813A1.408,1.408,0,0,1,8.621,1.406h7.067a1.408,1.408,0,0,1,1.406,1.406V15.188a1.408,1.408,0,0,1-1.406,1.406H8.621a1.408,1.408,0,0,1-1.406-1.406V13.782a.7.7,0,0,0-1.406,0ZM1.014,7.793,2.589,6.218a.7.7,0,0,1,.994.994l-1.12,1.12h8.443a.7.7,0,1,1,0,1.406H2.463l1.12,1.12a.7.7,0,1,1-.994.994L1.014,10.279A1.76,1.76,0,0,1,1.014,7.793Zm0,0"
+                            transform="translate(-0.5)"
+                        />
+                    </svg>
+                    <tippy delay="200" placement="right">{{ $t('editor.returnToLanding') }}</tippy>
+                </router-link>
+            </span>
+            <div class="ml-3 flex flex-col">
+                <span class="font-semibold text-lg">{{ metadata.title }}</span>
+                <span :class="metadata.title ? 'text-xs' : ''">UUID: {{ uuid }}</span>
             </div>
-
-            <div class="flex mt-8">
-                <button @click="saveMetadata" class="pl-8">{{ $t('editor.saveChanges') }}</button>
-                <div class="ml-auto">
-                    <router-link :to="{ name: 'home' }" target>
-                        <button>{{ $t('editor.back') }}</button>
-                    </router-link>
-                    <button @click="continueToEditor" class="bg-black text-white px-8">
-                        {{ $t('editor.next') }}
-                    </button>
-                </div>
-            </div>
-        </template>
-
-        <template v-if="loadStatus === 'loaded'">
-            <div class="sticky top-0 z-50 flex items-center border-b border-black bg-gray-200 py-2 px-2">
-                <span class="mx-1">
-                    <router-link :to="{ name: 'home' }" class="mt-1 flex justify-center h-full w-full" target>
-                        <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18.001" viewBox="0 0 18 18.001">
+            <span class="ml-auto"></span>
+            <transition name="fade">
+                <span v-if="unsavedChanges" class="border-2 border-red-700 text-red-700 rounded p-1 mr-2">
+                    <span class="align-middle inline-block mr-1 pb-1 fill-current"
+                        ><svg
+                            clip-rule="evenodd"
+                            fill-rule="evenodd"
+                            class="fill-red-600"
+                            width="18"
+                            height="18"
+                            stroke-linejoin="round"
+                            stroke-miterlimit="2"
+                            viewBox="0 0 24 24"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
                             <path
-                                id="logout-Icon-SVG-098767893"
-                                d="M5.808,13.782v1.406A2.816,2.816,0,0,0,8.621,18h7.067A2.816,2.816,0,0,0,18.5,15.188V2.813A2.816,2.816,0,0,0,15.687,0H8.621A2.816,2.816,0,0,0,5.808,2.813V4.219a.7.7,0,0,0,1.406,0V2.813A1.408,1.408,0,0,1,8.621,1.406h7.067a1.408,1.408,0,0,1,1.406,1.406V15.188a1.408,1.408,0,0,1-1.406,1.406H8.621a1.408,1.408,0,0,1-1.406-1.406V13.782a.7.7,0,0,0-1.406,0ZM1.014,7.793,2.589,6.218a.7.7,0,0,1,.994.994l-1.12,1.12h8.443a.7.7,0,1,1,0,1.406H2.463l1.12,1.12a.7.7,0,1,1-.994.994L1.014,10.279A1.76,1.76,0,0,1,1.014,7.793Zm0,0"
-                                transform="translate(-0.5)"
+                                d="m12.002 21.534c5.518 0 9.998-4.48 9.998-9.998s-4.48-9.997-9.998-9.997c-5.517 0-9.997 4.479-9.997 9.997s4.48 9.998 9.997 9.998zm0-1.5c-4.69 0-8.497-3.808-8.497-8.498s3.807-8.497 8.497-8.497 8.498 3.807 8.498 8.497-3.808 8.498-8.498 8.498zm0-6.5c-.414 0-.75-.336-.75-.75v-5.5c0-.414.336-.75.75-.75s.75.336.75.75v5.5c0 .414-.336.75-.75.75zm-.002 3c.552 0 1-.448 1-1s-.448-1-1-1-1 .448-1 1 .448 1 1 1z"
+                                fill-rule="nonzero"
                             />
                         </svg>
-                        <tippy delay="200" placement="right">{{ $t('editor.returnToLanding') }}</tippy>
-                    </router-link>
+                    </span>
+                    <span class="align-center inline-block select-none">Unsaved Changes</span>
                 </span>
-                <div class="ml-3 flex flex-col">
-                    <span class="font-semibold text-lg">{{ metadata.title }}</span>
-                    <span :class="metadata.title ? 'text-xs' : ''">UUID: {{ uuid }}</span>
-                </div>
-                <span class="ml-auto"></span>
-                <transition name="fade">
-                    <span v-if="unsavedChanges" class="border-2 border-red-700 text-red-700 rounded p-1 mr-2">
-                        <span class="align-middle inline-block mr-1 pb-1 fill-current"
+            </transition>
+            <slot name="langModal" v-bind="{ unsavedChanges: unsavedChanges }"></slot>
+            <router-link
+                :to="{
+                    name: 'preview',
+                    params: {
+                        conf: configs[configLang],
+                        configFileStructure: configFileStructure,
+                        metadata: metadata,
+                        sourceCounts: sourceCounts
+                    }
+                }"
+            >
+                <button @click="preview" class="bg-white border border-black hover:bg-gray-100">
+                    {{ $t('editor.preview') }}
+                </button>
+            </router-link>
+            <button @click="generateConfig" class="bg-black text-white hover:bg-gray-900" :disabled="saving">
+                <span class="inline-block">{{ saving ? $t('editor.savingChanges') : $t('editor.saveChanges') }}</span>
+                <span v-if="saving" class="align-middle inline-block px-1"
+                    ><spinner size="16px" background="#6B7280" color="#FFFFFF" stroke="2px" class="ml-1 mb-1"></spinner>
+                </span>
+            </button>
+            <router-link
+                :to="{
+                    path: `/${$route.params.lang}/editor-preview/${uuid}`
+                }"
+                target="_blank"
+            >
+                <button class="bg-white border border-black hover:bg-gray-100">View Saved Product</button>
+            </router-link>
+        </div>
+        <div class="flex">
+            <div class="w-80 flex-shrink-0 border-r border-black editor-toc">
+                <div class="flex items-center justify-center border-b p-2">
+                    <button @click.stop="$modals.show('metadata-edit-modal')">
+                        <span class="align-middle inline-block px-1"
                             ><svg
                                 clip-rule="evenodd"
                                 fill-rule="evenodd"
-                                class="fill-red-600"
-                                width="18"
-                                height="18"
+                                width="16"
+                                height="16"
                                 stroke-linejoin="round"
                                 stroke-miterlimit="2"
                                 viewBox="0 0 24 24"
                                 xmlns="http://www.w3.org/2000/svg"
                             >
                                 <path
-                                    d="m12.002 21.534c5.518 0 9.998-4.48 9.998-9.998s-4.48-9.997-9.998-9.997c-5.517 0-9.997 4.479-9.997 9.997s4.48 9.998 9.997 9.998zm0-1.5c-4.69 0-8.497-3.808-8.497-8.498s3.807-8.497 8.497-8.497 8.498 3.807 8.498 8.497-3.808 8.498-8.498 8.498zm0-6.5c-.414 0-.75-.336-.75-.75v-5.5c0-.414.336-.75.75-.75s.75.336.75.75v5.5c0 .414-.336.75-.75.75zm-.002 3c.552 0 1-.448 1-1s-.448-1-1-1-1 .448-1 1 .448 1 1 1z"
+                                    d="m4.481 15.659c-1.334 3.916-1.48 4.232-1.48 4.587 0 .528.46.749.749.749.352 0 .668-.137 4.574-1.492zm1.06-1.061 3.846 3.846 11.321-11.311c.195-.195.293-.45.293-.707 0-.255-.098-.51-.293-.706-.692-.691-1.742-1.74-2.435-2.432-.195-.195-.451-.293-.707-.293-.254 0-.51.098-.706.293z"
                                     fill-rule="nonzero"
                                 />
                             </svg>
                         </span>
-                        <span class="align-center inline-block select-none">Unsaved Changes</span>
-                    </span>
-                </transition>
-                <button @click.stop="unsavedChanges ? $modals.show(`change-lang`) : swapLang()">
-                    {{ lang === 'en' ? $t('editor.frenchConfig') : $t('editor.englishConfig') }}
-                </button>
-                <confirmation-modal :name="`change-lang`" :message="$t('editor.changeLang.modal')" @Ok="swapLang()" />
-                <router-link
-                    :to="{
-                        name: 'preview',
-                        params: { conf: configs[lang], configFileStructure: configFileStructure }
-                    }"
-                >
-                    <button @click="preview" class="bg-white border border-black hover:bg-gray-100">
-                        {{ $t('editor.preview') }}
+                        <span class="align-middle inline-block">Edit Project Metadata</span>
                     </button>
-                </router-link>
-                <button @click="generateConfig" class="bg-black text-white hover:bg-gray-900" :disabled="saving">
-                    <span class="inline-block">{{
-                        saving ? $t('editor.savingChanges') : $t('editor.saveChanges')
-                    }}</span>
-                    <span v-if="saving" class="align-middle inline-block px-1"
-                        ><spinner
-                            size="16px"
-                            background="#6B7280"
-                            color="#FFFFFF"
-                            stroke="2px"
-                            class="ml-1 mb-1"
-                        ></spinner>
-                    </span>
-                </button>
-                <router-link
-                    :to="{
-                        path: `editor-preview/${uuid}`
-                    }"
-                    target="_blank"
-                >
-                    <button class="bg-white border border-black hover:bg-gray-100">View Saved Product</button>
-                </router-link>
-            </div>
-            <div class="flex">
-                <div class="w-80 flex-shrink-0 border-r border-black editor-toc">
-                    <div class="flex items-center justify-center border-b p-2">
-                        <button @click.stop="$modals.show('metadata-edit-modal')">
-                            <span class="align-middle inline-block px-1"
-                                ><svg
-                                    clip-rule="evenodd"
-                                    fill-rule="evenodd"
-                                    width="16"
-                                    height="16"
-                                    stroke-linejoin="round"
-                                    stroke-miterlimit="2"
-                                    viewBox="0 0 24 24"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                >
-                                    <path
-                                        d="m4.481 15.659c-1.334 3.916-1.48 4.232-1.48 4.587 0 .528.46.749.749.749.352 0 .668-.137 4.574-1.492zm1.06-1.061 3.846 3.846 11.321-11.311c.195-.195.293-.45.293-.707 0-.255-.098-.51-.293-.706-.692-.691-1.742-1.74-2.435-2.432-.195-.195-.451-.293-.707-.293-.254 0-.51.098-.706.293z"
-                                        fill-rule="nonzero"
-                                    />
-                                </svg>
-                            </span>
-                            <span class="align-middle inline-block">Edit Project Metadata</span>
-                        </button>
-                    </div>
-                    <slide-toc
-                        :slides="slides"
-                        :currentSlide="currentSlide"
-                        :slideIndex="slideIndex"
-                        @slide-change="selectSlide"
-                        @slides-updated="updateSlides"
-                        :configFileStructure="configFileStructure"
-                        :lang="lang"
-                        :sourceCounts="sourceCounts"
-                    ></slide-toc>
                 </div>
-                <slide-editor
-                    ref="slide"
-                    :configFileStructure="configFileStructure"
+                <slide-toc
+                    :slides="slides"
                     :currentSlide="currentSlide"
-                    :lang="lang"
                     :slideIndex="slideIndex"
-                    :isLast="slideIndex === slides.length - 1"
-                    :uid="uuid"
                     @slide-change="selectSlide"
-                    @slide-edit="onSlidesEdited"
+                    @slides-updated="updateSlides"
+                    :configFileStructure="configFileStructure"
+                    :lang="configLang"
                     :sourceCounts="sourceCounts"
-                ></slide-editor>
+                ></slide-toc>
             </div>
-        </template>
-        <vue-modal name="metadata-edit-modal" :outer-close="false" :hide-close-btn="true" size="xlg">
-            <h2 slot="header" class="text-lg font-bold">Edit Project Metadata</h2>
-            <metadata-editor
-                :metadata="metadata"
-                @metadata-changed="updateMetadata"
-                @logo-changed="onFileChange"
-                @logo-source-changed="onLogoSourceInput"
-            ></metadata-editor>
-            <div class="w-full flex justify-end">
-                <button class="bg-black text-white hover:bg-gray-800" @click="saveMetadata">Done</button>
-            </div>
-        </vue-modal>
+            <slide-editor
+                ref="slide"
+                :configFileStructure="configFileStructure"
+                :currentSlide="currentSlide"
+                :lang="configLang"
+                :slideIndex="slideIndex"
+                :isLast="slideIndex === slides.length - 1"
+                :uid="uuid"
+                @slide-change="selectSlide"
+                @slide-edit="onSlidesEdited"
+                :sourceCounts="sourceCounts"
+            ></slide-editor>
+        </div>
+        <slot name="metadataModal"></slot>
     </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue, Prop, Watch } from 'vue-property-decorator';
-import { Route } from 'vue-router';
 import { StoryRampConfig, Slide } from '@/definitions';
 
-const JSZip = require('jszip');
 const axios = require('axios').default;
-const { v4: uuidv4 } = require('uuid');
 
 import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
 import SlideEditorV from './slide-editor.vue';
 import SlideTocV from './slide-toc.vue';
-import MetadataEditorV from './metadata-editor.vue';
-import ConfirmationModalV from './helpers/confirmation-modal.vue';
+import MetadataContentV from './helpers/metadata-content.vue';
 
 @Component({
     components: {
-        'confirmation-modal': ConfirmationModalV,
-        'metadata-editor': MetadataEditorV,
+        'metadata-content': MetadataContentV,
         spinner: Circle2,
         'slide-editor': SlideEditorV,
         'slide-toc': SlideTocV
     }
 })
 export default class EditorV extends Vue {
-    @Prop({ default: true }) editExisting!: boolean; // true if editing existing storylines product, false if new product
-
-    configs: {
+    @Prop() configs!: {
         [key: string]: StoryRampConfig | undefined;
-    } = { en: undefined, fr: undefined };
-    configFileStructure: any = undefined;
-    loadStatus = 'waiting';
-    error = false; // whether an error has occurred
-    lang = 'en';
+    };
+    @Prop() configFileStructure!: any;
+    @Prop() sourceCounts!: any;
+    @Prop() metadata!: any;
+    @Prop() slides!: Slide[];
+    @Prop() configLang!: string;
+
     unsavedChanges = false;
     saving = false;
 
     // Form properties.
     uuid = '';
     logoImage: undefined | File = undefined;
-    slides: Slide[] = [];
     currentSlide: any = '';
     slideIndex = -1;
     $modals: any;
-    metadata = {
-        title: '',
-        introTitle: '',
-        introSubtitle: '',
-        logoPreview: '',
-        logoName: '',
-        contextLink: '',
-        contextLabel: '',
-        dateModified: ''
-    };
-    sourceCounts: any = {};
 
     @Watch('slides', { deep: true })
     onSlidesEdited(): void {
@@ -284,276 +176,11 @@ export default class EditorV extends Vue {
 
     created(): void {
         window.addEventListener('beforeunload', this.beforeWindowUnload);
-
-        // Generate UUID for new product
-        this.uuid = this.$route.params.uid ?? (this.editExisting ? undefined : uuidv4());
-        this.lang = this.$route.params.lang ? this.$route.params.lang : 'en';
-
-        // Initialize Storylines config and the configuration structure.
-        this.configs = { en: undefined, fr: undefined };
-        this.configFileStructure = undefined;
-
-        // If a product UUID is provided, fetch the contents from the server.
-        if (this.$route.params.uid) {
-            this.generateRemoteConfig();
-        }
+        this.uuid = this.$route.params.uid;
     }
 
     beforeDestroy(): void {
         window.removeEventListener('beforeunload', this.beforeWindowUnload);
-    }
-
-    /**
-     * Generates a new product file for brand new products.
-     */
-    generateNewConfig(): void {
-        const configZip = new JSZip();
-
-        // Generate a new configuration file and populate required fields.
-        this.configs[this.lang] = this.configHelper();
-        this.configs[this.lang]!.title = this.metadata.title;
-        this.configs[this.lang]!.introSlide.title = this.metadata.introTitle;
-        this.configs[this.lang]!.introSlide.subtitle = this.metadata.introSubtitle;
-        this.configs[this.lang]!.slides = this.slides;
-
-        // Set the source of the product logo
-        if (!this.metadata.logoName) {
-            this.configs[this.lang]!.introSlide.logo.src = '';
-        } else if (!this.metadata.logoName.includes('http')) {
-            this.configs[this.lang]!.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
-        } else {
-            this.configs[this.lang]!.introSlide.logo.src = this.metadata.logoName;
-        }
-
-        const otherLang = this.lang === 'en' ? 'fr' : 'en';
-
-        this.configs[otherLang] = this.configs[this.lang];
-        this.configs[otherLang]!.lang = otherLang;
-
-        // Add the newly generated Storylines configuration file to the ZIP file.
-        const fileName = `${this.uuid}_${this.lang}.json`;
-        const formattedConfigFile = JSON.stringify(this.configs[this.lang], null, 4);
-        const formattedOtherLangConfig = JSON.stringify(this.configs[otherLang], null, 4);
-
-        configZip.file(fileName, formattedConfigFile);
-        configZip.file(`${this.uuid}_${otherLang}.json`, formattedOtherLangConfig);
-
-        // Generate the file structure, defer uploading the image until the structure is created.
-        this.configFileStructureHelper(configZip, this.logoImage);
-
-        this.unsavedChanges = false;
-    }
-
-    configHelper(): StoryRampConfig {
-        // TODO: require user to input these fields instead of defaulting (speeds up testing purposes for now)
-        return {
-            title: 'Test Config',
-            lang: 'en',
-            introSlide: {
-                logo: {
-                    src: ''
-                },
-                title: '',
-                subtitle: ''
-            },
-            slides: [],
-            contextLabel: this.metadata.contextLabel,
-            contextLink: this.metadata.contextLink,
-            dateModified: this.metadata.dateModified
-        };
-    }
-
-    /**
-     * Provided with a UID, retrieve the project contents from the file server.
-     */
-    generateRemoteConfig(): void {
-        this.loadStatus = 'loading';
-
-        // Attempt to fetch the project from the server.
-        fetch(`http://localhost:6040/retrieve/${this.uuid}`).then((res: any) => {
-            if (res.status === 404) {
-                // Product not found.
-                this.$message.error(`The requested UUID ${this.uuid ?? ''} does not exist.`);
-                this.error = true;
-                this.loadStatus = 'waiting';
-            } else {
-                const configZip = new JSZip();
-                // Files retrieved. Convert them into a JSZip object.
-                res.blob().then((file: any) => {
-                    configZip.loadAsync(file).then(() => {
-                        this.configFileStructureHelper(configZip);
-                        this.$message.success('Successfully loaded storyline!');
-                    });
-                });
-            }
-        });
-    }
-
-    findSources(configs: { [key: string]: StoryRampConfig | undefined }): void {
-        ['en', 'fr'].forEach((lang) => {
-            this.incrementSourceCount(configs[lang]!.introSlide.logo.src);
-            configs[lang]!.slides.forEach((slide) => {
-                slide.panel.forEach((panel) => {
-                    this.panelSourceHelper(panel);
-                });
-            });
-        });
-    }
-
-    panelSourceHelper(panel: any): void {
-        switch (panel.type) {
-            case 'dynamic':
-                panel.children.forEach((subPanel: any) => {
-                    this.panelSourceHelper(subPanel.panel);
-                });
-                break;
-            case 'slideshow':
-                panel.images.forEach((image: any) => {
-                    this.incrementSourceCount(image.src);
-                });
-                break;
-            case 'chart':
-                panel.charts.forEach((chart: any) => {
-                    this.incrementSourceCount(chart.src);
-                });
-                break;
-            case 'image':
-            case 'video':
-            case 'audio':
-                this.incrementSourceCount(panel.src);
-                break;
-            case 'map':
-                this.incrementSourceCount(panel.config);
-                break;
-            default:
-                break;
-        }
-    }
-
-    incrementSourceCount(src: string): void {
-        if (this.sourceCounts[src]) {
-            this.sourceCounts[src] += 1;
-        } else {
-            this.sourceCounts[src] = 1;
-        }
-    }
-
-    /**
-     * Generates or loads a ZIP file and creates required project folders if needed.
-     * Returns an object that makes it easy to access any specific folder.
-     */
-    configFileStructureHelper(configZip: any, uploadLogo?: File | undefined): void {
-        const assetsFolder = configZip.folder('assets');
-        const chartsFolder = configZip.folder('charts');
-        const rampConfigFolder = configZip.folder('ramp-config');
-
-        this.configFileStructure = {
-            uuid: this.uuid,
-            zip: configZip,
-            configs: this.configs,
-            assets: {
-                en: assetsFolder.folder('en'),
-                fr: assetsFolder.folder('fr')
-            },
-            charts: {
-                en: chartsFolder.folder('en'),
-                fr: chartsFolder.folder('fr')
-            },
-            rampConfig: {
-                en: rampConfigFolder.folder('en'),
-                fr: rampConfigFolder.folder('fr')
-            }
-        };
-
-        // If uploadLogo is set, upload the logo to the directory.
-        if (uploadLogo !== undefined) {
-            this.configFileStructure.assets[this.lang].file(uploadLogo?.name, uploadLogo);
-        }
-
-        this.loadConfig();
-    }
-
-    /**
-     * Loads a configuration file from the product folder, and sets application data
-     * as needed.
-     */
-    async loadConfig(config?: StoryRampConfig): Promise<void> {
-        const configPath = `${this.uuid}_${this.lang}.json`;
-
-        if (config) {
-            this.useConfig(config);
-            return;
-        }
-
-        await this.configFileStructure.zip
-            .file(`${this.uuid}_en.json`)
-            .async('string')
-            .then((res: any) => {
-                this.configs['en'] = JSON.parse(res);
-            });
-        await this.configFileStructure.zip
-            .file(`${this.uuid}_fr.json`)
-            .async('string')
-            .then((res: any) => {
-                this.configs['fr'] = JSON.parse(res);
-            });
-
-        this.editExisting ? (this.loadStatus = 'waiting') : (this.loadStatus = 'loaded');
-
-        // Load in project data.
-        if (this.configs[this.lang]) {
-            this.useConfig(this.configs[this.lang]!);
-
-            this.findSources(this.configs);
-        }
-    }
-
-    useConfig(config: StoryRampConfig) {
-        this.metadata.title = config.title;
-        this.metadata.introTitle = config.introSlide.title;
-        this.metadata.introSubtitle = config.introSlide.subtitle;
-        this.metadata.contextLink = config.contextLink;
-        this.metadata.contextLabel = config.contextLabel;
-        this.metadata.dateModified = config.dateModified;
-        const logo = config.introSlide.logo.src;
-
-        // Fetch the logo from the folder (if it exists).
-        const logoSrc = `${logo.substring(logo.indexOf('/') + 1)}`;
-        const logoName = `${logo.split('/')[logo.split('/').length - 1]}`;
-
-        if (this.configFileStructure.zip.file(logoSrc)) {
-            this.configFileStructure.zip
-                .file(logoSrc)
-                .async('blob')
-                .then((img: any) => {
-                    this.logoImage = new File([img], logoName);
-                    this.metadata.logoPreview = URL.createObjectURL(img);
-                    this.metadata.logoName = logoName;
-                });
-        } else {
-            // If it doesn't exist, maybe it's a remote file?
-            fetch(logo).then((data: any) => {
-                if (data.status !== 404) {
-                    this.logoImage = new File([data], logoName);
-                    this.metadata.logoPreview = logo;
-                }
-            });
-
-            // Fill in the field with this value whether it exists or not.
-            this.metadata.logoName = logo;
-        }
-
-        this.slides = config.slides;
-        // conversion for individual image panels to slideshow for gallery display
-        this.slides.forEach((slide: Slide) => {
-            if (slide.panel.length === 2 && slide.panel[1].type === 'image') {
-                const newSlide = {
-                    type: 'slideshow',
-                    images: [slide.panel[1]]
-                };
-                Vue.set(slide.panel, 1, newSlide);
-            }
-        });
     }
 
     /**
@@ -568,8 +195,8 @@ export default class EditorV extends Vue {
         }
 
         // Update the configuration file.
-        const fileName = `${this.uuid}_${this.lang}.json`;
-        const formattedConfigFile = JSON.stringify(this.configs[this.lang], null, 4);
+        const fileName = `${this.uuid}_${this.configLang}.json`;
+        const formattedConfigFile = JSON.stringify(this.configs[this.configLang], null, 4);
 
         this.configFileStructure.zip.file(fileName, formattedConfigFile);
 
@@ -601,44 +228,6 @@ export default class EditorV extends Vue {
         return this.configFileStructure;
     }
 
-    updateMetadata(
-        key: 'title' | 'introTitle' | 'introSubtitle' | 'contextLink' | 'contextLabel' | 'dateModified',
-        value: string
-    ): void {
-        this.metadata[key] = value;
-    }
-
-    /**
-     * Called when `Save Changes` is pressed on metadata page. Save metadata content fields
-     * to config file. TODO: decide whether to upload file to server (e.g. call generateConfig).
-     */
-    saveMetadata(): void {
-        // update metadata content to existing config only if it has been successfully loaded
-        if (this.configs[this.lang] !== undefined) {
-            this.configs[this.lang]!.title = this.metadata.title;
-            this.configs[this.lang]!.introSlide.title = this.metadata.introTitle;
-            this.configs[this.lang]!.introSlide.subtitle = this.metadata.introSubtitle;
-            this.configs[this.lang]!.contextLink = this.metadata.contextLink;
-            this.configs[this.lang]!.contextLabel = this.metadata.contextLabel;
-            this.configs[this.lang]!.dateModified = this.metadata.dateModified;
-
-            // If the logo doesn't include HTTP, assume it's a local file.
-            if (!this.metadata.logoName) {
-                this.configs[this.lang]!.introSlide.logo.src = '';
-            } else if (!this.metadata.logoName.includes('http')) {
-                this.configs[
-                    this.lang
-                ]!.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
-                this.configFileStructure.assets[this.lang].file(this.logoImage?.name, this.logoImage);
-            } else {
-                this.configs[this.lang]!.introSlide.logo.src = this.metadata.logoName;
-            }
-        }
-        if (this.$modals.isActive('metadata-edit-modal')) {
-            this.$modals.hide('metadata-edit-modal');
-        }
-    }
-
     /**
      * Change current slide to selected slide.
      */
@@ -654,7 +243,7 @@ export default class EditorV extends Vue {
         };
 
         setTimeout(() => {
-            this.currentSlide = index === -1 ? '' : this.slides[index];
+            this.currentSlide = index === -1 ? '' : (this.slides as Slide[])[index];
             this.slideIndex = index;
             (this.$refs.slide as any).panelIndex = 0;
             window.scrollTo(0, 0);
@@ -670,30 +259,6 @@ export default class EditorV extends Vue {
     }
 
     /**
-     * Called when 'next' button is pressed on metadata page to continue to main editor.
-     */
-    continueToEditor(): void {
-        if (this.editExisting) {
-            this.configs[this.lang] !== undefined
-                ? (this.loadStatus = 'loaded')
-                : this.$message.error('No config exists for storylines product.');
-            this.unsavedChanges = false;
-        } else {
-            // TODO: check for non-empty required metadata fields
-            this.generateNewConfig();
-        }
-    }
-
-    /**
-     * Language toggle.
-     */
-    swapLang(): void {
-        this.lang = this.lang === 'en' ? 'fr' : 'en';
-        this.loadConfig();
-        this.selectSlide(-1);
-    }
-
-    /**
      * Open current editor config as a new Storylines product in new tab.
      */
     preview(): void {
@@ -701,53 +266,6 @@ export default class EditorV extends Vue {
         if (this.$refs.slide !== undefined) {
             (this.$refs.slide as any).saveChanges();
         }
-    }
-
-    /**
-     * React to param changes in URL.
-     */
-    beforeRouteUpdate(to: Route, from: Route, next: () => void): void {
-        this.lang = to.params.lang;
-        this.uuid = to.params.uid;
-        this.$i18n.locale = this.lang;
-
-        if (this.uuid) {
-            this.generateRemoteConfig();
-        }
-        next();
-    }
-
-    onLogoSourceInput(e: InputEvent) {
-        const isImgUrl = (url: string) => {
-            const img = new Image();
-            img.src = url;
-            return new Promise((resolve) => {
-                img.onerror = () => resolve(false);
-                img.onload = () => resolve(true);
-            });
-        };
-
-        this.metadata.logoName = (e.target as HTMLInputElement).value;
-
-        isImgUrl(this.metadata.logoName).then((res) => {
-            if (res) {
-                this.metadata.logoPreview = this.metadata.logoName;
-                this.$message.success('Successfully loaded logo image.');
-            } else {
-                this.metadata.logoPreview = 'error';
-                this.$message.error('Failed to load logo image.');
-            }
-        });
-    }
-
-    onFileChange(e: Event): void {
-        // Retrieve the uploaded file.
-        const uploadedFile = ((e.target as HTMLInputElement).files as any)[0];
-        this.logoImage = uploadedFile;
-
-        // Generate an image preview.
-        this.metadata.logoPreview = URL.createObjectURL(uploadedFile);
-        this.metadata.logoName = uploadedFile.name;
     }
 
     beforeWindowUnload(e: any): void {
@@ -760,93 +278,66 @@ export default class EditorV extends Vue {
 }
 </script>
 
-<style lang="scss">
-$font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+<style lang="scss" scoped>
+.editor-container {
+    margin: 0 auto;
+}
 
-.storyramp-app {
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    .h1,
-    .h2,
-    .h3,
-    .h4,
-    .h5,
-    .h6 {
-        font-family: $font-list;
-        line-height: 1.5;
-        border-bottom: 0px;
-    }
+.editor-container label {
+    width: 10vw;
+    text-align: right;
+    margin-right: 15px;
+    display: inline-block;
+}
 
-    .editor-container {
-        margin: 0 auto;
-    }
+.editor-container h3 {
+    font-size: larger;
+}
 
-    .editor-container label {
-        width: 10vw;
-        text-align: right;
-        margin-right: 15px;
-        display: inline-block;
-    }
+.editor-container input {
+    padding: 5px 10px;
+    margin-top: 5px;
+    border: 1px solid black;
+    display: inline;
+}
 
-    .editor-container h3 {
-        font-size: larger;
-    }
+.editor-container .input-error {
+    border: 1px solid red;
+}
 
-    .editor-container input {
-        padding: 5px 10px;
-        margin-top: 5px;
-        border: 1px solid black;
-        display: inline;
-    }
+.editor-container button {
+    padding: 5px 12px;
+    margin: 0px 10px;
+    font-weight: 600;
+    transition-duration: 0.2s;
+}
 
-    .editor-container .input-error {
-        border: 1px solid red;
-    }
+.editor-container button:hover:enabled {
+    background-color: #dbdbdb;
+    color: black;
+}
 
-    .editor-container button {
-        padding: 5px 12px;
-        margin: 0px 10px;
-        font-weight: 600;
-        transition-duration: 0.2s;
-    }
+.editor-container button:disabled {
+    border: 1px solid gray;
+    color: gray;
+    cursor: not-allowed;
+}
 
-    .editor-container button:hover:enabled {
-        background-color: #dbdbdb;
-        color: black;
-    }
+.editor-toc button {
+    background-color: #f3f4f6;
+    color: black;
+    border: none;
+    transition-duration: 0.2s;
+    padding: 0.25 0.25em !important;
+}
 
-    .editor-container button:disabled {
-        border: 1px solid gray;
-        color: gray;
-        cursor: not-allowed;
-    }
+.fade-enter-active,
+.fade-leave-active {
+    transition: opacity 0.2s;
+}
 
-    .editor-toc button {
-        background-color: #f3f4f6;
-        color: black;
-        border: none;
-        transition-duration: 0.2s;
-        padding: 0.25 0.25em !important;
-    }
-
-    .image-preview {
-        max-width: 150px;
-        max-height: 150px;
-        display: inline;
-    }
-
-    .fade-enter-active,
-    .fade-leave-active {
-        transition: opacity 0.2s;
-    }
-
-    .fade-enter,
-    .fade-leave-to {
-        opacity: 0;
-    }
+.fade-enter,
+.fade-leave-to {
+    opacity: 0;
 }
 </style>

--- a/src/components/editor/helpers/metadata-content.vue
+++ b/src/components/editor/helpers/metadata-content.vue
@@ -1,0 +1,101 @@
+<template>
+    <div>
+        <label class="mb-5">{{ $t('editor.title') }}:</label>
+        <input type="text" name="title" :value="metadata.title" @change="metadataChanged" class="w-1/3" />
+        <br />
+        <label class="mb-5">Intro Title:</label>
+        <input type="text" name="introTitle" :value="metadata.introTitle" @change="metadataChanged" class="w-1/4" />
+        <label class="mb-5">Intro Subtitle:</label>
+        <input
+            type="text"
+            name="introSubtitle"
+            :value="metadata.introSubtitle"
+            @change="metadataChanged"
+            class="w-1/4"
+        />
+        <br />
+        <!-- only display an image preview if one is provided.-->
+        <div v-if="!!metadata.logoPreview">
+            <label>{{ $t('editor.logoPreview') }}:</label>
+            <img
+                :src="metadata.logoPreview"
+                v-if="!!metadata.logoPreview && metadata.logoPreview != 'error'"
+                class="image-preview"
+            />
+            <p v-if="metadata.logoPreview == 'error'" class="image-preview">
+                An error occurred when trying to load image.
+            </p>
+        </div>
+        <label class="mb-5">{{ $t('editor.logo') }}:</label>
+        <input type="text" @change="$emit('logo-source-changed', $event)" :value="metadata.logoName" class="w-1/4" />
+        <button @click.stop="openFileSelector" class="bg-black text-white hover:bg-gray-800">
+            {{ $t('editor.browse') }}
+        </button>
+        <button v-if="metadata.logoName || metadata.logoPreview" @click.stop="removeLogo" class="border border-black">
+            Remove
+        </button>
+        <!-- hide the actual file input -->
+        <input
+            type="file"
+            id="logoUpload"
+            @change="$emit('logo-changed', $event)"
+            class="w-1/4"
+            style="display: none"
+        />
+        <br />
+        <label>{{ $t('editor.contextLink') }}:</label>
+        <input type="text" name="contextLink" :value="metadata.contextLink" @change="metadataChanged" class="w-2/3" />
+        <br />
+        <label class="mb-5"></label>
+        <p class="inline-block">
+            <i>
+                Context link shows up at the bottom of the page to provide additional resources for interested users
+            </i>
+        </p>
+        <br />
+        <label>{{ $t('editor.contextLabel') }}:</label>
+        <input type="text" name="contextLabel" :value="metadata.contextLabel" @change="metadataChanged" class="w-2/3" />
+        <br />
+        <label class="mb-5"></label>
+        <p class="inline-block">
+            <i> Context label shows up before the context link to explain what the link is for </i>
+        </p>
+        <br />
+        <label class="mb-5">{{ $t('editor.dateModified') }}:</label>
+        <input type="date" name="dateModified" :value="metadata.dateModified" @change="metadataChanged" />
+        <br /><br />
+    </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from 'vue-property-decorator';
+
+@Component({
+    components: {}
+})
+export default class MetadataEditorV extends Vue {
+    @Prop() metadata!: {
+        title: string;
+        introTitle: string;
+        introSubtitle: string;
+        logoName: string;
+        logoPreview: string;
+        contextLink: string;
+        contextLabel: string;
+        dateModified: string;
+    };
+
+    openFileSelector(): void {
+        document.getElementById('logoUpload')?.click();
+    }
+
+    metadataChanged(event: any): void {
+        this.$emit('metadata-changed', event.target.name, event.target.value);
+    }
+
+    removeLogo(): void {
+        this.metadata.logoName = '';
+        this.metadata.logoPreview = '';
+    }
+}
+</script>

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -200,7 +200,7 @@ export default class ImageEditorV extends Vue {
         this.edited = false;
     }
 
-    onImagesEdited() {
+    onImagesEdited(): void {
         this.edited = true;
         this.$parent.$emit('slide-edit');
     }

--- a/src/components/editor/map-editor.vue
+++ b/src/components/editor/map-editor.vue
@@ -122,7 +122,7 @@ export default class MapEditorV extends Vue {
         this.validateTimeSlider();
     }
 
-    beforeDestroy() {
+    beforeDestroy(): void {
         window.removeEventListener('message', this.saveEditor);
     }
 
@@ -189,7 +189,7 @@ export default class MapEditorV extends Vue {
         }
     }
 
-    saveTimeSlider() {
+    saveTimeSlider(): void {
         if (!this.timeSliderError || !this.usingTimeSlider) {
             this.panel.timeSlider = this.usingTimeSlider ? this.timeSliderConf : undefined;
         }
@@ -213,14 +213,14 @@ export default class MapEditorV extends Vue {
         }
     }
 
-    onTimeSliderInput(property: 'range' | 'start' | 'attribute', index: number, value: string) {
+    onTimeSliderInput(property: 'range' | 'start' | 'attribute', index: number, value: string): void {
         property === 'attribute'
             ? (this.timeSliderConf[property] = value)
             : (this.timeSliderConf[property][index] = Number(value));
         this.validateTimeSlider();
     }
 
-    validateTimeSlider() {
+    validateTimeSlider(): void {
         this.timeSliderError =
             this.timeSliderConf.range.some((val) => val < 0 || !Number.isInteger(val)) ||
             this.timeSliderConf.start.some((val) => val < 0 || !Number.isInteger(val)) ||

--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -1,101 +1,683 @@
 <template>
-    <div>
-        <label class="mb-5">{{ $t('editor.title') }}:</label>
-        <input type="text" name="title" :value="metadata.title" @change="metadataChanged" class="w-1/3" />
-        <br />
-        <label class="mb-5">Intro Title:</label>
-        <input type="text" name="introTitle" :value="metadata.introTitle" @change="metadataChanged" class="w-1/4" />
-        <label class="mb-5">Intro Subtitle:</label>
-        <input
-            type="text"
-            name="introSubtitle"
-            :value="metadata.introSubtitle"
-            @change="metadataChanged"
-            class="w-1/4"
-        />
-        <br />
-        <!-- only display an image preview if one is provided.-->
-        <div v-if="!!metadata.logoPreview">
-            <label>{{ $t('editor.logoPreview') }}:</label>
-            <img
-                :src="metadata.logoPreview"
-                v-if="!!metadata.logoPreview && metadata.logoPreview != 'error'"
-                class="image-preview"
-            />
-            <p v-if="metadata.logoPreview == 'error'" class="image-preview">
-                An error occurred when trying to load image.
-            </p>
-        </div>
-        <label class="mb-5">{{ $t('editor.logo') }}:</label>
-        <input type="text" @change="$emit('logo-source-changed', $event)" :value="metadata.logoName" class="w-1/4" />
-        <button @click.stop="openFileSelector" class="bg-black text-white hover:bg-gray-800">
-            {{ $t('editor.browse') }}
-        </button>
-        <button v-if="metadata.logoName || metadata.logoPreview" @click.stop="removeLogo" class="border border-black">
-            Remove
-        </button>
-        <!-- hide the actual file input -->
-        <input
-            type="file"
-            id="logoUpload"
-            @change="$emit('logo-changed', $event)"
-            class="w-1/4"
-            style="display: none"
-        />
-        <br />
-        <label>{{ $t('editor.contextLink') }}:</label>
-        <input type="text" name="contextLink" :value="metadata.contextLink" @change="metadataChanged" class="w-2/3" />
-        <br />
-        <label class="mb-5"></label>
-        <p class="inline-block">
-            <i>
-                Context link shows up at the bottom of the page to provide additional resources for interested users
-            </i>
-        </p>
-        <br />
-        <label>{{ $t('editor.contextLabel') }}:</label>
-        <input type="text" name="contextLabel" :value="metadata.contextLabel" @change="metadataChanged" class="w-2/3" />
-        <br />
-        <label class="mb-5"></label>
-        <p class="inline-block">
-            <i> Context label shows up before the context link to explain what the link is for </i>
-        </p>
-        <br />
-        <label class="mb-5">{{ $t('editor.dateModified') }}:</label>
-        <input type="date" name="dateModified" :value="metadata.dateModified" @change="metadataChanged" />
-        <br /><br />
+    <!-- If the configuration file is being fetched, display a spinner to indicate loading. -->
+    <div class="editor-container">
+        <template v-if="!loadEditor">
+            <div class="px-20 py-5">
+                <div class="flex">
+                    <div class="flex text-2xl font-bold mb-5">
+                        {{ editExisting ? $t('editor.editProduct') : $t('editor.createProduct') }}
+                    </div>
+                    <button @click="swapLang">
+                        {{ lang === 'en' ? $t('editor.frenchConfig') : $t('editor.englishConfig') }}
+                    </button>
+                </div>
+
+                <div class="border py-5 w-5/6">
+                    <label>{{ $t('editor.uuid') }}:</label>
+                    <input
+                        type="text"
+                        @input="error = false"
+                        v-model="uuid"
+                        class="w-1/3"
+                        :class="error ? 'input-error' : ''"
+                    />
+                    <button
+                        @click="generateRemoteConfig"
+                        class="bg-black text-white hover:bg-gray-800"
+                        :class="error ? 'input-error' : ''"
+                        v-if="editExisting"
+                    >
+                        {{ $t('editor.load') }}
+                    </button>
+
+                    <!-- If config is loading, display a small spinner. -->
+                    <div class="inline-flex" v-if="loadStatus === 'loading'">
+                        <spinner
+                            size="20px"
+                            background="#00D2D3"
+                            color="#009cd1"
+                            stroke="2px"
+                            class="mx-2 my-auto"
+                        ></spinner>
+                    </div>
+                </div>
+
+                <br />
+
+                <div class="mb-4">
+                    <h3>Storylines product details</h3>
+                    <p>
+                        Fill in metadata details about your new Storyline. Use the “Preview” button to see what your
+                        slides will look like.
+                    </p>
+                </div>
+
+                <metadata-content
+                    :metadata="metadata"
+                    @metadata-changed="updateMetadata"
+                    @logo-changed="onFileChange"
+                    @logo-source-changed="onLogoSourceInput"
+                ></metadata-content>
+            </div>
+
+            <div class="flex mt-8">
+                <button @click="saveMetadata" class="pl-8">{{ $t('editor.saveChanges') }}</button>
+                <div class="ml-auto">
+                    <router-link :to="{ name: 'home' }" target>
+                        <button>{{ $t('editor.back') }}</button>
+                    </router-link>
+                    <button @click="continueToEditor" class="bg-black text-white px-8">
+                        {{ $t('editor.next') }}
+                    </button>
+                </div>
+            </div>
+        </template>
+
+        <template v-if="loadEditor && loadStatus === 'loaded'">
+            <editor
+                :configs="configs"
+                :configFileStructure="configFileStructure"
+                :sourceCounts="sourceCounts"
+                :metadata="metadata"
+                :slides="slides"
+                :configLang="lang"
+                ref="mainEditor"
+            >
+                <template v-slot:langModal="slotProps">
+                    <button @click.stop="slotProps.unsavedChanges ? $modals.show(`change-lang`) : swapLang()">
+                        {{ lang === 'en' ? $t('editor.frenchConfig') : $t('editor.englishConfig') }}
+                    </button>
+                    <confirmation-modal
+                        :name="`change-lang`"
+                        :message="$t('editor.changeLang.modal')"
+                        @Ok="swapLang()"
+                    />
+                </template>
+
+                <template v-slot:metadataModal>
+                    <vue-modal name="metadata-edit-modal" :outer-close="false" :hide-close-btn="true" size="xlg">
+                        <h2 slot="header" class="text-lg font-bold">Edit Project Metadata</h2>
+                        <metadata-content
+                            :metadata="metadata"
+                            @metadata-changed="updateMetadata"
+                            @logo-changed="onFileChange"
+                            @logo-source-changed="onLogoSourceInput"
+                        ></metadata-content>
+                        <div class="w-full flex justify-end">
+                            <button class="bg-black text-white hover:bg-gray-800" @click="saveMetadata">Done</button>
+                        </div>
+                    </vue-modal>
+                </template>
+            </editor>
+        </template>
     </div>
 </template>
 
 <script lang="ts">
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import { Route } from 'vue-router';
+import {
+    AudioPanel,
+    BasePanel,
+    ChartConfig,
+    ChartPanel,
+    DynamicChildItem,
+    DynamicPanel,
+    ImagePanel,
+    MapPanel,
+    Slide,
+    SlideshowPanel,
+    StoryRampConfig
+} from '@/definitions';
+
+const JSZip = require('jszip');
+const { v4: uuidv4 } = require('uuid');
+
+import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
+import SlideEditorV from './slide-editor.vue';
+import SlideTocV from './slide-toc.vue';
+import MetadataContentV from './helpers/metadata-content.vue';
+import ConfirmationModalV from './helpers/confirmation-modal.vue';
+import EditorV from './editor.vue';
 
 @Component({
-    components: {}
+    components: {
+        Editor: EditorV,
+        'confirmation-modal': ConfirmationModalV,
+        'metadata-content': MetadataContentV,
+        spinner: Circle2,
+        'slide-editor': SlideEditorV,
+        'slide-toc': SlideTocV
+    }
 })
 export default class MetadataEditorV extends Vue {
-    @Prop() metadata!: {
-        title: string;
-        introTitle: string;
-        introSubtitle: string;
-        logoName: string;
-        logoPreview: string;
-        contextLink: string;
-        contextLabel: string;
-        dateModified: string;
+    @Prop({ default: true }) editExisting!: boolean; // true if editing existing storylines product, false if new product
+
+    configs: {
+        [key: string]: StoryRampConfig | undefined;
+    } = { en: undefined, fr: undefined };
+    configFileStructure: any = undefined;
+    loadStatus = 'waiting';
+    loadEditor = false;
+    error = false; // whether an error has occurred
+    lang = 'en';
+
+    // Form properties.
+    uuid = '';
+    logoImage: undefined | File = undefined;
+    $modals: any;
+    metadata = {
+        title: '',
+        introTitle: '',
+        introSubtitle: '',
+        logoPreview: '',
+        logoName: '',
+        contextLink: '',
+        contextLabel: '',
+        dateModified: ''
     };
+    slides: Slide[] = [];
+    sourceCounts: any = {};
 
-    openFileSelector(): void {
-        document.getElementById('logoUpload')?.click();
+    created(): void {
+        // Generate UUID for new product
+        this.uuid = this.$route.params.uid ?? (this.editExisting ? undefined : uuidv4());
+        this.lang = this.$route.params.lang ? this.$route.params.lang : 'en';
+
+        // Initialize Storylines config and the configuration structure.
+        this.configs = { en: undefined, fr: undefined };
+        this.configFileStructure = undefined;
+
+        // Find which view to render based on route
+        if (this.$route.name === 'editor') {
+            this.loadEditor = true;
+
+            // Properties already passed in props, load editor view (could use a refactor to clean up this workflow process)
+            if (this.$route.params.configs && this.$route.params.configFileStructure) {
+                this.configs = this.$route.params.configs as any;
+                this.configFileStructure = this.$route.params.configFileStructure;
+                this.metadata = this.$route.params.metadata as any;
+                this.slides = this.$route.params.slides as any;
+                this.sourceCounts = this.$route.params.sourceCounts;
+
+                this.loadStatus = 'loaded';
+                return;
+            }
+        }
+
+        // If a product UUID is provided, fetch the contents from the server.
+        if (this.$route.params.uid) {
+            this.generateRemoteConfig();
+        }
     }
 
-    metadataChanged(event: any): void {
-        this.$emit('metadata-changed', event.target.name, event.target.value);
+    /**
+     * Generates a new product file for brand new products.
+     */
+    generateNewConfig(): void {
+        const configZip = new JSZip();
+
+        // Generate a new configuration file and populate required fields.
+        this.configs[this.lang] = this.configHelper();
+        const config = this.configs[this.lang] as StoryRampConfig;
+
+        config.title = this.metadata.title;
+        config.introSlide.title = this.metadata.introTitle;
+        config.introSlide.subtitle = this.metadata.introSubtitle;
+        config.slides = [];
+
+        // Set the source of the product logo
+        if (!this.metadata.logoName) {
+            config.introSlide.logo.src = '';
+        } else if (!this.metadata.logoName.includes('http')) {
+            config.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
+        } else {
+            config.introSlide.logo.src = this.metadata.logoName;
+        }
+
+        const otherLang = this.lang === 'en' ? 'fr' : 'en';
+        this.configs[otherLang] = config;
+        (this.configs[otherLang] as StoryRampConfig).lang = otherLang;
+        const formattedOtherLangConfig = JSON.stringify(this.configs[otherLang], null, 4);
+
+        // Add the newly generated Storylines configuration file to the ZIP file.
+        const fileName = `${this.uuid}_${this.lang}.json`;
+        const formattedConfigFile = JSON.stringify(config, null, 4);
+
+        configZip.file(fileName, formattedConfigFile);
+        configZip.file(`${this.uuid}_${otherLang}.json`, formattedOtherLangConfig);
+
+        // Generate the file structure, defer uploading the image until the structure is created.
+        this.configFileStructureHelper(configZip, this.logoImage);
     }
 
-    removeLogo(): void {
-        this.metadata.logoName = '';
-        this.metadata.logoPreview = '';
+    configHelper(): StoryRampConfig {
+        // TODO: require user to input these fields instead of defaulting (speeds up testing purposes for now)
+        return {
+            title: 'Test Config',
+            lang: 'en',
+            introSlide: {
+                logo: {
+                    src: ''
+                },
+                title: '',
+                subtitle: ''
+            },
+            slides: [],
+            contextLabel: this.metadata.contextLabel,
+            contextLink: this.metadata.contextLink,
+            dateModified: this.metadata.dateModified
+        };
+    }
+
+    /**
+     * Provided with a UID, retrieve the project contents from the file server.
+     */
+    generateRemoteConfig(): void {
+        this.loadStatus = 'loading';
+
+        // Attempt to fetch the project from the server.
+        fetch(`http://localhost:6040/retrieve/${this.uuid}`).then((res: any) => {
+            if (res.status === 404) {
+                // Product not found.
+                this.$message.error(`The requested UUID ${this.uuid ?? ''} does not exist.`);
+                this.error = true;
+                this.loadStatus = 'waiting';
+            } else {
+                const configZip = new JSZip();
+                // Files retrieved. Convert them into a JSZip object.
+                res.blob().then((file: any) => {
+                    configZip.loadAsync(file).then(() => {
+                        this.configFileStructureHelper(configZip);
+                        this.$message.success('Successfully loaded storyline!');
+                    });
+                });
+            }
+        });
+    }
+
+    findSources(configs: { [key: string]: StoryRampConfig | undefined }): void {
+        ['en', 'fr'].forEach((lang) => {
+            this.incrementSourceCount((configs[lang] as StoryRampConfig).introSlide.logo.src);
+            (configs[lang] as StoryRampConfig).slides.forEach((slide) => {
+                slide.panel.forEach((panel) => {
+                    this.panelSourceHelper(panel);
+                });
+            });
+        });
+    }
+
+    panelSourceHelper(panel: BasePanel): void {
+        switch (panel.type) {
+            case 'dynamic':
+                (panel as DynamicPanel).children.forEach((subPanel: DynamicChildItem) => {
+                    this.panelSourceHelper(subPanel.panel);
+                });
+                break;
+            case 'slideshow':
+                (panel as SlideshowPanel).images.forEach((image: ImagePanel) => {
+                    this.incrementSourceCount(image.src);
+                });
+                break;
+            case 'chart':
+                (panel as ChartPanel).charts.forEach((chart: ChartConfig) => {
+                    this.incrementSourceCount(chart.src);
+                });
+                break;
+            case 'image':
+            case 'video':
+            case 'audio':
+                this.incrementSourceCount((panel as AudioPanel).src);
+                break;
+            case 'map':
+                this.incrementSourceCount((panel as MapPanel).config);
+                break;
+            default:
+                break;
+        }
+    }
+
+    incrementSourceCount(src: string): void {
+        if (this.sourceCounts[src]) {
+            this.sourceCounts[src] += 1;
+        } else {
+            this.sourceCounts[src] = 1;
+        }
+    }
+
+    /**
+     * Generates or loads a ZIP file and creates required project folders if needed.
+     * Returns an object that makes it easy to access any specific folder.
+     */
+    configFileStructureHelper(configZip: any, uploadLogo?: File | undefined): void {
+        const assetsFolder = configZip.folder('assets');
+        const chartsFolder = configZip.folder('charts');
+        const rampConfigFolder = configZip.folder('ramp-config');
+
+        this.configFileStructure = {
+            uuid: this.uuid,
+            zip: configZip,
+            configs: this.configs,
+            assets: {
+                en: assetsFolder.folder('en'),
+                fr: assetsFolder.folder('fr')
+            },
+            charts: {
+                en: chartsFolder.folder('en'),
+                fr: chartsFolder.folder('fr')
+            },
+            rampConfig: {
+                en: rampConfigFolder.folder('en'),
+                fr: rampConfigFolder.folder('fr')
+            }
+        };
+
+        // If uploadLogo is set, upload the logo to the directory.
+        if (uploadLogo !== undefined) {
+            this.configFileStructure.assets[this.lang].file(uploadLogo?.name, uploadLogo);
+        }
+
+        this.loadConfig();
+    }
+
+    /**
+     * Loads a configuration file from the product folder, and sets application data
+     * as needed.
+     */
+    async loadConfig(config?: StoryRampConfig): Promise<void> {
+        if (config) {
+            this.useConfig(config);
+            return;
+        }
+
+        await this.configFileStructure.zip
+            .file(`${this.uuid}_en.json`)
+            .async('string')
+            .then((res: any) => {
+                this.configs['en'] = JSON.parse(res);
+            });
+        await this.configFileStructure.zip
+            .file(`${this.uuid}_fr.json`)
+            .async('string')
+            .then((res: any) => {
+                this.configs['fr'] = JSON.parse(res);
+            });
+
+        // Load in project data.
+        if (this.configs[this.lang]) {
+            this.useConfig(this.configs[this.lang] as StoryRampConfig);
+            this.findSources(this.configs);
+
+            // Update router path
+            if (!this.editExisting) {
+                this.loadEditor = true;
+                this.updateEditorPath();
+            }
+        }
+    }
+
+    useConfig(config: StoryRampConfig): void {
+        this.metadata.title = config.title;
+        this.metadata.introTitle = config.introSlide.title;
+        this.metadata.introSubtitle = config.introSlide.subtitle;
+        this.metadata.contextLink = config.contextLink;
+        this.metadata.contextLabel = config.contextLabel;
+        this.metadata.dateModified = config.dateModified;
+
+        // Conversion for individual image panels to slideshow for gallery display
+        this.slides = config.slides;
+        this.slides.forEach((slide: Slide) => {
+            if (slide.panel.length === 2 && slide.panel[1].type === 'image') {
+                const newSlide = {
+                    type: 'slideshow',
+                    images: [slide.panel[1]]
+                };
+                Vue.set(slide.panel, 1, newSlide);
+            }
+        });
+
+        const logo = config.introSlide.logo.src;
+        // Fetch the logo from the folder (if it exists).
+        const logoSrc = `${logo.substring(logo.indexOf('/') + 1)}`;
+        const logoName = `${logo.split('/')[logo.split('/').length - 1]}`;
+        if (this.configFileStructure.zip.file(logoSrc)) {
+            this.configFileStructure.zip
+                .file(logoSrc)
+                .async('blob')
+                .then((img: any) => {
+                    this.logoImage = new File([img], logoName);
+                    this.metadata.logoPreview = URL.createObjectURL(img);
+                    this.metadata.logoName = logoName;
+                    this.loadStatus = 'loaded';
+                });
+        } else {
+            // Fill in the field with this value whether it exists or not.
+            this.metadata.logoName = logo;
+
+            // If it doesn't exist, maybe it's a remote file?
+            fetch(logo).then((data: any) => {
+                if (data.status !== 404) {
+                    this.logoImage = new File([data], logoName);
+                    this.metadata.logoPreview = logo;
+                }
+                this.loadStatus = 'loaded';
+            });
+        }
+    }
+
+    updateMetadata(
+        key: 'title' | 'introTitle' | 'introSubtitle' | 'contextLink' | 'contextLabel' | 'dateModified',
+        value: string
+    ): void {
+        this.metadata[key] = value;
+    }
+
+    /**
+     * Called when `Save Changes` is pressed on metadata page. Save metadata content fields
+     * to config file. TODO: decide whether to upload file to server (e.g. call generateConfig).
+     */
+    saveMetadata(): void {
+        // update metadata content to existing config only if it has been successfully loaded
+        const config = this.configs[this.lang];
+        if (config !== undefined) {
+            config.title = this.metadata.title;
+            config.introSlide.title = this.metadata.introTitle;
+            config.introSlide.subtitle = this.metadata.introSubtitle;
+            config.contextLink = this.metadata.contextLink;
+            config.contextLabel = this.metadata.contextLabel;
+            config.dateModified = this.metadata.dateModified;
+
+            // If the logo doesn't include HTTP, assume it's a local file.
+            if (!this.metadata.logoName) {
+                config.introSlide.logo.src = '';
+            } else if (!this.metadata.logoName.includes('http')) {
+                config.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
+                this.configFileStructure.assets[this.lang].file(this.logoImage?.name, this.logoImage);
+            } else {
+                config.introSlide.logo.src = this.metadata.logoName;
+            }
+        }
+        if (this.$modals.isActive('metadata-edit-modal')) {
+            this.$modals.hide('metadata-edit-modal');
+        }
+    }
+
+    /**
+     * Called when 'next' button is pressed on metadata page to continue to main editor.
+     */
+    continueToEditor(): void {
+        if (this.editExisting) {
+            if (this.configs[this.lang] !== undefined) {
+                this.loadEditor = true;
+                this.updateEditorPath();
+            } else {
+                this.$message.error('No config exists for storylines product.');
+            }
+        } else {
+            // TODO: check for non-empty required metadata fields
+            this.generateNewConfig();
+        }
+    }
+
+    /**
+     * Language toggle.
+     */
+    swapLang(): void {
+        this.lang = this.lang === 'en' ? 'fr' : 'en';
+        this.loadConfig();
+        if (this.loadEditor) {
+            (this.$refs.mainEditor as any).selectSlide(-1);
+        }
+    }
+
+    /**
+     * React to param changes in URL.
+     */
+    beforeRouteUpdate(to: Route, from: Route, next: () => void): void {
+        this.lang = to.params.lang;
+        this.uuid = to.params.uid;
+        this.$i18n.locale = this.lang;
+
+        next();
+    }
+
+    onLogoSourceInput(e: InputEvent): void {
+        const isImgUrl = (url: string) => {
+            const img = new Image();
+            img.src = url;
+            return new Promise((resolve) => {
+                img.onerror = () => resolve(false);
+                img.onload = () => resolve(true);
+            });
+        };
+
+        this.metadata.logoName = (e.target as HTMLInputElement).value;
+
+        isImgUrl(this.metadata.logoName).then((res) => {
+            if (res) {
+                this.metadata.logoPreview = this.metadata.logoName;
+                this.$message.success('Successfully loaded logo image.');
+            } else {
+                this.metadata.logoPreview = 'error';
+                this.$message.error('Failed to load logo image.');
+            }
+        });
+    }
+
+    onFileChange(e: Event): void {
+        // Retrieve the uploaded file.
+        const uploadedFile = ((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
+        this.logoImage = uploadedFile;
+
+        // Generate an image preview.
+        this.metadata.logoPreview = URL.createObjectURL(uploadedFile);
+        this.metadata.logoName = uploadedFile.name;
+    }
+
+    updateEditorPath(): void {
+        if (this.$route.name !== 'editor') {
+            const props = {
+                uid: this.uuid,
+                configLang: this.lang,
+                configs: this.configs as any,
+                configFileStructure: this.configFileStructure,
+                sourceCounts: this.sourceCounts,
+                metadata: this.metadata as any,
+                slides: this.slides as any
+            };
+            this.$router.push({ name: 'editor', params: props });
+        }
     }
 }
 </script>
+
+<style lang="scss">
+$font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+
+.storyramp-app {
+    h1,
+    h2,
+    h3,
+    h4,
+    h5,
+    h6,
+    .h1,
+    .h2,
+    .h3,
+    .h4,
+    .h5,
+    .h6 {
+        font-family: $font-list;
+        line-height: 1.5;
+        border-bottom: 0px;
+    }
+
+    .editor-container {
+        margin: 0 auto;
+    }
+
+    .editor-container label {
+        width: 10vw;
+        text-align: right;
+        margin-right: 15px;
+        display: inline-block;
+    }
+
+    .editor-container h3 {
+        font-size: larger;
+    }
+
+    .editor-container input {
+        padding: 5px 10px;
+        margin-top: 5px;
+        border: 1px solid black;
+        display: inline;
+    }
+
+    .editor-container .input-error {
+        border: 1px solid red;
+    }
+
+    .editor-container button {
+        padding: 5px 12px;
+        margin: 0px 10px;
+        font-weight: 600;
+        transition-duration: 0.2s;
+    }
+
+    .editor-container button:hover:enabled {
+        background-color: #dbdbdb;
+        color: black;
+    }
+
+    .editor-container button:disabled {
+        border: 1px solid gray;
+        color: gray;
+        cursor: not-allowed;
+    }
+
+    .editor-toc button {
+        background-color: #f3f4f6;
+        color: black;
+        border: none;
+        transition-duration: 0.2s;
+        padding: 0.25 0.25em !important;
+    }
+
+    .image-preview {
+        max-width: 150px;
+        max-height: 150px;
+        display: inline;
+    }
+
+    .fade-enter-active,
+    .fade-leave-active {
+        transition: opacity 0.2s;
+    }
+
+    .fade-enter,
+    .fade-leave-to {
+        opacity: 0;
+    }
+}
+</style>

--- a/src/components/editor/preview.vue
+++ b/src/components/editor/preview.vue
@@ -11,7 +11,19 @@
             <header class="sticky top-0 z-50 flex border-b border-black bg-gray-200 py-2 px-2 justify-between">
                 <span class="font-semibold text-lg m-1">{{ config.title }}</span>
                 <!-- TODO: change this route back to the main editor (complete along with #89) -->
-                <router-link :to="{ name: 'home' }" target v-if="!savedProduct">
+                <router-link
+                    :to="{
+                        path: `editor-main/${uid}`,
+                        params: {
+                            config: config,
+                            configFileStructure: configFileStructure,
+                            metadata: metadata,
+                            sourceCounts: sourceCounts
+                        }
+                    }"
+                    target
+                    v-if="!savedProduct"
+                >
                     <button class="bg-white border border-black font-bold hover:bg-gray-100 px-4 py-2">
                         {{ $t('editor.back') }}
                     </button>
@@ -67,14 +79,17 @@ import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
     }
 })
 export default class StoryPreviewV extends Vue {
-    @Prop() conf!: StoryRampConfig | undefined;
+    @Prop() conf!: StoryRampConfig;
     @Prop() configFileStructure!: any;
+    @Prop() sourceCounts!: any;
+    @Prop() metadata!: any;
 
     config: StoryRampConfig | undefined = undefined;
     savedProduct = false;
     loadStatus = 'loading';
     activeChapterIndex = -1;
     lang = 'en';
+    uid = '';
 
     created(): void {
         const uid = this.$route.params.uid;
@@ -95,8 +110,9 @@ export default class StoryPreviewV extends Vue {
                     });
                 }
             });
-        } else if (this.conf) {
+        } else if (this.conf && this.configFileStructure) {
             this.config = this.conf;
+            this.uid = this.configFileStructure.uuid;
             this.loadStatus = 'loaded';
         }
 

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -285,7 +285,7 @@ export default class SlideEditorV extends Vue {
     };
 
     @Watch('currentSlide', { deep: true })
-    onSlideChange() {
+    onSlideChange(): void {
         this.currentSlide ? (this.rightOnly = this.currentSlide.panel.length === 1) : false;
     }
 
@@ -378,7 +378,7 @@ export default class SlideEditorV extends Vue {
         this.$emit('slide-change', index);
     }
 
-    cancelTypeChange() {
+    cancelTypeChange(): void {
         (this.$refs.typeSelector as HTMLSelectElement).value = this.currentSlide.panel[this.panelIndex].type;
     }
 

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -29,7 +29,7 @@
                     >
                         Copy All
                     </button>
-                    <span class="text-lg font-bold my-6"> {{ $t('or') }} </span>
+                    <span class="text-lg font-bold my-6"> {{ $t('editor.image.label.or') }} </span>
                     <div class="flex">
                         <select v-model="selectedForCopying" class="overflow-ellipsis copy-select">
                             <option
@@ -198,12 +198,12 @@ export default class SlideTocV extends Vue {
         this.$emit('slides-updated', this.slides);
     }
 
-    removeSourceCounts(deletedIndex: any): void {
+    removeSourceCounts(deletedIndex: number): void {
         const panel = this.slides.find((panel: any, idx: number) => idx === deletedIndex).panel;
         panel.forEach((p: any) => this.removeSourceHelper(p));
     }
 
-    removeSourceHelper(panel: any) {
+    removeSourceHelper(panel: any): void {
         // The provided panel is being removed. Update source counts accordingly.
         switch (panel.type) {
             case 'map':

--- a/src/components/panels/dynamic-panel.vue
+++ b/src/components/panels/dynamic-panel.vue
@@ -7,7 +7,7 @@
                         style="display: inline; margin: 0px"
                         src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAB4AAAAeCAYAAAA7MK6iAAAABmJLR0QA/wD/AP+gvaeTAAAB4UlEQVRIie3WP08WQRAG8J+2SolRQaLyKvR+BTsVaQnfwD9YCH4PS6I2ViAS1GhMKLWESkzUmBAT7azECoS8Fjcvqxe52zuMseBJNpebe2ae2dmdveUA/wiHGnCHcBWXcBqDYf+CT3iOp/j8t5IbwCy20a0ZO3gUie0L4/geQTcxhwmM4EiMkbDNB6eLDYy1Fb2lmEEXj3E2w2cYi9Lsp5qKjofjNm43dcZ0+O9oMPNBqbxtRHuYkcp+MsfhgVTe/WIpYt2rIw4pyrtp7zU9hlW8zhDuRKxtqf3+iJuR4VyF6FpwVjKEKdqri+tVpJdBmqgRXYv3HEyGz4sq0scgnSvZ+/Emvr3D8UxRij7v4n0VaSNIfSX7qvpTqzfKa98n7e5dHG6QeS66bZw+hOP5kr1c6hMNYo7+4reL8ozX43mhZP+Ki3gbgZblb65erPUq0o3Ibn6P723aaSH416pIp6QDZLhCfAWvMkQ72MIPNQcI3I8MFzMC1+FJxJrNIQ9IbTW9D9E7EeObBptxTPqtzbQU7flfaeo8JV0ElhTrVYeOVN4dxdnfCmNS2bcUB/6koqWOxhgN20JweuW93Fa0h37cVezMnMveQxlr2uR6Oyhdb8/4/Xq7rvj7PIv3A/w/+Am/TqGFCMnpPgAAAABJRU5ErkJggg=="
                     />
-                    {{ $t('dynamic.back') }}
+                    {{ $t('editor.back') }}
                 </button>
             </div>
 

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -64,5 +64,3 @@ editor.slides.addSlide,"New Slide",1,"New Slide",0
 editor.slides.copyFromLang,"Copy slides from the other language",1,"Copy slides from the other language",0
 editor.slides.deleteSlide.confirm,"Are you sure you want to delete the slide {title}?",1,"Are you sure you want to delete the slide {title}?",0
 editor.slides.changeSlide.confirm,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",1,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",0
-dynamic.back,Back,1,Retour,0
-or,Or,1,Ou,1

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -1,7 +1,7 @@
 import Vue from 'vue';
 import StoryV from '@/components/story/story.vue';
 import LandingV from '@/components/editor/landing.vue';
-import EditorV from '@/components/editor/editor.vue';
+import MetadataEditorV from '@/components/editor/metadata-editor.vue';
 import StoryPreviewV from '@/components/editor/preview.vue';
 import Router, { Route } from 'vue-router';
 
@@ -20,16 +20,27 @@ const routes = [
         meta: { title: 'editor.window.title' }
     },
     {
+        path: '/:lang/editor/:uid',
+        redirect: '/:lang/editor-metadata/:uid'
+    },
+    {
         path: '/:lang/editor-metadata',
         name: 'metadata',
-        component: EditorV,
+        component: MetadataEditorV,
         props: true,
         meta: { title: 'editor.window.title' }
     },
     {
-        path: '/:lang/editor/:uid',
+        path: '/:lang/editor-metadata/:uid',
+        component: MetadataEditorV,
+        props: true,
+        meta: { title: 'editor.window.title' }
+    },
+    {
+        path: '/:lang/editor-main/:uid',
         name: 'editor',
-        component: EditorV,
+        component: MetadataEditorV,
+        props: true,
         meta: { title: 'editor.window.title' }
     },
     {


### PR DESCRIPTION
Closes #89, #129, #169 

**Changes**: 
- added new routes: `/:lang/editor-main/:uid` for the slide editor (requires UID as parameter), `/:lang/editor-metadata/:uid` for metadata page with UID as parameter, `/:lang/editor/:uid` that redirects to the metadata page
- fixed back button in preview mode redirecting back to the slide editor (#129) but still should open in new tab  (opened #152)
- refactored code to separate metadata component and its logic from the main slide editor
- add functionality to load existing Storylines product for different page views if UID param is passed in route 
- renamed some files

**Testing**: 
Test transitioning between page views, save functionality, and loading products by passing in UID as URL parameter. Additionally, check all recently merged PR changes functionality in case any changes were lost during rebase.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/153)
<!-- Reviewable:end -->
