### PR TITLE
Fix alt text saving and added caption textbox

### DIFF
--- a/src/components/editor/helpers/image-preview.vue
+++ b/src/components/editor/helpers/image-preview.vue
@@ -1,6 +1,6 @@
 <template>
-    <li class="image-item items-center my-8 mx-4 overflow-hidden grabbable">
-        <div class="relative items-center justify-center text-center w-full">
+    <li class="image-item items-center my-8 mx-4 overflow-hidden">
+        <div class="relative items-center justify-center text-center w-full grabbable">
             <button
                 class="bg-white absolute h-6 w-6 leading-5 rounded-full top-0 right-0 p-0 cursor-pointer"
                 @click="() => $emit('delete', imageFile)"
@@ -13,12 +13,14 @@
                     />
                 </svg>
             </button>
-            <img
-                class="image-file object-cover w-full h-full"
-                :title="imageFile.id"
-                :src="imageFile.src"
-                :alt="imageFile.altText"
-            />
+            <div class="flex-grow">
+                <img
+                    class="image-file object-cover w-full h-full"
+                    :title="imageFile.id"
+                    :src="imageFile.src"
+                    :alt="imageFile.altText"
+                />
+            </div>
         </div>
         <slot></slot>
     </li>

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -47,9 +47,14 @@
                 :imageFile="image"
                 @delete="deleteImage"
             >
-                <div class="flex mt-4 items-center">
-                    <label class="alt-label">Alt tag:</label>
-                    <input type="text" v-model="image.altText" />
+                <div class="flex mt-4 items-center w-full text-left">
+                    <label class="text-label">Alt tag:</label>
+                    <input class="w-4/5" type="text" v-model="image.altText" @change="onImagesEdited" />
+                </div>
+
+                <div class="flex mt-4 items-center w-full text-left">
+                    <label class="text-label">Caption:</label>
+                    <input class="w-4/5" type="text" v-model="image.caption" @change="onImagesEdited" />
                 </div>
             </ImagePreview>
         </draggable>
@@ -137,6 +142,7 @@ export default class ImageEditorV extends Vue {
                 return {
                     id: file.name,
                     altText: '',
+                    caption: '',
                     src: imageSrc
                 };
             })
@@ -163,6 +169,7 @@ export default class ImageEditorV extends Vue {
                     return {
                         id: file.name,
                         altText: '',
+                        caption: '',
                         src: imageSrc
                     };
                 })
@@ -226,10 +233,9 @@ export default class ImageEditorV extends Vue {
     width: auto !important;
 }
 
-.alt-label {
-    width: 12% !important;
+.text-label {
+    width: 25% !important;
     margin-right: 0.5rem !important;
-    text-align: left !important;
 }
 
 .dragging {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -199,6 +199,7 @@ export interface ImageFile {
     id: string;
     src: string;
     altText: string;
+    caption?: string;
     width?: number;
     height?: number;
 }


### PR DESCRIPTION
Closes #162 

**Changes**: 
- properly saves alt text to config
- added textbox to add a caption for image and saves to config

Opened issue https://github.com/ramp4-pcar4/story-ramp/issues/314 for adding support to display image captions inside a slideshow panel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/172)
<!-- Reviewable:end -->
