### PR TITLE
add scrollbar to metadata popup if necessary

### DIFF
--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -131,7 +131,7 @@
                 <template v-slot:metadataModal>
                     <vue-final-modal
                         modalId="metadata-edit-modal"
-                        content-class="flex flex-col max-w-xl mx-4 p-4 bg-white border rounded-lg space-y-2"
+                        content-class="flex flex-col max-h-full overflow-y-auto max-w-xl mx-4 p-4 bg-white border rounded-lg space-y-2"
                         class="flex justify-center items-center"
                     >
                         <h2 slot="header" class="text-lg font-bold">{{ $t('editor.editMetadata') }}</h2>


### PR DESCRIPTION
Related to #257 

This PR enables a vertical scrollbar to appear on the metadata editor popup if required so that content is no longer cut off on smaller resolutions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/261)
<!-- Reviewable:end -->
