### PR TITLE
Add reload button

### DIFF
--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -30,6 +30,7 @@ editor.back,Back,1,Retour,1
 editor.next,Next,1,Suivant,1
 editor.preview,Preview,1,Aperçu,0
 editor.saveChanges,Save Changes,1,Sauvegarder les Modifications,0
+editor.resetChanges,Reset Changes,1,Reset Changes,0
 editor.savingChanges,Saving...,1,Sauver...,0
 editor.changeLang.modal,"Are you sure you want to switch languages? All unsaved changes will be lost.",1,"Are you sure you want to switch languages? All unsaved changes will be lost.",0
 editor.frenchConfig,View French Config,1,Afficher la configuration française,0


### PR DESCRIPTION
Closes #149 

This PR adds a reload button to the editor. When clicked, it will undo any changes that have been made since the last save by re-fetching the product from the server and re-loading it.


I currently have this reload button set to appear whenever the 'Unsaved Changes' indicator is showing. This can be changed based on any feedback you may have!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/157)
<!-- Reviewable:end -->
