### PR TITLE
implement metadata save button; fix logo upload; add refresh config button

### DIFF
--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -89,7 +89,9 @@
             </div>
 
             <div class="flex mt-8">
-                <button @click="saveMetadata" class="pl-8">{{ $t('editor.saveChanges') }}</button>
+                <button v-if="editExisting" @click="saveMetadata(true)" class="pl-8">
+                    {{ $t('editor.saveChanges') }}
+                </button>
                 <div class="ml-auto">
                     <router-link :to="{ name: 'home' }" target>
                         <button>{{ $t('editor.back') }}</button>
@@ -117,6 +119,12 @@
                 :metadata="metadata"
                 :slides="slides"
                 :configLang="lang"
+                :saving="saving"
+                :unsavedChanges="unsavedChanges"
+                :editExisting="editExisting"
+                @save-changes="generateConfig"
+                @save-status="updateSaveStatus"
+                @refresh-config="refreshConfig"
                 ref="mainEditor"
             >
                 <template v-slot:langModal="slotProps">
@@ -140,7 +148,9 @@
                             @logo-source-changed="onLogoSourceInput"
                         ></metadata-content>
                         <div class="w-full flex justify-end">
-                            <button class="bg-black text-white hover:bg-gray-800" @click="saveMetadata">Done</button>
+                            <button class="bg-black text-white hover:bg-gray-800" @click="saveMetadata(false)">
+                                Done
+                            </button>
                         </div>
                     </vue-modal>
                 </template>
@@ -167,6 +177,7 @@ import {
 } from '@/definitions';
 
 const JSZip = require('jszip');
+const axios = require('axios').default;
 const { v4: uuidv4 } = require('uuid');
 
 import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
@@ -198,6 +209,10 @@ export default class MetadataEditorV extends Vue {
     error = false; // whether an error has occurred
     warning = false; // used for duplicate uuid warning
     lang = 'en';
+
+    // Saving properties.
+    saving = false;
+    unsavedChanges = false;
 
     // Form properties.
     uuid = '';
@@ -251,7 +266,38 @@ export default class MetadataEditorV extends Vue {
                 this.slides = this.$route.params.slides as any;
                 this.sourceCounts = this.$route.params.sourceCounts;
 
-                this.loadStatus = 'loaded';
+                // Load product logo (if provided).
+                const logo = this.configs[this.lang]!.introSlide.logo.src;
+                const logoSrc = `assets/${this.lang}/${this.metadata.logoName}`;
+
+                if (logo) {
+                    if (this.configFileStructure.zip.file(logoSrc)) {
+                        this.configFileStructure.zip
+                            .file(logoSrc)
+                            .async('blob')
+                            .then((img: any) => {
+                                this.logoImage = new File([img], this.metadata.logoName);
+                                this.metadata.logoPreview = URL.createObjectURL(img);
+                                this.loadStatus = 'loaded';
+                            });
+                    } else {
+                        // Fill in the field with this value whether it exists or not.
+                        this.metadata.logoName = logo;
+
+                        // If it doesn't exist, maybe it's a remote file?
+                        fetch(logo).then((data: any) => {
+                            if (data.status !== 404) {
+                                this.logoImage = new File([data], this.metadata.logoName);
+                                this.metadata.logoPreview = logo;
+                            }
+                            this.loadStatus = 'loaded';
+                        });
+                    }
+                } else {
+                    // No logo to load.
+                    this.loadStatus = 'loaded';
+                }
+
                 return;
             }
         }
@@ -535,6 +581,52 @@ export default class MetadataEditorV extends Vue {
         }
     }
 
+    /**
+     * Called when `Save Changes` is pressed. Re-generates the Storylines configuration file
+     * with the new changes, then generates and submits the product file to the server.
+     */
+    generateConfig(): StoryRampConfig {
+        this.saving = true;
+        // save current slide final changes before generating config file
+        if (this.$refs.slide !== undefined) {
+            (this.$refs.slide as any).saveChanges();
+        }
+
+        // Update the configuration file.
+        const fileName = `${this.uuid}_${this.lang}.json`;
+        const formattedConfigFile = JSON.stringify(this.configs[this.lang], null, 4);
+
+        this.configFileStructure.zip.file(fileName, formattedConfigFile);
+
+        // Upload the ZIP file.
+        this.configFileStructure.zip.generateAsync({ type: 'blob' }).then((content: any) => {
+            const formData = new FormData();
+            formData.append('data', content, `${this.uuid}.zip`);
+            const headers = { 'Content-Type': 'multipart/form-data' };
+
+            axios
+                .post('http://localhost:6040/upload', formData, { headers })
+                .then((res: any) => {
+                    res.data.files; // binary representation of the file
+                    res.status; // HTTP status
+                    this.unsavedChanges = false;
+                    this.editExisting = true; // if editExisting was false, we can now set it to true
+                    this.$message.success('Successfully saved changes!');
+                })
+                .catch(() => {
+                    this.$message.error('Failed to save changes.');
+                })
+                .finally(() => {
+                    // padding to prevent save button from being clicked rapidly
+                    setTimeout(() => {
+                        this.saving = false;
+                    }, 500);
+                });
+        });
+
+        return this.configFileStructure;
+    }
+
     updateMetadata(
         key: 'title' | 'introTitle' | 'introSubtitle' | 'contextLink' | 'contextLabel' | 'dateModified',
         value: string
@@ -544,9 +636,9 @@ export default class MetadataEditorV extends Vue {
 
     /**
      * Called when `Save Changes` is pressed on metadata page. Save metadata content fields
-     * to config file. TODO: decide whether to upload file to server (e.g. call generateConfig).
+     * to config file. If `publish` is set to true, publish to server as well.
      */
-    saveMetadata(): void {
+    saveMetadata(publish = false): void {
         // update metadata content to existing config only if it has been successfully loaded
         const config = this.configs[this.lang];
         if (config !== undefined) {
@@ -565,6 +657,10 @@ export default class MetadataEditorV extends Vue {
                 this.configFileStructure.assets[this.lang].file(this.logoImage?.name, this.logoImage);
             } else {
                 config.introSlide.logo.src = this.metadata.logoName;
+            }
+
+            if (publish) {
+                this.generateConfig();
             }
         }
         if (this.$modals.isActive('metadata-edit-modal')) {
@@ -666,7 +762,8 @@ export default class MetadataEditorV extends Vue {
                 configFileStructure: this.configFileStructure,
                 sourceCounts: this.sourceCounts,
                 metadata: this.metadata as any,
-                slides: this.slides as any
+                slides: this.slides as any,
+                editExisting: this.editExisting as any
             };
             this.$router.push({ name: 'editor', params: props });
         }
@@ -702,6 +799,33 @@ export default class MetadataEditorV extends Vue {
             this.error = true;
         } else {
             this.generateNewConfig();
+        }
+    }
+
+    /**
+     * Update the unsaved changes value to the payload.
+     */
+    updateSaveStatus(payload: boolean) {
+        this.unsavedChanges = payload;
+    }
+
+    refreshConfig() {
+        // Re-fetch the product from the server.
+        if (this.editExisting) {
+            this.loadEditor = false;
+            this.loadStatus = 'loading';
+            this.generateRemoteConfig();
+        } else {
+            this.generateNewConfig();
+            setTimeout(() => {
+                this.$router.push({
+                    name: 'metadata',
+                    params: {
+                        lang: this.lang,
+                        editExisting: false as any
+                    }
+                });
+            }, 100);
         }
     }
 }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -31,6 +31,8 @@ editor.next,Next,1,Suivant,1
 editor.preview,Preview,1,Aperçu,0
 editor.saveChanges,Save Changes,1,Sauvegarder les Modifications,0
 editor.savingChanges,Saving...,1,Sauver...,0
+editor.resetChanges,Reset Changes,1,Reset Changes,0
+editor.refreshChanges.modal,"Are you sure you want to reload the product? All unsaved changes will be lost.",1,"Are you sure you want to reload the product? All unsaved changes will be lost.",0
 editor.changeLang.modal,"Are you sure you want to switch languages? All unsaved changes will be lost.",1,"Are you sure you want to switch languages? All unsaved changes will be lost.",0
 editor.frenchConfig,View French Config,1,Afficher la configuration française,0
 editor.englishConfig,View English Config,1,Afficher la configuration en anglais,0


### PR DESCRIPTION
Closes #155 and #149

Decided to merge the fixes for #155 and #149 into the same PR because they mostly required the same change.

Changes in this PR:
- [ ] The `Save Changes` button when editing product metadata will now upload the product changes to the server.
- [ ] Removed the `Save Changes` button when creating a new product, as the config is not yet created.
- [ ] Fixed a pre-existing issue (not logged) where opening the metadata popup in the main editor and then saving the product seemed to overwrite the logo.
- [ ] When the unsaved changes indicator is displayed, a `refresh config` button will also appear that will reset the configuration to whatever is saved on the server.
- [ ] When pressing the `refresh config` button for a new and unsaved product, a new fresh config is generated
- [ ] Saving a new config will set `editExisting` to true

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/175)
<!-- Reviewable:end -->
