### PR TITLE
Fix wrong config language being selected after metadata

### DIFF
--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -33,7 +33,7 @@ editor.saveChanges,Save Changes,1,Sauvegarder les Modifications,0
 editor.savingChanges,Saving...,1,Sauver...,0
 editor.resetChanges,Reset Changes,1,Reset Changes,0
 editor.refreshChanges.modal,"Are you sure you want to reload the product? All unsaved changes will be lost.",1,"Are you sure you want to reload the product? All unsaved changes will be lost.",0
-editor.changeLang.modal,"Are you sure you want to switch languages? All unsaved changes will be lost.",1,"Are you sure you want to switch languages? All unsaved changes will be lost.",0
+editor.changeLang.modal,"Are you sure you want to switch languages? Unsaved changes may be lost.",1,"Are you sure you want to switch languages? Unsaved changes may be lost.",0
 editor.frenchConfig,View French Config,1,Afficher la configuration française,0
 editor.englishConfig,View English Config,1,Afficher la configuration en anglais,0
 editor.returnToLanding,Return to Landing,1,Return to Landing,0


### PR DESCRIPTION
Closes #181 

Changed lang to configLang in metadata-editor, it was very confusing to me before for whatever reason.

On language switch we now check for an existing config. If a config exists we directly use it rather than trying to load from the zip, this now lets some unsaved changes survive the lang switching process. I tried to change the saving method to handle both configs fully but ended up confused so resorted to just changing the text on the prompt.

Also the check for the config gets rid of the malformed request error while switching in metadata.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/198)
<!-- Reviewable:end -->
