### PR TITLE
Implement previewing unsaved changes in new tab

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -43,35 +43,15 @@
                 </span>
             </transition>
             <slot name="langModal" v-bind="{ unsavedChanges: unsavedChanges }"></slot>
-            <router-link
-                :to="{
-                    name: 'preview',
-                    params: {
-                        conf: configs[configLang],
-                        configFileStructure: configFileStructure,
-                        metadata: metadata,
-                        sourceCounts: sourceCounts
-                    }
-                }"
-            >
-                <button @click="preview" class="bg-white border border-black hover:bg-gray-100">
-                    {{ $t('editor.preview') }}
-                </button>
-            </router-link>
+            <button @click="preview" class="bg-white border border-black hover:bg-gray-100">
+                {{ $t('editor.preview') }}
+            </button>
             <button @click="generateConfig" class="bg-black text-white hover:bg-gray-900" :disabled="saving">
                 <span class="inline-block">{{ saving ? $t('editor.savingChanges') : $t('editor.saveChanges') }}</span>
                 <span v-if="saving" class="align-middle inline-block px-1"
                     ><spinner size="16px" background="#6B7280" color="#FFFFFF" stroke="2px" class="ml-1 mb-1"></spinner>
                 </span>
             </button>
-            <router-link
-                :to="{
-                    path: `/${$route.params.lang}/editor-preview/${uuid}`
-                }"
-                target="_blank"
-            >
-                <button class="bg-white border border-black hover:bg-gray-100">View Saved Product</button>
-            </router-link>
         </div>
         <div class="flex">
             <div class="w-80 flex-shrink-0 border-r border-black editor-toc">
@@ -266,6 +246,12 @@ export default class EditorV extends Vue {
         if (this.$refs.slide !== undefined) {
             (this.$refs.slide as any).saveChanges();
         }
+        const routeData = this.$router.resolve({ name: 'preview' });
+        const previewTab = window.open(routeData.href, '_blank');
+        (previewTab as any).props = {
+            config: JSON.parse(JSON.stringify(this.configs[this.configLang])),
+            configFileStructure: this.configFileStructure
+        };
     }
 
     beforeWindowUnload(e: any): void {

--- a/src/components/editor/preview.vue
+++ b/src/components/editor/preview.vue
@@ -10,24 +10,6 @@
         <div class="storyramp-app bg-white" v-if="config !== undefined">
             <header class="sticky top-0 z-50 flex border-b border-black bg-gray-200 py-2 px-2 justify-between">
                 <span class="font-semibold text-lg m-1">{{ config.title }}</span>
-                <!-- TODO: change this route back to the main editor (complete along with #89) -->
-                <router-link
-                    :to="{
-                        path: `editor-main/${uid}`,
-                        params: {
-                            config: config,
-                            configFileStructure: configFileStructure,
-                            metadata: metadata,
-                            sourceCounts: sourceCounts
-                        }
-                    }"
-                    target
-                    v-if="!savedProduct"
-                >
-                    <button class="bg-white border border-black font-bold hover:bg-gray-100 px-4 py-2">
-                        {{ $t('editor.back') }}
-                    </button>
-                </router-link>
             </header>
 
             <introduction :config="config.introSlide" :configFileStructure="configFileStructure"></introduction>
@@ -79,12 +61,8 @@ import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
     }
 })
 export default class StoryPreviewV extends Vue {
-    @Prop() conf!: StoryRampConfig;
-    @Prop() configFileStructure!: any;
-    @Prop() sourceCounts!: any;
-    @Prop() metadata!: any;
-
     config: StoryRampConfig | undefined = undefined;
+    configFileStructure: any;
     savedProduct = false;
     loadStatus = 'loading';
     activeChapterIndex = -1;
@@ -110,9 +88,9 @@ export default class StoryPreviewV extends Vue {
                     });
                 }
             });
-        } else if (this.conf && this.configFileStructure) {
-            this.config = this.conf;
-            this.uid = this.configFileStructure.uuid;
+        } else {
+            this.config = (window as any).props.config;
+            this.configFileStructure = (window as any).props.configFileStructure;
             this.loadStatus = 'loaded';
         }
 

--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -32,24 +32,8 @@ import FullscreenV from '@/components/panels/helpers/fullscreen.vue';
 })
 export default class ImagePanelV extends Vue {
     @Prop() config!: ImagePanel;
-    @Prop() configFileStructure!: any;
 
     md = new MarkdownIt({ html: true });
-
-    mounted(): void {
-        // obtain image file from ZIP folder in editor preview mode
-        if (this.configFileStructure) {
-            const assetSrc = `${this.config.src.substring(this.config.src.indexOf('/') + 1)}`;
-            if (this.configFileStructure.zip.file(assetSrc)) {
-                this.configFileStructure.zip
-                    .file(assetSrc)
-                    .async('blob')
-                    .then((res: any) => {
-                        this.config.src = URL.createObjectURL(res);
-                    });
-            }
-        }
-    }
 }
 </script>
 

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -1,6 +1,10 @@
 <template>
     <div v-if="config.images.length === 1">
-        <image-panel :config="config.images[0]" :configFileStructure="configFileStructure"></image-panel>
+        <image-panel
+            :config="config.images[0]"
+            :configFileStructure="configFileStructure"
+            :key="config.images[0].src"
+        ></image-panel>
     </div>
     <div v-else class="carousel self-start px-10 my-8 bg-gray-200_ h-28_" :style="{ width: `${width}px` }">
         <full-screen :expandable="config.fullscreen" :type="config.type">
@@ -67,6 +71,7 @@ export default class SlideshowPanelV extends Vue {
                         .async('blob')
                         .then((res: any) => {
                             image.src = URL.createObjectURL(res);
+                            this.$forceUpdate();
                         });
                 }
             });


### PR DESCRIPTION
Closes #152.

A question that comes to mind is now that previewing in new tab works, do we want to remove the option of "viewing saved product", as the user could just open a preview at the start of the session and then open another one for their new changes to see the difference. I have kept it in for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/167)
<!-- Reviewable:end -->
