### PR TITLE
Highcharts number formatting based on language

### DIFF
--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -66,6 +66,7 @@ import { ChartConfig, ChartPanel, ConfigFileStructure, Highchart, SourceCounts }
 import ChartPreviewV from '@/components/editor/helpers/chart-preview.vue';
 import ConfirmationModalV from '@/components/editor/helpers/confirmation-modal.vue';
 import draggable from 'vuedraggable';
+import { chart } from 'highcharts';
 
 @Options({
     components: {
@@ -126,7 +127,7 @@ export default class ChartEditorV extends Vue {
 
     clearEditor(): void {
         // reset to clear modal editor options
-        this.modalEditor.editor.chart.options.setAll({
+        let chart_options = {
             title: {
                 text: `Chart ${this.chartConfigs.length + 1}`
             },
@@ -136,8 +137,12 @@ export default class ChartEditorV extends Vue {
             credits: {
                 enabled: false
             }
-        });
-
+        };
+        chart_options =
+            this.lang === 'en'
+                ? Object.assign({}, chart_options, { lang: { thousandsSep: ',' } })
+                : Object.assign({}, chart_options, { lang: { thousandsSep: ' ' } });
+        this.modalEditor.editor.chart.options.setAll(chart_options);
         // resets and clears datatable section
         const defaultTableData = `"Column 1";"Column 2"\n" "";" "`;
         this.modalEditor.editor.dataTable.loadCSV({ csv: defaultTableData });
@@ -163,7 +168,6 @@ export default class ChartEditorV extends Vue {
 
             // Add chart config to ZIP file.
             this.configFileStructure.charts[this.lang].file(`${chart.title.text}.json`, JSON.stringify(chart, null, 4));
-
             this.chartConfigs.push(chartConfig);
         }
         this.onChartsEdited();


### PR DESCRIPTION
For #226 

**Changes**
- Added the `thousandsSep` option to set the thousands separator to `,` for the editor in English and ` ` for the editor in French

**Notes**
English Example:
![highcharts en](https://github.com/ramp4-pcar4/storylines-editor/assets/83516523/7008534a-d0cd-4150-acd8-ff1c77516329)

French Example:
![highcharts fr](https://github.com/ramp4-pcar4/storylines-editor/assets/83516523/86660bf1-e776-497f-9817-f5468b73a5d9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/250)
<!-- Reviewable:end -->
