### PR TITLE
Fix project TS warnings

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -11,7 +11,7 @@ import { Route } from 'vue-router';
 @Component({})
 export default class App extends Vue {
     @Watch('$route', { immediate: true })
-    onRouteUpdate(to: Route, from: Route) {
+    onRouteUpdate(to: Route): void {
         this.$i18n.locale = to.params.lang ?? 'en';
         document.title = this.$t(to.meta?.title).toString();
     }

--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -60,7 +60,7 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
-import { ChartConfig } from '@/definitions';
+import { ChartConfig, ChartPanel, ConfigFileStructure, Highchart, SourceCounts } from '@/definitions';
 import ChartPanelV from '@/components/panels/chart-panel.vue';
 import ChartPreviewV from '@/components/editor/helpers/chart-preview.vue';
 import ConfirmationModalV from '@/components/editor/helpers/confirmation-modal.vue';
@@ -75,17 +75,15 @@ import draggable from 'vuedraggable';
     }
 })
 export default class ChartEditorV extends Vue {
-    @Prop() panel!: any;
-    @Prop() configFileStructure!: any;
+    @Prop() panel!: ChartPanel;
+    @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
-    @Prop() sourceCounts!: any;
-
-    $modals: any;
+    @Prop() sourceCounts!: SourceCounts;
 
     edited = false;
 
     chartConfigs = [] as Array<ChartConfig>;
-    modalEditor = {} as any;
+    modalEditor = {} as typeof highed.ModalEditor;
 
     mounted(): void {
         // attach highcharts modal editor to summoner node
@@ -99,8 +97,7 @@ export default class ChartEditorV extends Vue {
                         options: 'plugins csv json'
                     }
                 },
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                (chart: any) => {
+                (chart: Highchart) => {
                     this.createNewChart(chart.toString());
                 }
             );
@@ -153,8 +150,7 @@ export default class ChartEditorV extends Vue {
             const chartSrc = `${this.configFileStructure.uuid}/charts/en/${chart.title.text}.json`;
             const chartConfig = {
                 name: chart.title.text,
-                src: chartSrc,
-                config: chart
+                src: chartSrc
             };
 
             if (this.sourceCounts[chartSrc]) {

--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -87,12 +87,25 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop, Watch } from 'vue-property-decorator';
+import { Component, Vue, Prop } from 'vue-property-decorator';
+import {
+    ChartConfig,
+    ChartPanel,
+    ConfigFileStructure,
+    DefaultConfigs,
+    DynamicChildItem,
+    DynamicPanel,
+    ImagePanel,
+    MapPanel,
+    PanelType,
+    SlideshowPanel,
+    SourceCounts
+} from '@/definitions';
+
 import ChartEditorV from './chart-editor.vue';
 import ImageEditorV from './image-editor.vue';
 import TextEditorV from './text-editor.vue';
 import MapEditorV from './map-editor.vue';
-import { DefaultConfigs, PanelType } from '@/definitions';
 
 @Component({
     components: {
@@ -104,12 +117,12 @@ import { DefaultConfigs, PanelType } from '@/definitions';
     }
 })
 export default class DynamicEditorV extends Vue {
-    @Prop() panel!: any;
-    @Prop() configFileStructure!: any;
+    @Prop() panel!: DynamicPanel;
+    @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
-    @Prop() sourceCounts!: any;
+    @Prop() sourceCounts!: SourceCounts;
 
-    editors = {
+    editors: Record<string, string> = {
         text: 'text-editor',
         image: 'image-editor',
         slideshow: 'image-editor',
@@ -152,8 +165,8 @@ export default class DynamicEditorV extends Vue {
     newSlideName = '';
     newSlideType = 'text';
 
-    get idUsed(): any {
-        return this.panel.children.some((ch: any) => ch.id === this.newSlideName);
+    get idUsed(): boolean {
+        return this.panel.children.some((ch: DynamicChildItem) => ch.id === this.newSlideName);
     }
 
     changePanel(target: string): void {
@@ -168,46 +181,54 @@ export default class DynamicEditorV extends Vue {
 
         // Image Panel to Slideshow Panel Conversion
         if (this.panel.children[this.editingSlide].panel.type === 'image') {
-            this.panel.children[this.editingSlide].panel = {
-                type: 'slideshow',
-                images: [this.panel.children[this.editingSlide].panel]
+            (this.panel.children[this.editingSlide].panel as SlideshowPanel) = {
+                type: PanelType.Slideshow,
+                images: [this.panel.children[this.editingSlide].panel as ImagePanel]
             };
         }
     }
 
-    removeSlide(item: any): void {
-        const panel = this.panel.children.find((panel: any, idx: number) => idx === item).panel;
+    removeSlide(item: number): void {
+        const panel = this.panel.children.find((panel: DynamicChildItem, idx: number) => idx === item)?.panel;
 
         // Update source counts based on which panel is removed.
-        switch (panel.type) {
-            case 'map':
-                this.sourceCounts[panel.config] -= 1;
-                if (this.sourceCounts[panel.config] === 0) {
-                    this.configFileStructure.zip.remove(`${panel.config.substring(panel.config.indexOf('/') + 1)}`);
+        switch (panel?.type) {
+            case 'map': {
+                const mapPanel = panel as MapPanel;
+                this.sourceCounts[mapPanel.config] -= 1;
+                if (this.sourceCounts[mapPanel.config] === 0) {
+                    this.configFileStructure.zip.remove(
+                        `${mapPanel.config.substring(mapPanel.config.indexOf('/') + 1)}`
+                    );
                 }
                 break;
+            }
 
-            case 'chart':
-                panel.charts.forEach((chart: any) => {
+            case 'chart': {
+                const chartPanel = panel as ChartPanel;
+                chartPanel.charts.forEach((chart: ChartConfig) => {
                     this.sourceCounts[chart.src] -= 1;
                     if (this.sourceCounts[chart.src] === 0) {
                         this.configFileStructure.zip.remove(`${chart.src.substring(chart.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;
+            }
 
-            case 'slideshow':
-                panel.images.forEach((image: any) => {
+            case 'slideshow': {
+                const slideshowPanel = panel as SlideshowPanel;
+                slideshowPanel.images.forEach((image: ImagePanel) => {
                     this.sourceCounts[image.src] -= 1;
                     if (this.sourceCounts[image.src] === 0) {
                         this.configFileStructure.zip.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;
+            }
         }
 
         // Remove the panel itself.
-        this.panel.children = this.panel.children.filter((panel: any, idx: number) => idx !== item);
+        this.panel.children = this.panel.children.filter((panel: DynamicChildItem, idx: number) => idx !== item);
 
         // If the slide being removed is the currently selected slide, unselect it.
         if (this.editingSlide === item) {

--- a/src/components/editor/helpers/chart-preview.vue
+++ b/src/components/editor/helpers/chart-preview.vue
@@ -61,7 +61,14 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
-import { ChartConfig, DQVChartConfig, PieSeriesData, PieDataRow, LineSeriesData } from '@/definitions';
+import {
+    ChartConfig,
+    DQVChartConfig,
+    PieSeriesData,
+    PieDataRow,
+    LineSeriesData,
+    ConfigFileStructure
+} from '@/definitions';
 import ChartV from '@/components/panels/helpers/chart.vue';
 
 @Component({
@@ -71,13 +78,13 @@ import ChartV from '@/components/panels/helpers/chart.vue';
 })
 export default class ChartPreviewV extends Vue {
     @Prop() chart!: ChartConfig;
-    @Prop() configFileStructure!: any;
+    @Prop() configFileStructure!: ConfigFileStructure;
 
     loading = true;
     chartIdx = 0;
     chartConfig = {};
     chartName = '';
-    modalEditor: any = undefined;
+    modalEditor: typeof highed.ModalEditor = undefined;
 
     mounted(): void {
         this.chartConfig = this.chart;
@@ -104,7 +111,7 @@ export default class ChartPreviewV extends Vue {
                 },
                 defaultChartOptions: chartOptions
             },
-            (newChart: any) => {
+            (newChart: string) => {
                 const chart = JSON.parse(newChart);
                 const chartConfig = {
                     name: chart.title.text,

--- a/src/components/editor/helpers/confirmation-modal.vue
+++ b/src/components/editor/helpers/confirmation-modal.vue
@@ -18,8 +18,6 @@ export default class MetadataEditorV extends Vue {
     @Prop() message!: string;
     @Prop() name!: string;
 
-    $modals: any;
-
     onOk(): void {
         this.$emit('Ok');
         this.$modals.hide(this.name);

--- a/src/components/editor/helpers/metadata-content.vue
+++ b/src/components/editor/helpers/metadata-content.vue
@@ -89,8 +89,12 @@ export default class MetadataEditorV extends Vue {
         document.getElementById('logoUpload')?.click();
     }
 
-    metadataChanged(event: any): void {
-        this.$emit('metadata-changed', event.target.name, event.target.value);
+    metadataChanged(event: Event): void {
+        this.$emit(
+            'metadata-changed',
+            (event.target as HTMLInputElement).name,
+            (event.target as HTMLInputElement).value
+        );
     }
 
     removeLogo(): void {

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -68,8 +68,8 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
+import { ImagePanel, ImageFile, ConfigFileStructure, SourceCounts, SlideshowPanel, PanelType } from '@/definitions';
 import draggable from 'vuedraggable';
-import { ImagePanel, ImageFile } from '@/definitions';
 import ImagePreviewV from '@/components/editor/helpers/image-preview.vue';
 
 @Component({
@@ -79,10 +79,10 @@ import ImagePreviewV from '@/components/editor/helpers/image-preview.vue';
     }
 })
 export default class ImageEditorV extends Vue {
-    @Prop() panel!: any;
-    @Prop() configFileStructure!: any;
+    @Prop() panel!: SlideshowPanel;
+    @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
-    @Prop() sourceCounts!: any;
+    @Prop() sourceCounts!: SourceCounts;
 
     dragging = false;
     edited = false;
@@ -107,18 +107,18 @@ export default class ImageEditorV extends Vue {
                 const assetSrc = `${image.src.substring(image.src.indexOf('/') + 1)}`;
                 const filename = image.src.replace(/^.*[\\/]/, '');
 
-                this.imagePreviewPromises.push(
-                    this.configFileStructure.zip
-                        .file(assetSrc)
-                        .async('blob')
-                        .then((res: any) => {
+                const assetFile = this.configFileStructure.zip.file(assetSrc);
+                if (assetFile) {
+                    this.imagePreviewPromises.push(
+                        assetFile.async('blob').then((res: Blob) => {
                             return {
                                 ...image,
                                 id: filename ? filename : image.src,
                                 src: URL.createObjectURL(res)
-                            };
+                            } as ImageFile;
                         })
-                );
+                    );
+                }
             });
 
             // Once all images have been retrieved, display them.
@@ -127,7 +127,7 @@ export default class ImageEditorV extends Vue {
                 this.imagePreviewsLoading = false;
             });
 
-            this.slideshowCaption = this.panel.caption;
+            this.slideshowCaption = this.panel.caption as string;
         }
     }
 
@@ -208,7 +208,8 @@ export default class ImageEditorV extends Vue {
             this.panel.images = this.imagePreviews.map((imageFile: ImageFile) => {
                 return {
                     ...imageFile,
-                    src: `${this.configFileStructure.uuid}/assets/en/${imageFile.id}`
+                    src: `${this.configFileStructure.uuid}/assets/en/${imageFile.id}`,
+                    type: PanelType.Image
                 };
             });
             this.panel.caption = this.slideshowCaption ?? undefined;

--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -121,7 +121,6 @@
                 :configLang="lang"
                 :saving="saving"
                 :unsavedChanges="unsavedChanges"
-                :editExisting="editExisting"
                 @save-changes="generateConfig"
                 @save-status="updateSaveStatus"
                 @refresh-config="refreshConfig"
@@ -162,17 +161,22 @@
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
 import { Route } from 'vue-router';
+import { Dictionary } from 'vue-router/types/router';
+import { AxiosResponse } from 'axios';
 import {
     AudioPanel,
     BasePanel,
     ChartConfig,
     ChartPanel,
+    ConfigFileStructure,
     DynamicChildItem,
     DynamicPanel,
     ImagePanel,
     MapPanel,
+    MetadataContent,
     Slide,
     SlideshowPanel,
+    SourceCounts,
     StoryRampConfig
 } from '@/definitions';
 
@@ -186,6 +190,18 @@ import SlideTocV from './slide-toc.vue';
 import MetadataContentV from './helpers/metadata-content.vue';
 import ConfirmationModalV from './helpers/confirmation-modal.vue';
 import EditorV from './editor.vue';
+
+interface RouteParams {
+    uid: string;
+    configLang: string;
+    configs: {
+        [key: string]: StoryRampConfig | undefined;
+    };
+    configFileStructure: ConfigFileStructure;
+    metadata: MetadataContent;
+    slides: Slide[];
+    sourceCounts: SourceCounts;
+}
 
 @Component({
     components: {
@@ -203,7 +219,7 @@ export default class MetadataEditorV extends Vue {
     configs: {
         [key: string]: StoryRampConfig | undefined;
     } = { en: undefined, fr: undefined };
-    configFileStructure: any = undefined;
+    configFileStructure: ConfigFileStructure | undefined = undefined;
     loadStatus = 'waiting';
     loadEditor = false;
     error = false; // whether an error has occurred
@@ -217,8 +233,7 @@ export default class MetadataEditorV extends Vue {
     // Form properties.
     uuid = '';
     logoImage: undefined | File = undefined;
-    $modals: any;
-    metadata = {
+    metadata: MetadataContent = {
         title: '',
         introTitle: '',
         introSubtitle: '',
@@ -233,7 +248,7 @@ export default class MetadataEditorV extends Vue {
         uuid: true
     };
     slides: Slide[] = [];
-    sourceCounts: any = {};
+    sourceCounts: SourceCounts = {};
 
     created(): void {
         // Generate UUID for new product
@@ -260,37 +275,42 @@ export default class MetadataEditorV extends Vue {
 
             // Properties already passed in props, load editor view (could use a refactor to clean up this workflow process)
             if (this.$route.params.configs && this.$route.params.configFileStructure) {
-                this.configs = this.$route.params.configs as any;
-                this.configFileStructure = this.$route.params.configFileStructure;
-                this.metadata = this.$route.params.metadata as any;
-                this.slides = this.$route.params.slides as any;
-                this.sourceCounts = this.$route.params.sourceCounts;
+                // declare props typing to get around TS warnings
+                const route = this.$route as Route & {
+                    params: RouteParams;
+                };
+
+                this.configs = route.params.configs;
+                this.configFileStructure = route.params.configFileStructure;
+                this.metadata = route.params.metadata;
+                this.slides = route.params.slides;
+                this.sourceCounts = route.params.sourceCounts;
 
                 // Load product logo (if provided).
-                const logo = this.configs[this.lang]!.introSlide.logo.src;
+                const logo = (this.configs[this.lang] as StoryRampConfig).introSlide.logo.src;
                 const logoSrc = `assets/${this.lang}/${this.metadata.logoName}`;
 
                 if (logo) {
-                    if (this.configFileStructure.zip.file(logoSrc)) {
-                        this.configFileStructure.zip
-                            .file(logoSrc)
-                            .async('blob')
-                            .then((img: any) => {
-                                this.logoImage = new File([img], this.metadata.logoName);
-                                this.metadata.logoPreview = URL.createObjectURL(img);
-                                this.loadStatus = 'loaded';
-                            });
+                    const logoFile = this.configFileStructure?.zip.file(logoSrc);
+                    if (logoFile) {
+                        logoFile.async('blob').then((img: Blob) => {
+                            this.logoImage = new File([img], this.metadata.logoName);
+                            this.metadata.logoPreview = URL.createObjectURL(img);
+                            this.loadStatus = 'loaded';
+                        });
                     } else {
                         // Fill in the field with this value whether it exists or not.
                         this.metadata.logoName = logo;
 
                         // If it doesn't exist, maybe it's a remote file?
-                        fetch(logo).then((data: any) => {
+                        fetch(logo).then((data: Response) => {
                             if (data.status !== 404) {
-                                this.logoImage = new File([data], this.metadata.logoName);
-                                this.metadata.logoPreview = logo;
+                                data.blob().then((blob: Blob) => {
+                                    this.logoImage = new File([blob], this.metadata.logoName);
+                                    this.metadata.logoPreview = logo;
+                                    this.loadStatus = 'loaded';
+                                });
                             }
-                            this.loadStatus = 'loaded';
                         });
                     }
                 } else {
@@ -318,11 +338,6 @@ export default class MetadataEditorV extends Vue {
         this.configs[this.lang] = this.configHelper();
         const config = this.configs[this.lang] as StoryRampConfig;
 
-        config.title = this.metadata.title;
-        config.introSlide.title = this.metadata.introTitle;
-        config.introSlide.subtitle = this.metadata.introSubtitle;
-        config.slides = [];
-
         // Set the source of the product logo
         if (!this.metadata.logoName) {
             config.introSlide.logo.src = '';
@@ -331,6 +346,7 @@ export default class MetadataEditorV extends Vue {
         } else {
             config.introSlide.logo.src = this.metadata.logoName;
         }
+        config.slides = [];
 
         const otherLang = this.lang === 'en' ? 'fr' : 'en';
         this.configs[otherLang] = config;
@@ -349,16 +365,15 @@ export default class MetadataEditorV extends Vue {
     }
 
     configHelper(): StoryRampConfig {
-        // TODO: require user to input these fields instead of defaulting (speeds up testing purposes for now)
         return {
-            title: 'Test Config',
-            lang: 'en',
+            title: this.metadata.title,
+            lang: this.lang,
             introSlide: {
                 logo: {
                     src: ''
                 },
-                title: '',
-                subtitle: ''
+                title: this.metadata.introTitle,
+                subtitle: this.metadata.introSubtitle
             },
             slides: [],
             contextLabel: this.metadata.contextLabel,
@@ -375,7 +390,7 @@ export default class MetadataEditorV extends Vue {
 
         // Attempt to fetch the project from the server.
         fetch(`http://localhost:6040/retrieve/${this.uuid}`)
-            .then((res: any) => {
+            .then((res: Response) => {
                 if (res.status === 404) {
                     // Product not found.
                     this.$message.error(`The requested UUID '${this.uuid ?? ''}' does not exist.`);
@@ -385,7 +400,7 @@ export default class MetadataEditorV extends Vue {
                 } else {
                     const configZip = new JSZip();
                     // Files retrieved. Convert them into a JSZip object.
-                    res.blob().then((file: any) => {
+                    res.blob().then((file: Blob) => {
                         configZip.loadAsync(file).then(() => {
                             this.configFileStructureHelper(configZip);
                         });
@@ -451,7 +466,7 @@ export default class MetadataEditorV extends Vue {
      * Generates or loads a ZIP file and creates required project folders if needed.
      * Returns an object that makes it easy to access any specific folder.
      */
-    configFileStructureHelper(configZip: any, uploadLogo?: File | undefined): void {
+    configFileStructureHelper(configZip: typeof JSZip, uploadLogo?: File | undefined): void {
         const assetsFolder = configZip.folder('assets');
         const chartsFolder = configZip.folder('charts');
         const rampConfigFolder = configZip.folder('ramp-config');
@@ -459,7 +474,7 @@ export default class MetadataEditorV extends Vue {
         this.configFileStructure = {
             uuid: this.uuid,
             zip: configZip,
-            configs: this.configs,
+            configs: (this.configs as unknown) as { [key: string]: StoryRampConfig },
             assets: {
                 en: assetsFolder.folder('en'),
                 fr: assetsFolder.folder('fr')
@@ -493,18 +508,14 @@ export default class MetadataEditorV extends Vue {
         }
 
         try {
-            await this.configFileStructure.zip
-                .file(`${this.uuid}_en.json`)
-                .async('string')
-                .then((res: any) => {
-                    this.configs['en'] = JSON.parse(res);
-                });
-            await this.configFileStructure.zip
-                .file(`${this.uuid}_fr.json`)
-                .async('string')
-                .then((res: any) => {
-                    this.configs['fr'] = JSON.parse(res);
-                });
+            const enFile = this.configFileStructure?.zip.file(`${this.uuid}_en.json`);
+            const frFile = this.configFileStructure?.zip.file(`${this.uuid}_fr.json`);
+            await enFile?.async('string').then((res: string) => {
+                this.configs['en'] = JSON.parse(res);
+            });
+            await frFile?.async('string').then((res: string) => {
+                this.configs['fr'] = JSON.parse(res);
+            });
         } catch {
             this.$message.error(`The requested product '${this.uuid ?? ''}' is malformed.`);
             this.loadStatus = 'waiting';
@@ -556,27 +567,28 @@ export default class MetadataEditorV extends Vue {
         // Fetch the logo from the folder (if it exists).
         const logoSrc = `${logo.substring(logo.indexOf('/') + 1)}`;
         const logoName = `${logo.split('/')[logo.split('/').length - 1]}`;
-        if (this.configFileStructure.zip.file(logoSrc)) {
-            this.configFileStructure.zip
-                .file(logoSrc)
-                .async('blob')
-                .then((img: any) => {
-                    this.logoImage = new File([img], logoName);
-                    this.metadata.logoPreview = URL.createObjectURL(img);
-                    this.metadata.logoName = logoName;
-                    this.loadStatus = 'loaded';
-                });
+        const logoFile = this.configFileStructure?.zip.file(logoSrc);
+
+        if (logoFile) {
+            logoFile.async('blob').then((img: Blob) => {
+                this.logoImage = new File([img], logoName);
+                this.metadata.logoPreview = URL.createObjectURL(img);
+                this.metadata.logoName = logoName;
+                this.loadStatus = 'loaded';
+            });
         } else {
             // Fill in the field with this value whether it exists or not.
             this.metadata.logoName = logo;
 
             // If it doesn't exist, maybe it's a remote file?
-            fetch(logo).then((data: any) => {
+            fetch(logo).then((data: Response) => {
                 if (data.status !== 404) {
-                    this.logoImage = new File([data], logoName);
-                    this.metadata.logoPreview = logo;
+                    data.blob().then((blob: Blob) => {
+                        this.logoImage = new File([blob], logoName);
+                        this.metadata.logoPreview = logo;
+                        this.loadStatus = 'loaded';
+                    });
                 }
-                this.loadStatus = 'loaded';
             });
         }
     }
@@ -585,28 +597,28 @@ export default class MetadataEditorV extends Vue {
      * Called when `Save Changes` is pressed. Re-generates the Storylines configuration file
      * with the new changes, then generates and submits the product file to the server.
      */
-    generateConfig(): StoryRampConfig {
+    generateConfig(): ConfigFileStructure {
         this.saving = true;
         // save current slide final changes before generating config file
         if (this.$refs.slide !== undefined) {
-            (this.$refs.slide as any).saveChanges();
+            (this.$refs.slide as SlideEditorV).saveChanges();
         }
 
         // Update the configuration file.
         const fileName = `${this.uuid}_${this.lang}.json`;
         const formattedConfigFile = JSON.stringify(this.configs[this.lang], null, 4);
 
-        this.configFileStructure.zip.file(fileName, formattedConfigFile);
+        this.configFileStructure?.zip.file(fileName, formattedConfigFile);
 
         // Upload the ZIP file.
-        this.configFileStructure.zip.generateAsync({ type: 'blob' }).then((content: any) => {
+        this.configFileStructure?.zip.generateAsync({ type: 'blob' }).then((content: Blob) => {
             const formData = new FormData();
             formData.append('data', content, `${this.uuid}.zip`);
             const headers = { 'Content-Type': 'multipart/form-data' };
 
             axios
                 .post('http://localhost:6040/upload', formData, { headers })
-                .then((res: any) => {
+                .then((res: AxiosResponse) => {
                     res.data.files; // binary representation of the file
                     res.status; // HTTP status
                     this.unsavedChanges = false;
@@ -624,7 +636,7 @@ export default class MetadataEditorV extends Vue {
                 });
         });
 
-        return this.configFileStructure;
+        return this.configFileStructure as ConfigFileStructure;
     }
 
     updateMetadata(
@@ -632,6 +644,7 @@ export default class MetadataEditorV extends Vue {
         value: string
     ): void {
         this.metadata[key] = value;
+        this.unsavedChanges = true;
     }
 
     /**
@@ -654,7 +667,10 @@ export default class MetadataEditorV extends Vue {
                 config.introSlide.logo.src = '';
             } else if (!this.metadata.logoName.includes('http')) {
                 config.introSlide.logo.src = `${this.uuid}/assets/${this.lang}/${this.logoImage?.name}`;
-                this.configFileStructure.assets[this.lang].file(this.logoImage?.name, this.logoImage);
+                this.configFileStructure?.assets[this.lang].file(
+                    this.logoImage?.name as string,
+                    this.logoImage as File
+                );
             } else {
                 config.introSlide.logo.src = this.metadata.logoName;
             }
@@ -694,13 +710,13 @@ export default class MetadataEditorV extends Vue {
         this.lang = this.lang === 'en' ? 'fr' : 'en';
         this.loadConfig();
         if (this.loadEditor) {
-            (this.$refs.mainEditor as any).selectSlide(-1);
+            (this.$refs.mainEditor as EditorV).selectSlide(-1);
         }
     }
 
     checkUuid(): void {
         if (!this.editExisting) {
-            fetch(`http://localhost:6040/retrieve/${this.uuid}`).then((res: any) => {
+            fetch(`http://localhost:6040/retrieve/${this.uuid}`).then((res: Response) => {
                 if (res.status !== 404) {
                     this.warning = true;
                 }
@@ -755,16 +771,15 @@ export default class MetadataEditorV extends Vue {
 
     updateEditorPath(): void {
         if (this.$route.name !== 'editor') {
-            const props = {
+            const props = ({
                 uid: this.uuid,
                 configLang: this.lang,
-                configs: this.configs as any,
-                configFileStructure: this.configFileStructure,
+                configs: this.configs,
+                configFileStructure: this.configFileStructure as ConfigFileStructure,
                 sourceCounts: this.sourceCounts,
-                metadata: this.metadata as any,
-                slides: this.slides as any,
-                editExisting: this.editExisting as any
-            };
+                metadata: this.metadata,
+                slides: this.slides
+            } as unknown) as Dictionary<string>;
             this.$router.push({ name: 'editor', params: props });
         }
     }
@@ -788,7 +803,7 @@ export default class MetadataEditorV extends Vue {
         }
 
         if (this.editExisting) {
-            if (this.configs[this.lang] !== undefined && this.uuid === this.configFileStructure.uuid) {
+            if (this.configs[this.lang] !== undefined && this.uuid === this.configFileStructure?.uuid) {
                 this.loadEditor = true;
                 this.updateEditorPath();
             } else {
@@ -805,11 +820,11 @@ export default class MetadataEditorV extends Vue {
     /**
      * Update the unsaved changes value to the payload.
      */
-    updateSaveStatus(payload: boolean) {
+    updateSaveStatus(payload: boolean): void {
         this.unsavedChanges = payload;
     }
 
-    refreshConfig() {
+    refreshConfig(): void {
         // Re-fetch the product from the server.
         if (this.editExisting) {
             this.loadEditor = false;
@@ -820,12 +835,22 @@ export default class MetadataEditorV extends Vue {
             setTimeout(() => {
                 this.$router.push({
                     name: 'metadata',
-                    params: {
+                    params: ({
                         lang: this.lang,
-                        editExisting: false as any
-                    }
+                        editExisting: false
+                    } as unknown) as Dictionary<string>
                 });
             }, 100);
+        }
+    }
+
+    beforeRouteLeave(to: Route, from: Route, next: (cont?: boolean) => void): void {
+        const curEditor = this.$route.name === 'editor';
+        const confirmationMessage = 'Leave the page? Changes made may not be saved.';
+        if (this.unsavedChanges && curEditor && !window.confirm(confirmationMessage)) {
+            next(false);
+        } else {
+            next();
         }
     }
 }

--- a/src/components/editor/preview.vue
+++ b/src/components/editor/preview.vue
@@ -46,8 +46,8 @@
 </template>
 
 <script lang="ts">
-import { Component, Vue, Prop } from 'vue-property-decorator';
-import { StoryRampConfig } from '@/definitions';
+import { Component, Vue } from 'vue-property-decorator';
+import { ConfigFileStructure, StoryRampConfig } from '@/definitions';
 
 import StoryContentV from '@/components/story/story-content.vue';
 import IntroV from '@/components/story/introduction.vue';
@@ -62,7 +62,7 @@ import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
 })
 export default class StoryPreviewV extends Vue {
     config: StoryRampConfig | undefined = undefined;
-    configFileStructure: any;
+    configFileStructure: ConfigFileStructure | undefined = undefined;
     savedProduct = false;
     loadStatus = 'loading';
     activeChapterIndex = -1;
@@ -75,7 +75,7 @@ export default class StoryPreviewV extends Vue {
         if (uid) {
             this.savedProduct = true;
             // attempt to fetch saved config file from the server (TODO: setup as express route?)
-            fetch(`http://localhost:6040/retrieve/${uid}/${lang}`).then((res: any) => {
+            fetch(`http://localhost:6040/retrieve/${uid}/${lang}`).then((res: Response) => {
                 if (res.status === 404) {
                     console.error(`There does not exist a saved product with UID ${uid}.`);
                     // redirect to canada.ca 404 page on invalid URL params
@@ -89,8 +89,8 @@ export default class StoryPreviewV extends Vue {
                 }
             });
         } else {
-            this.config = (window as any).props.config;
-            this.configFileStructure = (window as any).props.configFileStructure;
+            this.config = window.props.config;
+            this.configFileStructure = window.props.configFileStructure;
             this.loadStatus = 'loaded';
         }
 

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="sticky top-20 h-auto self-start flex-grow m-5">
-        <div v-if="currentSlide !== ''">
+        <div v-if="!!currentSlide">
             <div class="flex">
                 <div class="flex flex-col">
                     <label>Slide title:</label>
@@ -235,7 +235,23 @@
 
 <script lang="ts">
 import { Component, Vue, Prop, Watch } from 'vue-property-decorator';
-import { StoryRampConfig, DefaultConfigs, PanelType } from '@/definitions';
+import {
+    StoryRampConfig,
+    DefaultConfigs,
+    PanelType,
+    ConfigFileStructure,
+    Slide,
+    SourceCounts,
+    TextPanel,
+    BasePanel,
+    MapPanel,
+    ChartPanel,
+    ChartConfig,
+    SlideshowPanel,
+    ImagePanel,
+    DynamicPanel,
+    DynamicChildItem
+} from '@/definitions';
 
 import Circle2 from 'vue-loading-spinner/src/components/Circle2.vue';
 import ChartEditorV from './chart-editor.vue';
@@ -260,21 +276,19 @@ import ConfirmationModalV from './helpers/confirmation-modal.vue';
 })
 export default class SlideEditorV extends Vue {
     config: StoryRampConfig | undefined = undefined;
-    @Prop() currentSlide!: any;
-    @Prop() configFileStructure!: any;
+    @Prop() currentSlide!: Slide;
+    @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
     @Prop() uid!: string;
     @Prop() slideIndex!: number;
     @Prop() isLast!: number;
-    @Prop() sourceCounts!: any;
-
-    $modals: any;
+    @Prop() sourceCounts!: SourceCounts;
 
     panelIndex = 0;
     newType = '';
     rightOnly = false;
 
-    editors = {
+    editors: Record<string, string> = {
         text: 'text-editor',
         image: 'image-editor',
         slideshow: 'image-editor',
@@ -298,9 +312,15 @@ export default class SlideEditorV extends Vue {
             },
             dynamic: {
                 type: PanelType.Dynamic,
-                title: this.currentSlide.panel[0] && prevType === 'text' ? this.currentSlide.panel[0].title : '',
+                title:
+                    this.currentSlide.panel[0] && prevType === 'text'
+                        ? (this.currentSlide.panel[0] as TextPanel).title
+                        : '',
                 titleTag: '',
-                content: this.currentSlide.panel[0] && prevType === 'text' ? this.currentSlide.panel[0].content : '',
+                content:
+                    this.currentSlide.panel[0] && prevType === 'text'
+                        ? (this.currentSlide.panel[0] as TextPanel).content
+                        : '',
                 children: []
             },
             slideshow: {
@@ -320,7 +340,7 @@ export default class SlideEditorV extends Vue {
         };
 
         // Before swapping panel type, update sources from the to-be-deleted config.
-        this.currentSlide.panel.forEach((panel: any) => this.removeSourceCounts(panel));
+        this.currentSlide.panel.forEach((panel: BasePanel) => this.removeSourceCounts(panel));
 
         // When switching to a dynamic panel, remove the secondary panel.
         if (newType === 'dynamic') {
@@ -332,45 +352,58 @@ export default class SlideEditorV extends Vue {
         }
     }
 
-    removeSourceCounts(panel: any): void {
+    removeSourceCounts(panel: BasePanel): void {
         // The provided panel is being removed. Update source counts accordingly.
         switch (panel.type) {
-            case 'map':
-                this.sourceCounts[panel.config] -= 1;
-                if (this.sourceCounts[panel.config] === 0) {
-                    this.configFileStructure.zip.remove(`${panel.config.substring(panel.config.indexOf('/') + 1)}`);
+            case 'map': {
+                const mapPanel = panel as MapPanel;
+                this.sourceCounts[mapPanel.config] -= 1;
+                if (this.sourceCounts[mapPanel.config] === 0) {
+                    this.configFileStructure.zip.remove(
+                        `${mapPanel.config.substring(mapPanel.config.indexOf('/') + 1)}`
+                    );
                 }
                 break;
+            }
 
-            case 'chart':
-                panel.charts.forEach((chart: any) => {
+            case 'chart': {
+                const chartPanel = panel as ChartPanel;
+                chartPanel.charts.forEach((chart: ChartConfig) => {
                     this.sourceCounts[chart.src] -= 1;
                     if (this.sourceCounts[chart.src] === 0) {
                         this.configFileStructure.zip.remove(`${chart.src.substring(chart.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;
+            }
 
-            case 'slideshow':
-                panel.images.forEach((image: any) => {
+            case 'slideshow': {
+                const slideshowPanel = panel as SlideshowPanel;
+                slideshowPanel.images.forEach((image: ImagePanel) => {
                     this.sourceCounts[image.src] -= 1;
                     if (this.sourceCounts[image.src] === 0) {
                         this.configFileStructure.zip.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
                     }
                 });
                 break;
+            }
 
-            case 'dynamic':
-                panel.children.forEach((subPanel: any) => {
+            case 'dynamic': {
+                const dynamicPanel = panel as DynamicPanel;
+                dynamicPanel.children.forEach((subPanel: DynamicChildItem) => {
                     this.removeSourceCounts(subPanel.panel);
                 });
                 break;
+            }
         }
     }
 
     saveChanges(): void {
-        if (this.$refs.editor !== undefined && typeof (this.$refs.editor as any).saveChanges === 'function') {
-            (this.$refs.editor as any).saveChanges();
+        if (
+            this.$refs.editor !== undefined &&
+            typeof (this.$refs.editor as ImageEditorV | ChartEditorV).saveChanges === 'function'
+        ) {
+            (this.$refs.editor as ImageEditorV | ChartEditorV).saveChanges();
         }
     }
 

--- a/src/components/editor/text-editor.vue
+++ b/src/components/editor/text-editor.vue
@@ -14,12 +14,17 @@
 
 <script lang="ts">
 import { Component, Vue, Prop } from 'vue-property-decorator';
+import { TextPanel } from '@/definitions';
+
+interface MDEditor {
+    insert(callback: (selected: string) => { text: string; selected: string }): void;
+}
 
 @Component({
     components: {}
 })
 export default class TextEditorV extends Vue {
-    @Prop() panel!: any;
+    @Prop() panel!: TextPanel;
 
     toolbar = {
         subsuper: {
@@ -29,7 +34,7 @@ export default class TextEditorV extends Vue {
                 {
                     name: 'Superscript',
                     text: 'Superscript',
-                    action(editor: any) {
+                    action(editor: MDEditor): void {
                         editor.insert((selected: string) => {
                             const content = selected || ``;
 
@@ -43,7 +48,7 @@ export default class TextEditorV extends Vue {
                 {
                     name: 'Subscript',
                     text: 'Subscript',
-                    action(editor: any) {
+                    action(editor: MDEditor): void {
                         editor.insert((selected: string) => {
                             const content = selected || ``;
 
@@ -63,7 +68,7 @@ export default class TextEditorV extends Vue {
                 {
                     name: 'Add External Link (New Tab)',
                     text: 'Add External Link (New Tab)',
-                    action(editor: any) {
+                    action(editor: MDEditor): void {
                         editor.insert((selected: string) => {
                             const content = selected || ``;
 
@@ -77,7 +82,7 @@ export default class TextEditorV extends Vue {
                 {
                     name: 'Add External Link (Same Tab)',
                     text: 'Add External Link (Same Tab)',
-                    action(editor: any) {
+                    action(editor: MDEditor): void {
                         editor.insert((selected: string) => {
                             const content = selected || ``;
 
@@ -91,7 +96,7 @@ export default class TextEditorV extends Vue {
                 {
                     name: 'Add Dynamic Link',
                     text: 'Add Dynamic Link',
-                    action(editor: any) {
+                    action(editor: MDEditor): void {
                         editor.insert((selected: string) => {
                             const content = selected || ``;
 

--- a/src/components/panels/helpers/time-slider.vue
+++ b/src/components/panels/helpers/time-slider.vue
@@ -143,7 +143,7 @@ export default class TimeSlider extends Vue {
             this.slider.set(sliderValues.map(() => sliderValues[0]));
         }
         // delay happens before first call
-        this.intervalID = setInterval(this.moveHandleRight, 1400);
+        this.intervalID = window.setInterval(this.moveHandleRight, 1400);
     }
 
     /**

--- a/src/components/panels/map-panel.vue
+++ b/src/components/panels/map-panel.vue
@@ -57,7 +57,7 @@ export default class MapPanelV extends Vue {
         const observer = new IntersectionObserver(
             ([e]) => {
                 if (e.isIntersecting) {
-                    this.intersectTimeoutHandle = setTimeout(() => {
+                    this.intersectTimeoutHandle = window.setTimeout(() => {
                         this.init();
                         observer.disconnect();
                         this.mapComponent?.querySelector('.map-loading')?.remove();

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,3 +1,5 @@
+import JSZip from 'jszip';
+
 export interface StoryRampConfig {
     title: string;
     lang: string;
@@ -6,6 +8,41 @@ export interface StoryRampConfig {
     contextLink: string;
     contextLabel: string;
     dateModified: string;
+}
+
+export interface ConfigFileStructure {
+    uuid: string;
+    zip: JSZip;
+    configs: { [key: string]: StoryRampConfig };
+    assets: {
+        [key: string]: JSZip;
+    };
+    charts: {
+        [key: string]: JSZip;
+    };
+    rampConfig: {
+        [key: string]: JSZip;
+    };
+}
+
+export interface SourceCounts {
+    [key: string]: number;
+}
+
+export interface MetadataContent {
+    title: string;
+    introTitle: string;
+    introSubtitle: string;
+    logoPreview: string;
+    logoName: string;
+    contextLink: string;
+    contextLabel: string;
+    dateModified: string;
+}
+
+// unofficial interface: add properties as needed (just to make TS warnings disappear)
+export interface Highchart {
+    toString(): string;
 }
 
 export interface DQVOptions {

--- a/src/shims-tsx.d.ts
+++ b/src/shims-tsx.d.ts
@@ -14,9 +14,13 @@ declare global {
     interface Window {
         config: string;
         configname: string;
+        props: any;
     }
 
     const RAMP: any;
 
-    const highed: any;
+    const highed: {
+        ready(callback: () => void): void;
+        ModalEditor: any;
+    };
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,9 +1,11 @@
 import { VuePapaParse } from 'vue-papa-parse';
 import { Route } from 'vue-router';
+import { Modals } from 'vue2-modal';
 
 declare module 'vue/types/vue' {
     interface Vue {
         $papa: VuePapaParse;
         $route: Route;
+        $modals: Modals;
     }
 }


### PR DESCRIPTION
Closes #178 

**Changes**: 
- fix all project TypeScript warnings (not including storylines viewer code)
- adds alerts when users attempt to navigate between routes with unsaved editor slide work

Testing if no functionality is broken as a sanity check would be helpful 👍 