### PR TITLE
fix unsaved changes modal appearing under editor content

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -1,7 +1,7 @@
 <template>
     <!-- If the configuration file is being fetched, display a spinner to indicate loading. -->
     <div class="editor-container">
-        <div class="editor-header sticky flex items-center border-b border-black bg-gray-200 py-2 px-2">
+        <div class="editor-header sticky flex items-center border-b border-black bg-gray-200 py-2 px-2 z-10">
             <span class="mx-1">
                 <router-link :to="{ name: 'home' }" class="mt-1 flex justify-center h-full w-full" target>
                     <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18.001" viewBox="0 0 18 18.001">


### PR DESCRIPTION
Closes #222 

This PR fixes an issue where the unsaved changes confirmation modal was appearing under the editor content, sometimes making it impossible to close it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/229)
<!-- Reviewable:end -->
