### PR TITLE
Added option for horizontal table of contents

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
                 "jszip": "^3.10.1",
                 "markdown-it": "^12.0.6",
                 "nouislider": "^15.5.0",
-                "ramp-storylines": "^3.0.4",
+                "ramp-storylines_demo-scenarios-pcar": "^3.1.3",
                 "uuid": "^9.0.0",
                 "vue": "^3.3.4",
                 "vue-class-component": "^8.0.0-rc.1",
@@ -15004,10 +15004,10 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/ramp-storylines": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/ramp-storylines/-/ramp-storylines-3.0.4.tgz",
-            "integrity": "sha512-xTzhJvjeDRNd/6nQD3IvfUib/JcN4hmc7RUcSindiVCCFllzTXlb56+RIdoMaLQ0VpJ5Z1XBVNlVPhJZUAZ2vg==",
+        "node_modules/ramp-storylines_demo-scenarios-pcar": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.1.3.tgz",
+            "integrity": "sha512-0da9++y4oeuFcxmusi5N1hnrB4K5lQrLjal3XfMZP8OGyY/D3aYL7OGqx+Ez4h1iz2LdqlrGepTf04gDlc6iJA==",
             "dependencies": {
                 "@tailwindcss/typography": "^0.4.0",
                 "@types/highcharts": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "jszip": "^3.10.1",
         "markdown-it": "^12.0.6",
         "nouislider": "^15.5.0",
-        "ramp-storylines": "^3.0.4",
+        "ramp-storylines_demo-scenarios-pcar": "^3.1.3",
         "uuid": "^9.0.0",
         "vue": "^3.3.4",
         "vue-class-component": "^8.0.0-rc.1",

--- a/src/components/editor/helpers/metadata-content.vue
+++ b/src/components/editor/helpers/metadata-content.vue
@@ -71,6 +71,23 @@
             <i> {{ $t('editor.contextLabel.info') }}</i>
         </p>
         <br />
+        <label class="mr-15">{{ $t('editor.tocOrientation') }}:</label>
+        <select
+            class="border-solid border border-black p-1"
+            name="tocOrientation"
+            id="toc"
+            @change="metadataChanged"
+            v-model="metadata.tocOrientation"
+        >
+            <option value="vertical">{{ $t('editor.tocOrientation.vertical') }}</option>
+            <option value="horizontal">{{ $t('editor.tocOrientation.horizontal') }}</option>
+        </select>
+        <br />
+        <label class="mb-5"></label>
+        <p class="inline-block">
+            <i>{{ $t('editor.tocOrientation.info') }}</i>
+        </p>
+        <br />
         <label class="mb-5">{{ $t('editor.dateModified') }}:</label>
         <input type="date" name="dateModified" :value="metadata.dateModified" @change="metadataChanged" />
         <br /><br />
@@ -90,6 +107,7 @@ export default class MetadataEditorV extends Vue {
         logoAltText: string;
         contextLink: string;
         contextLabel: string;
+        tocOrientation: string;
         dateModified: string;
     };
 

--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -244,6 +244,7 @@ export default class MetadataEditorV extends Vue {
         logoAltText: '',
         contextLink: '',
         contextLabel: '',
+        tocOrientation: '',
         dateModified: ''
     };
     // add more required metadata fields to here as needed
@@ -272,6 +273,8 @@ export default class MetadataEditorV extends Vue {
             const month = (curDate.getMonth() + 1).toString().padStart(2, '0');
             const day = curDate.getDate().toString().padStart(2, '0');
             this.metadata.dateModified = `${year}-${month}-${day}`;
+            // set vertical as the default table of contents orientation
+            this.metadata.tocOrientation = 'vertical';
         }
 
         // Find which view to render based on route
@@ -379,6 +382,7 @@ export default class MetadataEditorV extends Vue {
             slides: [],
             contextLabel: this.metadata.contextLabel,
             contextLink: this.metadata.contextLink,
+            tocOrientation: this.metadata.tocOrientation,
             dateModified: this.metadata.dateModified
         };
     }
@@ -555,6 +559,7 @@ export default class MetadataEditorV extends Vue {
         this.metadata.introSubtitle = config.introSlide.subtitle;
         this.metadata.contextLink = config.contextLink;
         this.metadata.contextLabel = config.contextLabel;
+        this.metadata.tocOrientation = config.tocOrientation;
         this.metadata.dateModified = config.dateModified;
 
         // Conversion for individual image panels to slideshow for gallery display
@@ -647,7 +652,14 @@ export default class MetadataEditorV extends Vue {
     }
 
     updateMetadata(
-        key: 'title' | 'introTitle' | 'introSubtitle' | 'contextLink' | 'contextLabel' | 'dateModified',
+        key:
+            | 'title'
+            | 'introTitle'
+            | 'introSubtitle'
+            | 'contextLink'
+            | 'contextLabel'
+            | 'tocOrientation'
+            | 'dateModified',
         value: string
     ): void {
         this.metadata[key] = value;
@@ -667,6 +679,7 @@ export default class MetadataEditorV extends Vue {
             config.introSlide.subtitle = this.metadata.introSubtitle;
             config.contextLink = this.metadata.contextLink;
             config.contextLabel = this.metadata.contextLabel;
+            config.tocOrientation = this.metadata.tocOrientation;
             config.dateModified = this.metadata.dateModified;
 
             // If the logo section is missing, create it here before overwriting values.
@@ -710,7 +723,8 @@ export default class MetadataEditorV extends Vue {
             dateModified: '',
             logoPreview: '',
             logoName: '',
-            logoAltText: ''
+            logoAltText: '',
+            tocOrientation: ''
         };
         this.configs = { en: undefined, fr: undefined };
         this.slides = [];

--- a/src/components/editor/preview.vue
+++ b/src/components/editor/preview.vue
@@ -8,7 +8,10 @@
 
     <div v-else-if="loadStatus === 'loaded'">
         <div class="storyramp-app bg-white" v-if="config !== undefined">
-            <header class="sticky top-0 z-50 flex border-b border-black bg-gray-200 py-2 px-2 justify-between">
+            <header
+                id="story-header"
+                class="story-header sticky top-0 flex border-b border-black bg-gray-200 py-2 px-2 justify-between"
+            >
                 <div class="w-mobile-full truncate">
                     <span class="font-semibold text-lg m-1">{{ config.title }}</span>
                 </div>
@@ -22,6 +25,7 @@
                     :configFileStructure="configFileStructure"
                     :lang="lang"
                     :plugin="true"
+                    :headerHeight="headerHeight"
                     @step="updateActiveIndex"
                 />
             </div>
@@ -65,6 +69,7 @@ export default class StoryPreviewV extends Vue {
     loadStatus = 'loading';
     activeChapterIndex = -1;
     lang = 'en';
+    headerHeight = 0;
     uid = '';
 
     created(): void {
@@ -100,6 +105,11 @@ export default class StoryPreviewV extends Vue {
 
     updateActiveIndex(idx: number): void {
         this.activeChapterIndex = idx;
+        //determine header height
+        const headerH = document.getElementById('story-header');
+        if (headerH) {
+            this.headerHeight = headerH.clientHeight;
+        }
     }
 }
 </script>
@@ -123,6 +133,10 @@ $font-list: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
         font-family: $font-list;
         line-height: 1.5;
         border-bottom: 0px;
+    }
+
+    .story-header {
+        z-index: 60;
     }
 
     .storyramp-modified {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -7,6 +7,7 @@ export interface StoryRampConfig {
     slides: Slide[];
     contextLink: string;
     contextLabel: string;
+    tocOrientation: string;
     dateModified: string;
 }
 
@@ -38,6 +39,7 @@ export interface MetadataContent {
     logoAltText: string;
     contextLink: string;
     contextLabel: string;
+    tocOrientation: string;
     dateModified: string;
 }
 

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -112,3 +112,7 @@ editor.slides.panel.body,Panel body,1,Corps du panneau,1
 editor.slides.panel.title,Panel title,1,Titre du panneau,1
 editor.slides.intro,Intro subtitle,1,Sous-titre de l’introduction,1
 editor.slides.title,Intro title,1,Titre de l’introduction,1
+editor.tocOrientation,Table of Contents Orientation,1,Orientation de la table des matières,0
+editor.tocOrientation.info,The table of contents orientation will be set to vertical in mobile view.,1,L'orientation de la table des matières sera définie sur verticale en vue mobile.,0
+editor.tocOrientation.vertical,Vertical,1,Vertical,0
+editor.tocOrientation.horizontal,Horizontal,1,Horizontal,0

--- a/src/main.ts
+++ b/src/main.ts
@@ -30,8 +30,8 @@ import HighchartsVue from 'highcharts-vue';
 import Message from 'vue-m-message';
 import 'vue-m-message/dist/style.css';
 
-import StorylinesViewer from 'ramp-storylines';
-import 'ramp-storylines/dist/storylines-viewer.css';
+import StorylinesViewer from 'ramp-storylines_demo-scenarios-pcar';
+import 'ramp-storylines_demo-scenarios-pcar/dist/storylines-viewer.css';
 
 const app = createApp(App);
 

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -6,7 +6,7 @@ declare module '*.vue' {
 declare module '@kangc/v-md-editor';
 declare module '@kangc/v-md-editor/lib/lang/en-US';
 declare module '@kangc/v-md-editor/lib/theme/github.js';
-declare module 'ramp-storylines';
+declare module 'ramp-storylines_demo-scenarios-pcar';
 declare module 'vue-m-message';
 declare module 'highcharts-vue';
 declare module 'vue-tippy';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -9,7 +9,7 @@ module.exports = {
     purge: [
         './index.html',
         './src/**/*.{vue,js,ts,jsx,tsx}',
-        './node_modules/ramp-storylines/**/*.{vue,js,ts,jsx,tsx}'
+        './node_modules/ramp-storylines_demo-scenarios-pcar/**/*.{vue,js,ts,jsx,tsx}'
     ],
     darkMode: false, // or 'media' or 'class'
     theme: {


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/story-ramp/issues/402 (not in this repo)

### Changes
- Added option for user to select between horizontal and vertical table of contents
- The default option is a vertical table of contents

### Notes
Option in the metadata panel:
![toc orientation](https://github.com/ramp4-pcar4/storylines-editor/assets/83516523/ebf379c0-4621-4ebc-b50a-189ff3462494)

Tested in editor preview by creating a local `story-ramp` package:
![horizontaltabsinpreview](https://github.com/ramp4-pcar4/storylines-editor/assets/83516523/577777eb-f3f0-428c-8336-9ec0c12782ff)

### Testing
Steps:
1. Open Project Metadata editor. Choose between horizontal or vertical table of contents.

This has been tested in the editor preview using by creating a local `story-ramp` package based on the [adjacent PR](https://github.com/ramp4-pcar4/story-ramp/pull/413).

~~There isn't a way to test whether the functionality works because there is [another PR open in the story-ramp repo](https://github.com/ramp4-pcar4/story-ramp/pull/413) that is meant to implement the functionality. If there are any other methods to test, that would be appreciated, thanks!~~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/265)
<!-- Reviewable:end -->
