### PR TITLE
add French translations

### DIFF
--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -7,14 +7,14 @@
                 class="border hover:bg-gray-100"
                 :class="editingStatus === 'text' ? 'border-black' : 'border-gray-300'"
             >
-                Text Section
+                {{ $t('dynamic.textSection') }}
             </button>
             <button
                 @click="() => changePanel('panels')"
                 class="border hover:bg-gray-100"
                 :class="editingStatus !== 'text' ? 'border-black' : 'border-gray-300'"
             >
-                Panel Collection
+                {{ $t('dynamic.panel.collection') }}
             </button>
         </div>
         <!-- Text Section -->
@@ -30,22 +30,22 @@
         <div v-if="editingStatus === 'panels'">
             <table class="w-2/3 mt-5">
                 <tr class="table-header">
-                    <th>Panel ID</th>
-                    <th>Panel Type</th>
-                    <th>Panel Actions</th>
+                    <th>{{ $t('dynamic.panel.id') }}</th>
+                    <th>{{ $t('dynamic.panel.type') }}</th>
+                    <th>{{ $t('dynamic.panel.actions') }}</th>
                 </tr>
                 <tr class="table-contents" v-for="(item, idx) in panel.children" :key="idx">
                     <td>{{ item.id }}</td>
                     <td>{{ item.panel.type }}</td>
                     <td>
-                        <span @click="() => switchSlide(idx)">Edit</span> |
-                        <span @click="() => removeSlide(idx)">Remove</span>
+                        <span @click="() => switchSlide(idx)">{{ $t('editor.chart.label.edit') }}</span> |
+                        <span @click="() => removeSlide(idx)">{{ $t('editor.remove') }}</span>
                     </td>
                 </tr>
                 <tr class="table-add-row">
                     <th class="flex flex-col items-center">
                         <input type="text" placeholder="Enter Panel ID" v-model="newSlideName" />
-                        <p v-if="idUsed">⚠ Panel ID is already taken.</p>
+                        <p v-if="idUsed">{{ $t('dynamic.panel.idTaken') }}</p>
                     </th>
                     <th>
                         <select v-model="newSlideType">
@@ -65,7 +65,8 @@
                 <br />
                 <hr />
                 <br />
-                <span class="font-bold text-xl">Panel Editor:</span><br />
+                <span class="font-bold text-xl">{{ $t('dynamic.panel.editor') }}</span
+                ><br />
                 <component
                     ref="slide"
                     :is="

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -52,7 +52,7 @@
                             />
                         </svg>
                     </span>
-                    <span class="align-center inline-block select-none">Unsaved Changes</span>
+                    <span class="align-center inline-block select-none">{{ $t('editor.unsavedChanges') }}</span>
                 </span>
             </transition>
             <slot name="langModal" v-bind="{ unsavedChanges: unsavedChanges }"></slot>

--- a/src/components/editor/helpers/confirmation-modal.vue
+++ b/src/components/editor/helpers/confirmation-modal.vue
@@ -2,7 +2,7 @@
     <vue-modal :name="name" :outer-close="false" :hide-close-btn="true" size="md">
         <h2 slot="header" class="text-lg font-bold">{{ message }}</h2>
         <div class="w-full flex justify-end">
-            <button class="confirm-button hover:bg-gray-800" @click.stop="onOk">Confirm</button>
+            <button class="confirm-button hover:bg-gray-800" @click.stop="onOk">{{ $t('editor.confirm') }}</button>
             <button class="cancel-button hover:bg-gray-100" @click.stop="onCancel">Cancel</button>
         </div>
     </vue-modal>

--- a/src/components/editor/helpers/metadata-content.vue
+++ b/src/components/editor/helpers/metadata-content.vue
@@ -5,7 +5,7 @@
         <br />
         <label class="mb-5">Intro Title:</label>
         <input type="text" name="introTitle" :value="metadata.introTitle" @change="metadataChanged" class="w-1/4" />
-        <label class="mb-5">Intro Subtitle:</label>
+        <label class="mb-5">{{ $t('editor.slides.intro') }}:</label>
         <input
             type="text"
             name="introSubtitle"
@@ -23,7 +23,7 @@
                 class="image-preview"
             />
             <p v-if="metadata.logoPreview == 'error'" class="image-preview">
-                An error occurred when trying to load image.
+                {{ $t('editor.image.loadingError') }}
             </p>
         </div>
         <label class="mb-5">{{ $t('editor.logo') }}:</label>
@@ -32,7 +32,7 @@
             {{ $t('editor.browse') }}
         </button>
         <button v-if="metadata.logoName || metadata.logoPreview" @click.stop="removeLogo" class="border border-black">
-            Remove
+            {{ $t('editor.remove') }}
         </button>
         <!-- hide the actual file input -->
         <input
@@ -59,7 +59,7 @@
         <label class="mb-5"></label>
         <p class="inline-block">
             <i>
-                Context link shows up at the bottom of the page to provide additional resources for interested users
+                {{ $t('editor.contextLink.info') }}
             </i>
         </p>
         <br />
@@ -68,7 +68,7 @@
         <br />
         <label class="mb-5"></label>
         <p class="inline-block">
-            <i> Context label shows up before the context link to explain what the link is for </i>
+            <i> {{ $t('editor.contextLabel.info') }}</i>
         </p>
         <br />
         <label class="mb-5">{{ $t('editor.dateModified') }}:</label>

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -31,7 +31,7 @@
         </div>
 
         <span v-show="!imagePreviewsLoading && imagePreviews.length" class="flex justify-center">
-            <i>Click and drag to reorder images</i>
+            <i> {{ $t('editor.image.reorder') }}</i>
         </span>
 
         <!-- Gallery preview of all images -->
@@ -48,7 +48,7 @@
                 @delete="deleteImage"
             >
                 <div class="flex mt-4 items-center w-full text-left">
-                    <label class="text-label">Alt tag:</label>
+                    <label class="text-label">{{ $t('editor.image.altTag') }}:</label>
                     <input class="w-4/5" type="text" v-model="image.altText" @change="onImagesEdited" />
                 </div>
 
@@ -60,7 +60,7 @@
         </draggable>
 
         <div v-show="imagePreviews.length > 1" class="flex items-center w-full text-left">
-            <label class="text-label">Slideshow Caption:</label>
+            <label class="text-label">{{ $t('editor.image.slideshowCaption') }}:</label>
             <input class="w-3/5" type="text" v-model="slideshowCaption" @change="onImagesEdited" />
         </div>
     </div>

--- a/src/components/editor/map-editor.vue
+++ b/src/components/editor/map-editor.vue
@@ -1,10 +1,10 @@
 <template>
     <div class="flex flex-col">
-        <label class="text-left">Map title:</label>
+        <label class="text-left">{{ $t('editor.map.title') }}:</label>
         <input type="text" v-model="panel.title" />
 
         <div v-if="status === 'editing'">
-            <label class="mt-6">Enable Scrollguard:</label>
+            <label class="mt-6">{{ $t('editor.map.scrollguard.enable') }}:</label>
             <input type="checkbox" @change="saveScrollguard" v-model="panel.scrollguard" />
             <span class="ml-6"></span>
             <label class="mt-6">{{ $t('editor.map.timeslider.enable') }}</label>
@@ -22,7 +22,7 @@
             <div class="mb-4" v-if="usingTimeSlider"></div>
 
             <div class="flex justify-between mb-4">
-                <label class="mt-2">Map Editor:</label>
+                <label class="mt-2">{{ $t('editor.map.edit') }}:</label>
                 <button
                     class="border border-black hover:bg-gray-100"
                     @click="
@@ -31,7 +31,7 @@
                         }
                     "
                 >
-                    Cancel Editing
+                    {{ $t('editor.map.edit.cancel') }}
                 </button>
             </div>
             <iframe
@@ -41,7 +41,7 @@
             ></iframe>
         </div>
         <div v-if="status === 'creating'">
-            <label class="text-left mt-2">Map config name*:</label>
+            <label class="text-left mt-2">{{ $t('editor.map.label.name') }}*:</label>
             <div class="flex flex-row items-center"><input type="text" v-model="newFileName" />.json</div>
 
             <ul class="flex flex-wrap list-none justify-center" v-if="newFileName != ''">
@@ -52,7 +52,7 @@
             </ul>
         </div>
         <div v-if="status === 'default'">
-            <label class="text-left mt-2">Map Editor:</label>
+            <label class="text-left mt-2">{{ $t('editor.map.edit') }}:</label>
             <ul class="flex flex-wrap list-none justify-center">
                 <li class="map-item items-center my-8 mx-5 overflow-hidden" @click="openEditor">
                     <div class="edit-map"></div>

--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -45,9 +45,7 @@
                                 />
                             </svg>
                         </span>
-                        <span class="align-center inline-block select-none"
-                            >UUID already exists. Saving this will overwrite existing product.</span
-                        >
+                        <span class="align-center inline-block select-none">{{ $t('editor.uuid.exists') }}</span>
                     </span>
                     <button
                         @click="generateRemoteConfig"
@@ -73,10 +71,9 @@
                 <br />
 
                 <div class="mb-4">
-                    <h3>Storylines product details</h3>
+                    <h3>{{ $t('editor.productDetails') }}</h3>
                     <p>
-                        Fill in metadata details about your new Storyline. Use the “Preview” button to see what your
-                        slides will look like.
+                        {{ $t('editor.metadata.instructions') }}
                     </p>
                 </div>
 

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -12,18 +12,18 @@
                             :disabled="slideIndex === 0"
                             class="border border-black"
                         >
-                            Previous Slide
+                            {{ $t('editor.slides.previousSlide') }}
                         </button>
                         <button
                             @click.stop="selectSlide(slideIndex + 1)"
                             :disabled="isLast"
                             class="border border-black"
                         >
-                            Next Slide
+                            {{ $t('editor.slides.nextSlide') }}
                         </button>
                     </div>
                     <div class="flex mt-3">
-                        <span class="mx-2 font-bold">Make the right panel the full slide</span>
+                        <span class="mx-2 font-bold">{{ $t('editor.slides.makeFull') }}</span>
                         <input
                             type="checkbox"
                             class="rounded-none cursor-pointer w-4 h-4"
@@ -80,7 +80,7 @@
                             />
                         </svg>
                     </span>
-                    <span class="align-middle inline-block pl-1">Left Panel</span>
+                    <span class="align-middle inline-block pl-1">{{ $t('editor.slides.leftPanel') }}</span>
                 </button>
                 <button
                     @click="
@@ -127,7 +127,7 @@
                         </svg>
                     </span>
 
-                    <span class="align-middle inline-block pl-1">Right Panel</span>
+                    <span class="align-middle inline-block pl-1">{{ $t('editor.slides.rightPanel') }}</span>
                 </button>
             </div>
             <div v-else class="border-b border-black">
@@ -174,7 +174,7 @@
                         </svg>
                     </span>
 
-                    <span class="align-middle inline-block pl-1">Fullscreen Panel</span>
+                    <span class="align-middle inline-block pl-1">{{ $t('editor.slides.fullscreenPanel') }}</span>
                 </button>
             </div>
             <div>
@@ -182,7 +182,7 @@
                     <span class="font-bold text-xl">Content:</span>
                     <span class="ml-auto flex-grow"></span>
                     <div v-if="panelIndex === 1 || rightOnly" class="flex flex-col mr-8">
-                        <label class="text-left text-lg">Content type:</label>
+                        <label class="text-left text-lg">{{ $t('editor.slides.contentType') }}:</label>
                         <select
                             ref="typeSelector"
                             @input="
@@ -216,7 +216,7 @@
             </div>
         </div>
         <div v-else class="flex h-full mt-4 justify-center text-gray-600 text-xl">
-            <span>Please select a slide to edit.</span>
+            <span>{{ $t('editor.slides.select') }}</span>
         </div>
         <confirmation-modal
             :name="`change-slide-${slideIndex}`"

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -27,7 +27,7 @@
                         class="w-32 h-12 ml-0"
                         @click="copyAllFromOtherLang(configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides)"
                     >
-                        Copy All
+                        {{ $t('editor.slides.copyAll') }}
                     </button>
                     <span class="text-lg font-bold my-6"> {{ $t('editor.image.label.or') }} </span>
                     <div class="flex">

--- a/src/components/editor/text-editor.vue
+++ b/src/components/editor/text-editor.vue
@@ -2,7 +2,7 @@
     <div class="flex flex-col mt-4">
         <label class="text-left">Panel title:</label>
         <input type="text" v-model="panel.title" />
-        <label class="text-left mt-2">Panel body:</label>
+        <label class="text-left mt-2">{{ $t('editor.slides.panel.body') }}:</label>
         <v-md-editor
             v-model="panel.content"
             height="400px"

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -1,72 +1,107 @@
 key,enValue,enValid,frValue,frValid
 chapters.title,Chapters,1,Chapitres,1
 chapters.return,Return to top,1,Retournez en haut,1
-chapters.menu,Toggle menu,1,Menu bascule,0
+chapters.menu,Toggle menu,1,Menu à bascule,1
 scrollguard.desc,Use ctrl + scroll to zoom the map,1,Utilisez les touches Ctrl et + pour faire un zoom de la carte,1
 story.window.title,RAMP Storylines,1,RAMP Storylines,0
 story.date,Date modified:,1,Date de modification:,1
 story.error,An error occurred while loading this Storylines product. See developer console for more information.,1,Une erreur est survenue pendant le chargement ce synopsis produit. Voir la console du promoteur pour obtenir de plus amples renseignements.,1
 image.fullscreen,Full Screen,1,Plein Écran,1
 dynamic.back,Back,1,Retour,0
+dynamic.textSection,Text Section,1,Section de texte,1
+dynamic.panel.collection,Panel Collection,1,Collection de panneaux,1
+dynamic.panel.id,Panel ID,1,No d’identification du panneau,1
+dynamic.panel.type,Panel Type,1,Type de panneaux,1
+dynamic.panel.actions,Panel Actions,1,Actions du panneau,1
+dynamic.panel.idTaken,Panel ID is already,1,Le nom du panneau est déjà utilisé,1
+dynamic.panel.editor,Panel Editor:,1,Éditeur de panneaux:,1
 timeslider.expand,Expand,1,Développer,1
 timeslider.minimize,Minimize,1,Réduire,1
-timeslider.play,Play,1,Lire,0
-timeslider.pause,Pause,1,Pause,0
-fullscreen.activate,Enter Fullscreen,1,Entrer en plein écran,0
-fullscreen.deactivate,Exit Fullscreen,1,Sortie plein écran,0
-editor.window.title,RAMP Storylines Editor,1,RAMP Storylines Editor,0
-editor.createProduct,Create New Storylines Product,1,Créer un nouveau produit Storylines,0
-editor.editProduct,Edit Existing Storylines Product,1,Modifier le produit Storylines existant,0
-editor.editMetadata,Edit Project Metadata,1,Modifier les Métadonnées du Projet,0
+timeslider.play,Play,1,Lecture,1
+timeslider.pause,Pause,1,Pause,1
+fullscreen.activate,Enter Fullscreen,1,Afficher le mode plein écran,1
+fullscreen.deactivate,Exit Fullscreen,1,Quitter le mode plein écran,1
+editor.window.title,RAMP Storylines Editor,1,Éditeur de scénarios de la PCAR,1
+editor.createProduct,Create New Storylines Product,1,Créer un nouveau produit de scénarios,1
+editor.editProduct,Edit Existing Storylines Product,1,Modifier un produit de scénarios,1
+editor.editMetadata,Edit Project Metadata,1,Modifier les métadonnées d’un projet,1
+editor.productDetails,Storylines product details,1,Détails du produit de scénarios,1
+editor.metadata.instructions,Fill in metadata details about your new Storylines product. Use the "Preview" button to see what your slides will look like.,1,Inscrivez les métadonnées de votre nouveau produit de scénario. Utilisez la fonction « Afficher l’aperçu » pour voir à quoi ressemblent vos diapositives.,1
 editor.uuid,UUID,1,UUID,0
-editor.title,Title,1,Titre,0
-editor.logo,Logo,1,Logo,0
-editor.logoPreview,Logo Preview,1,Logo Preview,0
-editor.logoAltText,Logo Alt Text,1,Description alternative du logo,0
+editor.uuid.exists,UUID already exists. Saving this will overwrite existing product.,1,L’IDUU existe déjà. Enregistrer ce produit écrasera le produit existant.,1
+editor.title,Title,1,Titre,1
+editor.logo,Logo,1,Logo,1
+editor.logoPreview,Logo Preview,1,Aperçu du logo,1
+editor.logoAltText,Logo Alt Text,1,Lien contextuel,1
 editor.logoAltText.desc,"For accessibility purposes, provide description text for the logo.",1,"Pour des raisons d'accessibilité, fournissez un texte descriptif pour le logo.",0
-editor.contextLink,Context Link,1,Lien contextuel,0
-editor.contextLabel,Context Label,1,Libellé de contexte,0
-editor.dateModified,Date Modified,1,Date modifiée,0
-editor.load,Load,1,Charger,0
-editor.browse,Browse,1,Parcourir,0
+editor.contextLink,Context Link,1,Lien contextuel,1
+editor.contextLink.info,Context link shows up at the bottom of the page to provide additional resources for interested users.,1,Le lien contextuel apparaît au bas de la page et fournit des ressources supplémentaires aux utilisateurs intéressés.,1
+editor.contextLabel,Context Label,1,Étiquette de contexte,1
+editor.contextLabel.info,Context label shows up before the context link to explain what the link is for,1,L’étiquette de contexte apparaît avant le lien contextuel et explique à quoi sert le lien.,1
+editor.dateModified,Date Modified,1,Date de modification,1
+editor.load,Load,1,Charger,1
+editor.browse,Browse,1,Parcourir,1
+editor.remove,Remove,1,Supprimer,1
 editor.back,Back,1,Retour,1
 editor.next,Next,1,Suivant,1
-editor.preview,Preview,1,Aperçu,0
-editor.saveChanges,Save Changes,1,Sauvegarder les Modifications,0
-editor.savingChanges,Saving...,1,Sauver...,0
-editor.resetChanges,Reset Changes,1,Reset Changes,0
-editor.refreshChanges.modal,"Are you sure you want to reload the product? All unsaved changes will be lost.",1,"Are you sure you want to reload the product? All unsaved changes will be lost.",0
-editor.changeLang.modal,"Are you sure you want to switch languages? Unsaved changes may be lost.",1,"Are you sure you want to switch languages? Unsaved changes may be lost.",0
-editor.frenchConfig,View French Config,1,Afficher la configuration française,0
-editor.englishConfig,View English Config,1,Afficher la configuration en anglais,0
-editor.returnToLanding,Return to Landing,1,Return to Landing,0
-editor.image.delete,Delete Image,1,Supprimer l'image,0
-editor.image.label.drag,Drag your images here,1,Faites glisser vos images ici,0
+editor.preview,Preview,1,Afficher l’aperçu,1
+editor.confirm,Confirm,1,Confirmer,1
+editor.unsavedChanges,Unsaved changes,1,Modifications non enregistrées,1
+editor.saveChanges,Save Changes,1,Enregistrer les modifications,1
+editor.savingChanges,Saving...,1,Enregistrement...,1
+editor.resetChanges,Reset Changes,1,Annuler les modifications,1
+editor.refreshChanges.modal,"Are you sure you want to reload the product? All unsaved changes will be lost.",1,"Voulez-vous vraiment recharger ce produit? Toute modification non enregistrée sera perdue.",1
+editor.changeLang.modal,"Are you sure you want to switch languages? Unsaved changes may be lost.",1,"Voulez-vous vraiment changer de langue? Toute modification non enregistrée sera perdue.",1
+editor.frenchConfig,View French Config,1,Afficher la configuration en français,1
+editor.englishConfig,View English Config,1,Afficher la configuration en anglais,1
+editor.returnToLanding,Return to Landing,1,Retour à la page d’accueil,1
+editor.image.delete,Delete Image,1,Supprimer l'image,1
+editor.image.label.drag,Drag your images here,1,Faites glisser vos images ici,1
 editor.image.label.or,or,1,ou,1
-editor.image.label.browse,browse,1,feuilleter,0
-editor.image.label.upload,to upload,1,télécharger,0
-editor.chart.delete,Delete Chart,1,Supprimer le graphique,0
+editor.image.label.browse,browse,1,parcourir,1
+editor.image.label.upload,to upload,1,téléverser,1
+editor.image.reorder,Click and drag to reorder images,1,Cliquez sur les images et faites-les glisser pour changer l’ordre.,1
+editor.image.altTag,Alt tag,1,Texte de remplacement,1
+editor.image.slideshowCaption,Slideshow Caption,1,Légende du diaporama,1
+editor.image.loadingError,An error occurred when trying to load image,1,Une erreur est survenue lors du chargement de l’image.,1
+editor.chart.delete,Delete Chart,1,Supprimer le graphique,1
 editor.chart.label.name,Name,1,Nom,1
 editor.chart.label.edit,Edit,1,Éditer,1
 editor.chart.label.empty,Empty,1,Vide,1
-editor.chart.label.create,Add new chart,1,Add new chart,0
-editor.chart.label.info,Interactive charts ({num}),1,Interactive charts ({num}),0
-editor.chart.delete.confirm,Are you sure you want to delete the chart {name}?,1,Are you sure you want to delete the chart {name}?,0
-editor.map.label.create,Create New Configuration File,1,Create New Configuration File,0
-editor.map.label.edit,Edit Map Configuration,1,Edit Map Configuration,0
-editor.map.timeslider.enable,Enable Time Slider:,1,Enable Time Slider:,0
-editor.map.timeslider.edit,Edit Time Slider Config,1,Edit Time Slider Config,0
-editor.map.timeslider.range,Range:,1,Range:,0
-editor.map.timeslider.start,Start:,1,Start:,0
-editor.map.timeslider.attribute,Attribute:,1,Attribute:,0
+editor.chart.label.create,Add new chart,1,Ajouter un nouveau graphique,1
+editor.chart.label.info,Interactive charts ({num}),1,Graphiques interactifs ({num}),1
+editor.chart.delete.confirm,Are you sure you want to delete the chart {name}?,1,Voulez-vous vraiment supprimer le graphique {nom}?,1
+editor.map.title,Map title,1,Titre de la carte,1
+editor.map.edit.cancel,Cancel editing,1,Annuler les modifications,1
+editor.map.edit,Map editor,1,Éditeur de carte,1
+editor.map.label.name,Map config name,1,Nom de la configuration de la carte,1
+editor.map.label.create,Create New Configuration File,1,Créer un nouveau fichier de configuration,1
+editor.map.label.edit,Edit Map Configuration,1,Modifier la configuration de la carte,1
+editor.map.scrollguard.enable,Enable scrollguard,1,Activer le contrôle du défilement,1
+editor.map.timeslider.enable,Enable Time Slider:,1,Activer le curseur temporel:,1
+editor.map.timeslider.edit,Edit Time Slider Config,1,Modifier la configuration du curseur temporel,1
+editor.map.timeslider.range,Range:,1,Tranche:,1
+editor.map.timeslider.start,Start:,1,Début:,1
+editor.map.timeslider.attribute,Attribute:,1,Caractéristique:,1
 editor.map.timeslider.layers,(OPTIONAL) Comma separated Layer IDs:,1,(OPTIONAL) Comma separated Layer IDs:,0
 editor.map.timeslider.to,to,1,to,0
-editor.map.timeslider.warning,⚠️Warning! Please ensure that:,1,⚠️Warning! Please ensure that:,0
-editor.map.timeslider.warning.bullet1,All range and start values are positive integers.,1,All range and start values are positive integers.,0
-editor.map.timeslider.warning.bullet2,The "to" value is greater than or equal to the "from" value.,1,The "to" value is greater than or equal to the "from" value.,0
-editor.map.timeslider.warning.end,"Otherwise, your time slider config cannot be saved.",1,"Otherwise, your time slider config cannot be saved.",0
-editor.slides.title,SLIDES,1,SLIDES,0
-editor.slides.addSlide,"New Slide",1,"New Slide",0
-editor.slides.copyFromLang,"Copy slides from the other language",1,"Copy slides from the other language",0
-editor.slides.deleteSlide.confirm,"Are you sure you want to delete the slide {title}?",1,"Are you sure you want to delete the slide {title}?",0
-editor.slides.changeSlide.confirm,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",1,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",0
+editor.map.timeslider.warning,⚠️Warning! Please ensure that:,1,⚠️Avertissement! Veuillez vous assurer de ce qui suit:,1
+editor.map.timeslider.warning.bullet1,All range and start values are positive integers.,1,Toutes les valeurs de la tranche et du début sont des nombres entiers positifs.,1
+editor.map.timeslider.warning.bullet2,The "to" value is greater than or equal to the "from" value.,1,La valeur « À » est supérieure ou égale à la valeur « De ».,1
+editor.map.timeslider.warning.end,"Otherwise, your time slider config cannot be saved.",1,Autrement, la configuration du curseur temporel ne pourra pas être enregistrée.,1
+editor.slides.title,SLIDES,1,DIAPOSITIVES,1
+editor.slides.addSlide,"New Slide",1,Nouvelle diapositive,1
+editor.slides.copyFromLang,"Copy slides from the other language",1,"Copier les diapositives de l’autre langue",1
+editor.slides.deleteSlide.confirm,"Are you sure you want to delete the slide {title}?",1,"Voulez-vous vraiment supprimer la diapositive {titre}?",1
+editor.slides.changeSlide.confirm,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",1,"Voulez-vous vraiment modifier la diapositive {titre}? Toute modification non enregistrée sera perdue.",1
+editor.slides.makeFull,Make the right panel the full slide,1,Mettre la diapositive complète dans le panneau de droite,1
+editor.slides.copyAll,Copy all,1,Copier tout,1
+editor.slides.previousSlide,Previous slide,1,Diapositive précédente,1
+editor.slides.nextSlide,Next slide,1,Diapositive suivante,1
+editor.slides.leftPanel,Left panel,1,Panneau de gauche,1
+editor.slides.rightPanel,Right panel,1,Panneau de droite,1
+editor.slides.fullscreenPanel,Fullscreen panel,1,Panneau plein écran,1
+editor.slides.contentType,Content type,1,Type de contenu,1
+editor.slides.select,Please select a slide to edit,1,Veuillez sélectionner une diapositive à modifier,1
+editor.slides.panel.body,Panel body,1,Corps du panneau,1
+editor.slides.intro,Intro subtitle,1,Sous-titre de l’introduction,1


### PR DESCRIPTION
Closes #202 

Adds translated French strings to the app.

While going through and adding these, I found a few more strings that we don't have translations for:

"Caption" (in image-editor.vue)
"Content" (in slide-editor.vue)
"Panel title" (in text-editor.vue)
"Slide" and "Copy" (in slide-toc.vue)
"Cancel" (in confirmation-modal.vue)
"Intro title" (in metadata-content.vue)