### PR TITLE
fix switching between tabs when editing dynamic panel

### DIFF
--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -171,7 +171,9 @@ export default class DynamicEditorV extends Vue {
     }
 
     changePanel(target: string): void {
-        this.saveChanges();
+        if (this.editingStatus !== 'text') {
+            this.saveChanges();
+        }
         this.editingStatus = target;
     }
 


### PR DESCRIPTION
Related to #258 

This PR fixes an issue where you can't switch back to the `panel collection` tab after visiting the collection and switching back to the text editor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/262)
<!-- Reviewable:end -->
