### PR TITLE
Allow links to target `_self`

### DIFF
--- a/src/components/editor/text-editor.vue
+++ b/src/components/editor/text-editor.vue
@@ -61,14 +61,28 @@ export default class TextEditorV extends Vue {
             icon: 'v-md-icon-link',
             menus: [
                 {
-                    name: 'Add External Link',
-                    text: 'Add External Link',
+                    name: 'Add External Link (New Tab)',
+                    text: 'Add External Link (New Tab)',
                     action(editor: any) {
                         editor.insert((selected: string) => {
                             const content = selected || ``;
 
                             return {
                                 text: `[${content}](http://)`,
+                                selected: selected
+                            };
+                        });
+                    }
+                },
+                {
+                    name: 'Add External Link (Same Tab)',
+                    text: 'Add External Link (Same Tab)',
+                    action(editor: any) {
+                        editor.insert((selected: string) => {
+                            const content = selected || ``;
+
+                            return {
+                                text: `<a href='http://' target='_self'>${content}</a>`,
                                 selected: selected
                             };
                         });


### PR DESCRIPTION
Closes #173.

Added an option in the markdown text editor to add a link that opens in the same tab.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/180)
<!-- Reviewable:end -->
