### PR TITLE
Lazy Image Loading

### DIFF
--- a/src/components/panels/image-panel.vue
+++ b/src/components/panels/image-panel.vue
@@ -2,7 +2,8 @@
     <div class="graphic self-start justify-center flex flex-col h-full align-middle py-5 w-full">
         <full-screen :expandable="config.fullscreen" :type="config.type">
             <img
-                :src="config.src"
+                ref="img"
+                :src="slideIdx > 2 ? '' : config.src"
                 :class="config.class"
                 :alt="config.altText || ''"
                 :style="{ width: `${config.width}px`, height: `${config.height}px` }"
@@ -32,8 +33,25 @@ import FullscreenV from '@/components/panels/helpers/fullscreen.vue';
 })
 export default class ImagePanelV extends Vue {
     @Prop() config!: ImagePanel;
+    @Prop() slideIdx!: number;
 
     md = new MarkdownIt({ html: true });
+
+    observer =
+        this.slideIdx > 2
+            ? new IntersectionObserver(([image]) => {
+                  // lazy load images
+                  if (image.isIntersecting) {
+                      (this.$refs.img as Element).setAttribute('src', this.config.src);
+                      this.$forceUpdate();
+                      this.observer!.disconnect();
+                  }
+              })
+            : undefined;
+
+    mounted(): void {
+        this.observer?.observe(this.$refs.img as Element);
+    }
 }
 </script>
 

--- a/src/components/panels/slideshow-panel.vue
+++ b/src/components/panels/slideshow-panel.vue
@@ -6,12 +6,13 @@
             :key="config.images[0].src"
         ></image-panel>
     </div>
-    <div v-else class="carousel self-start px-10 my-8 bg-gray-200_ h-28_" :style="{ width: `${width}px` }">
+    <div ref="images" v-else class="carousel self-start px-10 my-8 bg-gray-200_ h-28_" :style="{ width: `${width}px` }">
         <full-screen :expandable="config.fullscreen" :type="config.type">
             <hooper ref="carousel" v-if="width !== -1" class="h-full bg-white" :infiniteScroll="config.loop">
                 <slide v-for="(image, index) in config.images" :key="index" :index="index" class="self-center">
                     <img
-                        :src="image.src"
+                        :data-src="image.src"
+                        :src="slideIdx > 2 ? '' : image.src"
                         :alt="image.altText || ''"
                         :style="{ width: `${image.width}px`, height: `${image.height}px` }"
                         class="m-auto story-graphic carousel-image"
@@ -52,10 +53,25 @@ import ImagePanelV from '@/components/panels/image-panel.vue';
 export default class SlideshowPanelV extends Vue {
     @Prop() config!: SlideshowPanel;
     @Prop() configFileStructure!: any;
+    @Prop() slideIdx!: number;
 
     width = -1;
 
     md = new MarkdownIt({ html: true });
+
+    observer =
+        this.slideIdx > 2
+            ? new IntersectionObserver(([image]) => {
+                  // lazy load images
+                  if (image.isIntersecting) {
+                      (this.$refs.images as Element).querySelectorAll('.carousel-image').forEach((img) => {
+                          img.setAttribute('src', img.getAttribute('data-src')!);
+                      });
+                      this.$forceUpdate();
+                      this.observer!.disconnect();
+                  }
+              })
+            : undefined;
 
     mounted(): void {
         setTimeout(() => {
@@ -76,6 +92,10 @@ export default class SlideshowPanelV extends Vue {
                         });
                 }
             });
+        }
+
+        if (this.config.images.length > 1) {
+            this.observer?.observe(this.$refs.images as Element);
         }
     }
 }


### PR DESCRIPTION
Will close [#315](https://github.com/ramp4-pcar4/story-ramp/issues/315)

Image panels are now lazily-loaded, meaning that they are only downloaded once a user has reached the part of the Storyline where the image sits.

Edit: For some reason the page rendered differently in the build, which caused errors with the `IntersectionObserver`. Now there is a buffer where images are only lazily-loaded after the first 3 slides, and images on the first 3 slides are loaded normally.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/194)
<!-- Reviewable:end -->
