### PR TITLE
Add video panel support in editor

### DIFF
--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -100,13 +100,15 @@ import {
     MapPanel,
     PanelType,
     SlideshowPanel,
-    SourceCounts
+    SourceCounts,
+    VideoPanel
 } from '@/definitions';
 
 import ChartEditorV from './chart-editor.vue';
 import ImageEditorV from './image-editor.vue';
 import TextEditorV from './text-editor.vue';
 import MapEditorV from './map-editor.vue';
+import VideoEditorV from './video-editor.vue';
 
 @Options({
     components: {
@@ -114,7 +116,8 @@ import MapEditorV from './map-editor.vue';
         'image-editor': ImageEditorV,
         'text-editor': TextEditorV,
         'dynamic-editor': DynamicEditorV,
-        'map-editor': MapEditorV
+        'map-editor': MapEditorV,
+        'video-editor': VideoEditorV
     }
 })
 export default class DynamicEditorV extends Vue {
@@ -128,7 +131,8 @@ export default class DynamicEditorV extends Vue {
         image: 'image-editor',
         slideshow: 'image-editor',
         chart: 'chart-editor',
-        map: 'map-editor'
+        map: 'map-editor',
+        video: 'video-editor'
     };
 
     startingConfig: DefaultConfigs = {
@@ -157,6 +161,12 @@ export default class DynamicEditorV extends Vue {
             config: '',
             title: '',
             scrollguard: false
+        },
+        video: {
+            type: PanelType.Video,
+            title: '',
+            videoType: '',
+            src: ''
         }
     };
 
@@ -224,6 +234,19 @@ export default class DynamicEditorV extends Vue {
                         this.configFileStructure.zip.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
                     }
                 });
+                break;
+            }
+
+            case 'video': {
+                const videoPanel = panel as VideoPanel;
+                if (videoPanel.videoType === 'local') {
+                    this.sourceCounts[videoPanel.src] -= 1;
+                    if (this.sourceCounts[videoPanel.src] === 0) {
+                        this.configFileStructure.zip.remove(
+                            `${videoPanel.src.substring(videoPanel.src.indexOf('/') + 1)}`
+                        );
+                    }
+                }
                 break;
             }
         }

--- a/src/components/editor/helpers/video-preview.vue
+++ b/src/components/editor/helpers/video-preview.vue
@@ -1,0 +1,87 @@
+<template>
+    <div class="my-8 mx-4 overflow-hidden w-full">
+        <div class="relative text-center w-full grabbable">
+            <button
+                class="bg-white absolute h-6 w-6 leading-5 rounded-full top-0 right-0 p-0 cursor-pointer"
+                @click="() => $emit('delete', file)"
+                :content="$t('editor.video.delete')"
+                v-tippy="{ placement: 'top', hideOnClick: false, animateFill: true }"
+            >
+                <svg height="24px" width="24px" viewBox="0 0 352 512" xmlns="http://www.w3.org/2000/svg">
+                    <path
+                        d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"
+                    />
+                </svg>
+            </button>
+            <div class="video-container">
+                <!-- YouTube video -->
+                <template v-if="file.videoType === 'YouTube'">
+                    <iframe
+                        class="w-3/5"
+                        :src="file.src"
+                        :height="file.height ? file.height : 400"
+                        :width="file.width"
+                        allowfullscreen
+                    ></iframe>
+                </template>
+
+                <!-- video with local/external source -->
+                <template v-if="file.videoType === 'local' || file.videoType === 'external'">
+                    <video
+                        class="w-3/5"
+                        :title="file.title"
+                        :height="file.height ? file.height : 500"
+                        :width="file.width"
+                        controls
+                    >
+                        <source :type="fileType" :src="file.src" />
+                        <!-- add captions with transcript -->
+                        <track
+                            kind="captions"
+                            :src="file.caption"
+                            :srclang="lang"
+                            :label="langs[lang]"
+                            v-if="file.caption"
+                        />
+                    </video>
+                </template>
+            </div>
+        </div>
+        <slot></slot>
+    </div>
+</template>
+
+<script lang="ts">
+import { Prop, Vue } from 'vue-property-decorator';
+import { VideoFile } from '@/definitions';
+import MarkdownIt from 'markdown-it';
+
+export default class VideoPreviewV extends Vue {
+    @Prop() file!: VideoFile;
+    @Prop() fileType!: string;
+    @Prop() lang!: string;
+
+    md = new MarkdownIt({ html: true });
+    langs = { en: 'English', fr: 'French' } as Record<string, string>;
+
+    expandTranscript = false;
+    rawTranscript = '';
+    transcriptContent = '';
+}
+</script>
+
+<style lang="scss" scoped>
+.video-file {
+    max-height: 300px;
+}
+
+.video-container {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+button {
+    padding: 0 !important;
+}
+</style>

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -20,9 +20,9 @@
                     <span>
                         <div>{{ $t('editor.image.label.drag') }}</div>
                         <div>
-                            {{ $t('editor.image.label.or') }}
-                            <span class="text-blue-400 font-bold">{{ $t('editor.image.label.browse') }}</span>
-                            {{ $t('editor.image.label.upload') }}
+                            {{ $t('editor.label.or') }}
+                            <span class="text-blue-400 font-bold">{{ $t('editor.label.browse') }}</span>
+                            {{ $t('editor.label.upload') }}
                         </div>
                     </span>
                     <input type="file" class="cursor-pointer" @change="onFileChange" multiple="multiple" />

--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -171,7 +171,8 @@ import {
     Slide,
     SlideshowPanel,
     SourceCounts,
-    StoryRampConfig
+    StoryRampConfig,
+    VideoPanel
 } from '@/definitions';
 import { VueSpinnerOval } from 'vue3-spinners';
 import { VueFinalModal } from 'vue-final-modal';
@@ -446,6 +447,10 @@ export default class MetadataEditorV extends Vue {
                 break;
             case 'image':
             case 'video':
+                if ((panel as VideoPanel).videoType === 'local') {
+                    this.incrementSourceCount((panel as VideoPanel).src);
+                }
+                break;
             case 'audio':
                 this.incrementSourceCount((panel as AudioPanel).src);
                 break;

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -187,7 +187,7 @@
                             ref="typeSelector"
                             @input="
                                 $vfm.open(`change-slide-${slideIndex}`);
-                                newType = $event.target.value;
+                                newType = ($event.target as HTMLInputElement).value;
                             "
                             :value="currentSlide.panel[panelIndex].type"
                         >
@@ -250,13 +250,15 @@ import {
     SlideshowPanel,
     SourceCounts,
     StoryRampConfig,
-    TextPanel
+    TextPanel,
+    VideoPanel
 } from '@/definitions';
 
 import ChartEditorV from './chart-editor.vue';
 import ImageEditorV from './image-editor.vue';
 import TextEditorV from './text-editor.vue';
 import MapEditorV from './map-editor.vue';
+import VideoEditorV from './video-editor.vue';
 import LoadingPageV from './helpers/loading-page.vue';
 import DynamicEditorV from './dynamic-editor.vue';
 import ConfirmationModalV from './helpers/confirmation-modal.vue';
@@ -267,6 +269,7 @@ import ConfirmationModalV from './helpers/confirmation-modal.vue';
         'image-editor': ImageEditorV,
         'text-editor': TextEditorV,
         'map-editor': MapEditorV,
+        'video-editor': VideoEditorV,
         'loading-page': LoadingPageV,
         'dynamic-editor': DynamicEditorV,
         'confirmation-modal': ConfirmationModalV
@@ -292,6 +295,7 @@ export default class SlideEditorV extends Vue {
         slideshow: 'image-editor',
         chart: 'chart-editor',
         map: 'map-editor',
+        video: 'video-editor',
         loading: 'loading-page',
         dynamic: 'dynamic-editor'
     };
@@ -334,6 +338,12 @@ export default class SlideEditorV extends Vue {
                 config: '',
                 title: '',
                 scrollguard: false
+            },
+            video: {
+                type: PanelType.Video,
+                title: '',
+                videoType: '',
+                src: ''
             }
         };
 
@@ -386,6 +396,19 @@ export default class SlideEditorV extends Vue {
                 break;
             }
 
+            case 'video': {
+                const videoPanel = panel as VideoPanel;
+                if (videoPanel.videoType === 'local') {
+                    this.sourceCounts[videoPanel.src] -= 1;
+                    if (this.sourceCounts[videoPanel.src] === 0) {
+                        this.configFileStructure.zip.remove(
+                            `${videoPanel.src.substring(videoPanel.src.indexOf('/') + 1)}`
+                        );
+                    }
+                }
+                break;
+            }
+
             case 'dynamic': {
                 const dynamicPanel = panel as DynamicPanel;
                 dynamicPanel.children.forEach((subPanel: DynamicChildItem) => {
@@ -399,9 +422,9 @@ export default class SlideEditorV extends Vue {
     saveChanges(): void {
         if (
             this.$refs.editor !== undefined &&
-            typeof (this.$refs.editor as ImageEditorV | ChartEditorV).saveChanges === 'function'
+            typeof (this.$refs.editor as ImageEditorV | ChartEditorV | VideoEditorV).saveChanges === 'function'
         ) {
-            (this.$refs.editor as ImageEditorV | ChartEditorV).saveChanges();
+            (this.$refs.editor as ImageEditorV | ChartEditorV | VideoEditorV).saveChanges();
         }
     }
 

--- a/src/components/editor/slide-toc.vue
+++ b/src/components/editor/slide-toc.vue
@@ -40,7 +40,7 @@
                     >
                         {{ $t('editor.slides.copyAll') }}
                     </button>
-                    <span class="text-lg font-bold my-6"> {{ $t('editor.image.label.or') }} </span>
+                    <span class="text-lg font-bold my-6"> {{ $t('editor.or') }} </span>
                     <div class="flex">
                         <select v-model="selectedForCopying" class="overflow-ellipsis copy-select">
                             <option
@@ -150,7 +150,8 @@ import {
     Slide,
     SlideshowPanel,
     SourceCounts,
-    TextPanel
+    TextPanel,
+    VideoPanel
 } from '@/definitions';
 import { VueFinalModal } from 'vue-final-modal';
 import cloneDeep from 'clone-deep';
@@ -270,6 +271,19 @@ export default class SlideTocV extends Vue {
                         this.configFileStructure.zip.remove(`${image.src.substring(image.src.indexOf('/') + 1)}`);
                     }
                 });
+                break;
+            }
+
+            case 'video': {
+                const videoPanel = panel as VideoPanel;
+                if (videoPanel.videoType === 'local') {
+                    this.sourceCounts[videoPanel.src] -= 1;
+                    if (this.sourceCounts[videoPanel.src] === 0) {
+                        this.configFileStructure.zip.remove(
+                            `${videoPanel.src.substring(videoPanel.src.indexOf('/') + 1)}`
+                        );
+                    }
+                }
                 break;
             }
 

--- a/src/components/editor/video-editor.vue
+++ b/src/components/editor/video-editor.vue
@@ -1,0 +1,300 @@
+<template>
+    <div class="block">
+        <!-- Upload video area -->
+        <div class="flex mt-4 items-center w-full text-left">
+            <label class="text-label">{{ $t('editor.video.title') }}:</label>
+            <input class="w-3/5" type="text" v-model="videoPreview.title" @change="onVideoEdited" />
+        </div>
+
+        <!-- Option 1: upload video file -->
+        <div
+            class="upload-video text-center m-5 p-12 bg-gray-100 border-4 border-dashed border-gray-300"
+            :class="{ dragging: isDragging }"
+            @dragover.prevent="() => (dragging = true)"
+            @dragleave.prevent="() => (dragging = false)"
+            @drop.prevent="dropVideo($event)"
+        >
+            <label class="flex drag-label cursor-pointer">
+                <span class="align-middle inline-block pr-4">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 -2 30 30">
+                        <path
+                            d="M599,692 C597.896,692 597,692.896 597,694 L597,698 L575,698 L575,694 C575,692.896 574.104,692 573,692 C571.896,692 571,692.896 571,694 L571,701 C571,701.479 571.521,702 572,702 L600,702 C600.604,702 601,701.542 601,701 L601,694 C601,692.896 600.104,692 599,692 L599,692 Z M582,684 L584,684 L584,693 C584,694.104 584.896,695 586,695 C587.104,695 588,694.104 588,693 L588,684 L590,684 C590.704,684 591.326,684.095 591.719,683.7 C592.11,683.307 592.11,682.668 591.719,682.274 L586.776,676.283 C586.566,676.073 586.289,675.983 586.016,675.998 C585.742,675.983 585.465,676.073 585.256,676.283 L580.313,682.274 C579.921,682.668 579.921,683.307 580.313,683.7 C580.705,684.095 581.608,684 582,684 L582,684 Z"
+                            transform="translate(-571.000000, -676.000000)"
+                        />
+                    </svg>
+                </span>
+                <span class="align-middle inline-block">
+                    <span>
+                        <div>{{ $t('editor.video.label.drag') }}</div>
+                        <div>
+                            {{ $t('editor.label.or') }}
+                            <span class="text-blue-400 font-bold">{{ $t('editor.label.browse') }}</span>
+                            {{ $t('editor.label.upload') }}
+                        </div>
+                    </span>
+                    <input ref="videoFileInput" type="file" class="cursor-pointer" @change="onFileChange" />
+                </span>
+            </label>
+        </div>
+
+        <!-- Option 2: provide URL to external or YT link -->
+        <div class="flex mt-4 items-center w-full text-left">
+            <label class="text-label">{{ $t('editor.label.or') + ' ' + $t('editor.video.pasteUrl') }}:</label>
+            <input
+                ref="videoUrl"
+                class="w-3/5"
+                type="search"
+                v-model="videoPreview.src"
+                v-if="videoPreview.videoType !== 'local'"
+            />
+            <input ref="videoUrl" class="w-3/5" type="search" v-else />
+            <button @click="uploadVideoUrl" class="bg-white border border-black hover:bg-gray-100">
+                {{ $t('editor.video.label.upload') }}
+            </button>
+        </div>
+
+        <!-- Preview of video -->
+        <div
+            v-if="!videoPreviewLoading && Object.keys(videoPreview).length !== 0"
+            class="flex flex-wrap justify-center list-none border my-4"
+            @update="onVideoEdited"
+            item-key="id"
+        >
+            <VideoPreview
+                :key="`${videoPreview.id}`"
+                :file="videoPreview"
+                :fileType="fileType"
+                :lang="lang"
+                @delete="deleteVideo"
+            >
+                <!-- <div class="flex mt-4 items-center w-full text-left">
+                    <label class="text-label">{{ $t('editor.video.label.captions') }}:</label>
+                    <input class="w-4/5" type="file" @change="updateCaptions" />
+                </div>
+
+                <div class="flex mt-4 items-center w-full text-left">
+                    <label class="text-label">{{ $t('editor.video.label.transcript') }}:</label>
+                    <input class="w-4/5" type="file" @change="updateTranscript" />
+                </div> -->
+            </VideoPreview>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Options, Prop, Vue } from 'vue-property-decorator';
+import { ConfigFileStructure, SourceCounts, VideoFile, VideoPanel } from '@/definitions';
+import draggable from 'vuedraggable';
+import VideoPreviewV from '@/components/editor/helpers/video-preview.vue';
+
+@Options({
+    components: {
+        VideoPreview: VideoPreviewV,
+        draggable
+    }
+})
+export default class VideoEditorV extends Vue {
+    @Prop() panel!: VideoPanel;
+    @Prop() configFileStructure!: ConfigFileStructure;
+    @Prop() lang!: string;
+    @Prop() sourceCounts!: SourceCounts;
+
+    dragging = false;
+    edited = false;
+
+    fileType = '';
+    videoPreviewLoading = false;
+    videoPreviewPromise = undefined as Promise<VideoFile> | undefined;
+    videoPreview = {} as VideoFile | Record<string, never>;
+    slideshowCaption = '';
+
+    get isDragging(): boolean {
+        return this.dragging;
+    }
+
+    mounted(): void {
+        if (this.panel.src) {
+            if (this.panel.videoType === 'local') {
+                this.videoPreviewLoading = true;
+
+                // retrieve existing video file
+                const assetSrc = `${this.panel.src.substring(this.panel.src.indexOf('/') + 1)}`;
+                const filename = this.panel.src.replace(/^.*[\\/]/, '');
+
+                const assetFile = this.configFileStructure.zip.file(assetSrc);
+                if (assetFile) {
+                    this.videoPreviewPromise = assetFile.async('blob').then((res: Blob) => {
+                        return {
+                            ...this.panel,
+                            id: filename ? filename : this.panel.src,
+                            src: URL.createObjectURL(res)
+                        } as VideoFile;
+                    });
+                }
+                // attempt to load in video to preview in editor
+                this.videoPreviewPromise?.then((res) => {
+                    this.videoPreview = res;
+                    this.videoPreviewLoading = false;
+                });
+
+                this.slideshowCaption = this.panel.caption as string;
+            } else {
+                // existing file is a URL format
+                this.videoPreview = {
+                    id: this.panel.src,
+                    title: this.panel.title,
+                    videoType: this.panel.videoType === 'YouTube' ? 'YouTube' : 'external',
+                    src: this.panel.src
+                };
+            }
+        }
+    }
+
+    // adds an uploaded file that is either a: video, transcript or captions
+    addUploadedFile(file: File, type: string): void {
+        const uploadSource = `${this.configFileStructure.uuid}/assets/${this.lang}/${file.name}`;
+        this.configFileStructure.assets[this.lang].file(file.name, file);
+        if (this.sourceCounts[uploadSource]) {
+            this.sourceCounts[uploadSource] += 1;
+        } else {
+            this.sourceCounts[uploadSource] = 1;
+        }
+
+        // check if source file is creating a new video or uploading captions/transcript for current video
+        const fileSrc = URL.createObjectURL(file);
+        if (type === 'src') {
+            this.videoPreview = {
+                id: file.name,
+                title: this.videoPreview.title || file.name,
+                videoType: 'local',
+                src: fileSrc
+            };
+            this.findFileType(file.name);
+        } else {
+            this.videoPreview[type as 'caption' | 'transcript'] = fileSrc;
+        }
+        this.edited = true;
+        this.$emit('slide-edit');
+    }
+
+    onFileChange(e: Event): void {
+        const file = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
+        this.addUploadedFile(file, 'src');
+        this.onVideoEdited();
+    }
+
+    findFileType(file: string): void {
+        if (this.videoPreview.videoType === 'external' || this.videoPreview.videoType === 'local') {
+            const fileName = file.substring(file.lastIndexOf('/') + 1);
+            const ext = fileName.split('.').pop();
+            this.fileType = `video/${ext}`;
+        }
+    }
+
+    // extract the video ID from YouTube link (we need to convert to embed link)
+    extractYoutubeId(url: string): string | null {
+        const regExp = /^.*(youtu.be\/|v\/|u\/\w\/|embed\/|watch\?v=|&v=)([^#&?]*).*/;
+        const match = url.match(regExp);
+        return match && match[2].length === 11 ? match[2] : null;
+    }
+
+    uploadVideoUrl(): void {
+        // TODO: might need to improve upon detecting YT link depending on cases
+        let url = (this.$refs.videoUrl as HTMLInputElement).value as string;
+        const isYoutube = url.toLowerCase().includes('youtube');
+
+        // change YT link to embed format
+        if (isYoutube) {
+            // extract and restructure YT url to be embeddable
+            // const videoId = this.extractYoutubeId(url);
+            // // TODO: add error handling for invalid URLs
+            // url = 'https://www.youtube.com/embed/' + (videoId as string);
+            url = url.replace('/watch?v=', '/embed/');
+        }
+        this.videoPreview = {
+            id: url,
+            title: this.videoPreview.title || url,
+            videoType: url.includes('youtube') ? 'YouTube' : 'external',
+            src: url
+        };
+        this.edited = true;
+        this.$emit('slide-edit');
+    }
+
+    updateCaptions(e: Event): void {
+        const file = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
+        this.addUploadedFile(file, 'caption');
+    }
+
+    updateTranscript(e: Event): void {
+        const file = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
+        this.addUploadedFile(file, 'transcript');
+    }
+
+    dropVideo(e: DragEvent): void {
+        if (e.dataTransfer !== null) {
+            const file = [...e.dataTransfer.files][0];
+            this.addUploadedFile(file, 'src');
+            this.dragging = false;
+        }
+        this.onVideoEdited();
+    }
+
+    deleteVideo(): void {
+        (this.$refs.videoFileInput as HTMLInputElement).value = '';
+        this.videoPreview = {};
+        this.onVideoEdited();
+    }
+
+    saveChanges(): void {
+        if (this.edited && this.videoPreview) {
+            // save all changes to panel config (cannot directly set to avoid prop mutate)
+            this.panel.title = this.videoPreview.title;
+            this.panel.videoType = this.videoPreview.videoType;
+            this.panel.src =
+                this.videoPreview.videoType === 'local'
+                    ? `${this.configFileStructure.uuid}/assets/${this.lang}/${this.videoPreview.id}`
+                    : this.videoPreview.src;
+            this.panel.caption = this.videoPreview.caption ? this.videoPreview.caption : '';
+            this.panel.transcript = this.videoPreview.transcript ? this.videoPreview.transcript : '';
+        }
+        this.edited = false;
+    }
+
+    onVideoEdited(): void {
+        this.edited = true;
+        this.$emit('slide-edit');
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.upload-video {
+    input[type='file']:not(:focus-visible) {
+        position: absolute !important;
+        width: 1px !important;
+        height: 1px !important;
+        padding: 0 !important;
+        margin: -1px !important;
+        overflow: hidden !important;
+        clip: rect(0, 0, 0, 0) !important;
+        white-space: nowrap !important;
+        border: 0 !important;
+    }
+}
+
+.drag-label {
+    width: auto !important;
+}
+
+.text-label {
+    width: 25% !important;
+    margin-right: 0.5rem !important;
+    margin-bottom: 0 !important;
+}
+
+.dragging {
+    background-color: #fffaf0;
+    border-color: #fff;
+}
+</style>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -200,10 +200,13 @@ export interface ImagePanel extends BasePanel {
 
 export interface VideoPanel extends BasePanel {
     type: PanelType.Video;
+    title: string;
     width?: number;
     height?: number;
     src: string;
+    videoType: string;
     caption?: string;
+    transcript?: string;
 }
 
 export interface AudioPanel extends BasePanel {
@@ -243,10 +246,22 @@ export interface ImageFile {
     height?: number;
 }
 
+export interface VideoFile {
+    id: string;
+    title: string;
+    src: string;
+    videoType: 'local' | 'external' | 'YouTube';
+    caption?: string;
+    transcript?: string;
+    width?: number;
+    height?: number;
+}
+
 export interface DefaultConfigs {
     text: TextPanel;
     slideshow: SlideshowPanel;
     chart: ChartPanel;
     dynamic: DynamicPanel;
     map: MapPanel;
+    video: VideoPanel;
 }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -49,6 +49,9 @@ editor.confirm,Confirm,1,Confirmer,1
 editor.cancel,Cancel,1,Annuler,1
 editor.unsavedChanges,Unsaved changes,1,Modifications non enregistrées,1
 editor.saveChanges,Save Changes,1,Enregistrer les modifications,1
+editor.label.or,or,1,ou,1
+editor.label.browse,browse,1,parcourir,1
+editor.label.upload,to upload,1,téléverser,1
 editor.savingChanges,Saving...,1,Enregistrement...,1
 editor.resetChanges,Reset Changes,1,Annuler les modifications,1
 editor.refreshChanges.modal,"Are you sure you want to reload the product? All unsaved changes will be lost.",1,"Voulez-vous vraiment recharger ce produit? Toute modification non enregistrée sera perdue.",1
@@ -58,14 +61,18 @@ editor.englishConfig,View English Config,1,Afficher la configuration en anglais,
 editor.returnToLanding,Return to Landing,1,Retour à la page d’accueil,1
 editor.image.delete,Delete Image,1,Supprimer l'image,1
 editor.image.label.drag,Drag your images here,1,Faites glisser vos images ici,1
-editor.image.label.or,or,1,ou,1
-editor.image.label.browse,browse,1,parcourir,1
-editor.image.label.upload,to upload,1,téléverser,1
 editor.image.label.caption,Caption,1,Légende,1
 editor.image.reorder,Click and drag to reorder images,1,Cliquez sur les images et faites-les glisser pour changer l’ordre.,1
 editor.image.altTag,Alt tag,1,Texte de remplacement,1
 editor.image.slideshowCaption,Slideshow Caption,1,Légende du diaporama,1
 editor.image.loadingError,An error occurred when trying to load image,1,Une erreur est survenue lors du chargement de l’image.,1
+editor.video.title,Video Title,1,Titre de la vidéo,1
+editor.video.label.drag,Drag your video file here,1,Glissez votre fichier vidéo ici,1
+editor.video.label.captions,Video Captions,1,Sous-titres,1
+editor.video.label.transcript,Video Transcript,1,Transcription,1
+editor.video.label.upload,Upload,1,Télécharger,1
+editor.video.delete,Delete Video,1,Supprimer la vidéo,1
+editor.video.pasteUrl,Paste the URL to a video,1,Paste the URL to a video,0
 editor.chart.delete,Delete Chart,1,Supprimer le graphique,1
 editor.chart.label.name,Name,1,Nom,1
 editor.chart.label.edit,Edit,1,Éditer,1


### PR DESCRIPTION
### Related Item(s)
Closes #236 

### Changes
Integrated video panel editor in the slide editor. Supports two options: user-uploaded video or a URL that can be either a YouTube link or another external video source.

### Notes
Outstanding issues include: 
- attempting to save while on right panel does not save changes (#266)
- fixing user uploaded videos in preview mode (creating blob in preview tab does not work)
- adding support for uploading captions/transcripts for videos (#267)

### Testing
Test the new video panel editor for any bugs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/268)
<!-- Reviewable:end -->
