### PR TITLE
fix long names adding a horizontal scrollbar to app

### DIFF
--- a/src/components/editor/preview.vue
+++ b/src/components/editor/preview.vue
@@ -9,7 +9,9 @@
     <div v-else-if="loadStatus === 'loaded'">
         <div class="storyramp-app bg-white" v-if="config !== undefined">
             <header class="sticky top-0 z-50 flex border-b border-black bg-gray-200 py-2 px-2 justify-between">
-                <span class="font-semibold text-lg m-1">{{ config.title }}</span>
+                <div class="w-mobile-full truncate">
+                    <span class="font-semibold text-lg m-1">{{ config.title }}</span>
+                </div>
             </header>
 
             <introduction :config="config.introSlide" :configFileStructure="configFileStructure"></introduction>
@@ -141,6 +143,16 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
 
     .prose a:not([panel])::after {
         content: url('../../assets/popout.svg');
+    }
+
+    .w-mobile-full {
+        width: 80%;
+    }
+}
+
+@media screen and (max-width: 640px) {
+    .w-mobile-full {
+        width: 100% !important;
     }
 }
 </style>

--- a/src/components/story/story.vue
+++ b/src/components/story/story.vue
@@ -25,7 +25,7 @@
                         :slides="config.slides"
                         :lang="lang"
                     />
-                    <div class="flex-none font-semibold">
+                    <div class="flex-none w-mobile-full truncate font-semibold">
                         <span class="text-lg">{{ config.title }}</span>
                     </div>
                     <div class="flex justify-end flex-auto space-x-6">
@@ -180,11 +180,18 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
     .prose a:not([panel])::after {
         content: url('../../assets/popout.svg');
     }
+
+    .w-mobile-full {
+        width: 80%;
+    }
 }
 
 @media screen and (min-width: 640px) {
     .mobile-menu {
         display: none !important;
+    }
+    .w-mobile-full {
+        width: 100% !important;
     }
 }
 </style>


### PR DESCRIPTION
Closes https://github.com/ramp4-pcar4/story-ramp/issues/340 (same fix as main repo)

This PR fixes an issue where long names just extend the width of the screen. Ellipses are now added to the end of the title. I did attempt to see how it would work to have the title wrap to the next line, but it causes a ton of issues with how we have the second slide stick to the top on mobile view.

As far as the chart problem goes, I'm unable to test the exact product that the issue was found on, but other charts seem to work well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/221)
<!-- Reviewable:end -->
