### PR TITLE
Fix saving for right panels and unsaved alert not appearing

### DIFF
--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -81,6 +81,7 @@
                     :configFileStructure="configFileStructure"
                     :lang="lang"
                     :sourceCounts="sourceCounts"
+                    @slide-edit="$emit('slide-edit')"
                 ></component>
             </div>
         </div>

--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -262,11 +262,10 @@ export default class EditorV extends Vue {
         if (this.$refs.slide !== undefined) {
             this.$nextTick(() => {
                 (this.$refs.slide as SlideEditorV).saveChanges();
+                // emit save changes event
+                this.$emit('save-changes');
             });
         }
-
-        // emit save changes event
-        this.$emit('save-changes');
     }
 
     beforeWindowUnload(e: BeforeUnloadEvent): void {

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -25,7 +25,7 @@
                             {{ $t('editor.image.label.upload') }}
                         </div>
                     </span>
-                    <input type="file" class="cursor-pointer" @change="onFileChange" multiple="multiple" />
+                    <input type="file" class="cursor-pointer" @change="onFileChange" multiple />
                 </span>
             </label>
         </div>

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -212,6 +212,7 @@
                     :lang="lang"
                     :uid="uid"
                     :sourceCounts="sourceCounts"
+                    @slide-edit="$emit('slide-edit')"
                 ></component>
             </div>
         </div>


### PR DESCRIPTION
### Related Item(s)
Closes #266 

### Changes
Fixes issues of not being able to save while making changes on multimedia right panel due to timing of config save + upload to server. Also resolves issue of unsaved changes message not popping up when editing multimedia panel.

### Testing
Attempt to make changes and save + reload product to ensure all changes are preserved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/270)
<!-- Reviewable:end -->
