### PR TITLE
allow changing left panel to any type

### DIFF
--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -181,7 +181,7 @@
                 <div class="flex mt-4">
                     <span class="font-bold text-xl">{{ $t('editor.slides.content') }}:</span>
                     <span class="ml-auto flex-grow"></span>
-                    <div v-if="panelIndex === 1 || rightOnly" class="flex flex-col mr-8">
+                    <div class="flex flex-col mr-8">
                         <label class="text-left text-lg">{{ $t('editor.slides.contentType') }}:</label>
                         <select
                             ref="typeSelector"


### PR DESCRIPTION
### Related Item(s)
#252 

### Changes
- Removes the condition on the type selector to allow changing the type of the left panel.
 
### Notes
As with the other PRs that require changes in the main Storylines repo, previewing this feature will not work until the NPM package is updated.

### Testing
Steps:
1. Try changing the type of the left panel and ensure everything is saving correctly in the config.
2. Will update these steps once previewing is working.
