### PR TITLE
add logo alt text; fix app breaking when missing logo

### DIFF
--- a/src/components/editor/helpers/metadata-content.vue
+++ b/src/components/editor/helpers/metadata-content.vue
@@ -43,6 +43,16 @@
             style="display: none"
         />
         <br />
+        <label>{{ $t('editor.logoAltText') }}:</label>
+        <input type="text" name="logoAltText" :value="metadata.logoAltText" @change="metadataChanged" class="w-2/3" />
+        <br />
+        <label class="mb-5"></label>
+        <p class="inline-block">
+            <i>
+                {{ $t('editor.logoAltText.desc') }}
+            </i>
+        </p>
+        <br />
         <label>{{ $t('editor.contextLink') }}:</label>
         <input type="text" name="contextLink" :value="metadata.contextLink" @change="metadataChanged" class="w-2/3" />
         <br />
@@ -80,6 +90,7 @@ export default class MetadataEditorV extends Vue {
         introSubtitle: string;
         logoName: string;
         logoPreview: string;
+        logoAltText: string;
         contextLink: string;
         contextLabel: string;
         dateModified: string;

--- a/src/components/story/introduction.vue
+++ b/src/components/story/introduction.vue
@@ -1,6 +1,11 @@
 <template>
     <div class="py-24 mx-auto text-center max-w-9xl" id="intro">
-        <img class="inline-block" :src="config.logo.src" :alt="config.logo.altText" />
+        <img
+            v-if="config.logo && config.logo.src"
+            class="inline-block"
+            :src="config.logo.src"
+            :alt="config.logo.altText"
+        />
 
         <h1 class="m-10 text-5xl font-bold text-gray-800">
             {{ config.title }}
@@ -80,15 +85,19 @@ export default class IntroV extends Vue {
     mounted(): void {
         // obtain logo from ZIP file if it exists
         if (this.configFileStructure) {
-            const logoSrc = `${this.config.logo.src.substring(this.config.logo.src.indexOf('/') + 1)}`;
-            if (this.configFileStructure.zip.file(logoSrc)) {
-                this.configFileStructure.zip
-                    .file(logoSrc)
-                    .async('blob')
-                    .then((res: any) => {
-                        this.config.logo.src = URL.createObjectURL(res);
-                        this.$forceUpdate();
-                    });
+            const logo = this.config.logo?.src;
+
+            if (logo) {
+                const logoSrc = `${logo.substring(logo.indexOf('/') + 1)}`;
+                if (this.configFileStructure.zip.file(logoSrc)) {
+                    this.configFileStructure.zip
+                        .file(logoSrc)
+                        .async('blob')
+                        .then((res: any) => {
+                            this.config.logo.src = URL.createObjectURL(res);
+                            this.$forceUpdate();
+                        });
+                }
             }
         }
     }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -21,6 +21,8 @@ editor.uuid,UUID,1,UUID,0
 editor.title,Title,1,Titre,0
 editor.logo,Logo,1,Logo,0
 editor.logoPreview,Logo Preview,1,Logo Preview,0
+editor.logoAltText,Logo Alt Text,1,Description alternative du logo,0
+editor.logoAltText.desc,"For accessibility purposes, provide description text for the logo.",1,"Pour des raisons d'accessibilité, fournissez un texte descriptif pour le logo.",0
 editor.contextLink,Context Link,1,Lien contextuel,0
 editor.contextLabel,Context Label,1,Libellé de contexte,0
 editor.dateModified,Date Modified,1,Date modifiée,0


### PR DESCRIPTION
Closes #207 (1/2)

This PR adds an alt text field for the logo. It also fixes a bug where the app will crash if no logo section is provided in the config.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/214)
<!-- Reviewable:end -->
