### PR TITLE
Inline Image Editor

### DIFF
--- a/src/components/editor/text-editor.vue
+++ b/src/components/editor/text-editor.vue
@@ -8,13 +8,15 @@
             height="400px"
             left-toolbar="undo redo clear | h bold italic strikethrough quote subsuper | ul ol table hr | addLink image code | save"
             :toolbar="toolbar"
+            :disabled-menus="[]"
+            @upload-image="handleUploadImage"
         ></v-md-editor>
     </div>
 </template>
 
 <script lang="ts">
 import { Component, Prop, Vue } from 'vue-property-decorator';
-import { TextPanel } from '@/definitions';
+import { ConfigFileStructure, TextPanel } from '@/definitions';
 
 interface MDEditor {
     insert(callback: (selected: string) => { text: string; selected: string }): void;
@@ -25,6 +27,8 @@ interface MDEditor {
 })
 export default class TextEditorV extends Vue {
     @Prop() panel!: TextPanel;
+    @Prop() configFileStructure!: ConfigFileStructure;
+    @Prop() lang!: string;
 
     toolbar = {
         subsuper: {
@@ -110,6 +114,18 @@ export default class TextEditorV extends Vue {
             ]
         }
     };
+
+    handleUploadImage(event: any, insertImage: any, files: File[]) {
+        const file = files[0];
+        // Get the files and upload them to the file server, then insert the corresponding content into the editor
+        this.configFileStructure.assets[this.lang].file(file.name, file);
+
+        // Here is just an example
+        insertImage({
+            url: `/${this.configFileStructure.uuid}/assets/${this.lang}/${file.name}`,
+            desc: file.name
+        });
+    }
 }
 </script>
 


### PR DESCRIPTION
Related: #164 

Adds an inline image uploader to the markdown editor (**Upload Image** under the image icon).

Note: inline images do not appear in the markdown preview or storylines preview due to the way files are referenced in these pages. Obviously this is less than ideal, as it is much more helpful if the images appear when editing. I found that adding the storyline config with the uploaded assets to the `/public/` folder fixed this issue, and for some reason the issue remained fixed (the inline images were previewable) even after deleting the config from `/public/` again. Someone who is more knowledgeable with the file structure could offer some insight into this.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/233)
<!-- Reviewable:end -->
