### PR TITLE
Fix multiple slideshow panels in dynamic slide

### DIFF
--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -220,7 +220,7 @@ export default class DynamicEditorV extends Vue {
 
         const newConfig = {
             id: this.newSlideName,
-            panel: this.startingConfig[this.newSlideType as keyof DefaultConfigs]
+            panel: JSON.parse(JSON.stringify(this.startingConfig[this.newSlideType as keyof DefaultConfigs]))
         };
 
         this.newSlideName = '';


### PR DESCRIPTION
Closes #177.

Updating a chart or slideshow panel in a dynamic slide will no longer result in all the other panels of the same type getting updated.