### PR TITLE
Fix slide deletion for existing products

### DIFF
--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -338,7 +338,7 @@ export default class SlideEditorV extends Vue {
             case 'map':
                 this.sourceCounts[panel.config] -= 1;
                 if (this.sourceCounts[panel.config] === 0) {
-                    this.configFileStructure.config.remove(`${panel.config.substring(panel.config.indexOf('/') + 1)}`);
+                    this.configFileStructure.zip.remove(`${panel.config.substring(panel.config.indexOf('/') + 1)}`);
                 }
                 break;
 
@@ -346,7 +346,7 @@ export default class SlideEditorV extends Vue {
                 panel.charts.forEach((chart: any) => {
                     this.sourceCounts[chart.src] -= 1;
                     if (this.sourceCounts[chart.src] === 0) {
-                        this.configFileStructure.config.remove(`${chart.src.substring(chart.src.indexOf('/') + 1)}`);
+                        this.configFileStructure.zip.remove(`${chart.src.substring(chart.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;
@@ -355,7 +355,7 @@ export default class SlideEditorV extends Vue {
                 panel.images.forEach((image: any) => {
                     this.sourceCounts[image.src] -= 1;
                     if (this.sourceCounts[image.src] === 0) {
-                        this.configFileStructure.config.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
+                        this.configFileStructure.zip.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -209,7 +209,7 @@ export default class SlideTocV extends Vue {
             case 'map':
                 this.sourceCounts[panel.config] -= 1;
                 if (this.sourceCounts[panel.config] === 0) {
-                    this.configFileStructure.config.remove(`${panel.config.substring(panel.config.indexOf('/') + 1)}`);
+                    this.configFileStructure.zip.remove(`${panel.config.substring(panel.config.indexOf('/') + 1)}`);
                 }
                 break;
 
@@ -217,7 +217,7 @@ export default class SlideTocV extends Vue {
                 panel.charts.forEach((chart: any) => {
                     this.sourceCounts[chart.src] -= 1;
                     if (this.sourceCounts[chart.src] === 0) {
-                        this.configFileStructure.config.remove(`${chart.src.substring(chart.src.indexOf('/') + 1)}`);
+                        this.configFileStructure.zip.remove(`${chart.src.substring(chart.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;
@@ -226,7 +226,7 @@ export default class SlideTocV extends Vue {
                 panel.images.forEach((image: any) => {
                     this.sourceCounts[image.src] -= 1;
                     if (this.sourceCounts[image.src] === 0) {
-                        this.configFileStructure.config.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
+                        this.configFileStructure.zip.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;


### PR DESCRIPTION
Closes #171.

Slide deletion will now work correctly for existing products for slides that had some form of media (image/map/chart) in them.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/174)
<!-- Reviewable:end -->
