### PR TITLE
fix panel contents covering header bar

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -177,7 +177,7 @@ export default class EditorV extends Vue {
 
     mounted(): void {
         // from https://css-tricks.com/how-to-detect-when-a-sticky-element-gets-pinned/
-        const observer = new IntersectionObserver(([e]) => e.target.classList.toggle('z-50', e.intersectionRatio < 1), {
+        const observer = new IntersectionObserver(([e]) => e.target.classList.toggle('z-40', e.intersectionRatio < 1), {
             threshold: [1]
         });
 

--- a/src/components/panels/panel.vue
+++ b/src/components/panels/panel.vue
@@ -2,7 +2,7 @@
     <div
         :class="
             config.type !== 'text'
-                ? `sticky ${config.type === 'map' ? 'top-16' : 'top-8'} sm:self-start flex-2 order-1 sm:order-2 z-50`
+                ? `sticky ${config.type === 'map' ? 'top-16' : 'top-8'} sm:self-start flex-2 order-1 sm:order-2 z-40`
                 : 'flex order-2 sm:order-1'
         "
         class="flex-col relative"


### PR DESCRIPTION
Closes #231 

This PR fixes an issue where some panel elements were covering the header bar when you scrolled down in the app.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/232)
<!-- Reviewable:end -->
