### PR TITLE
fix saving on metadata page

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -187,6 +187,7 @@ export default class EditorV extends Vue {
     created(): void {
         this.loadSlides = this.slides;
         this.uuid = this.$route.params.uid as string;
+
         window.addEventListener('beforeunload', this.beforeWindowUnload);
     }
 

--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -201,6 +201,7 @@ interface RouteParams {
     slides: Slide[];
     sourceCounts: SourceCounts;
     existing: boolean;
+    unsavedChanges: boolean;
 }
 
 @Options({
@@ -291,6 +292,7 @@ export default class MetadataEditorV extends Vue {
                 this.slides = props.slides;
                 this.sourceCounts = props.sourceCounts;
                 this.loadExisting = props.existing;
+                this.unsavedChanges = props.unsavedChanges;
                 // Load product logo (if provided).
                 const logo = this.configs[this.configLang]?.introSlide.logo?.src;
                 const logoSrc = `assets/${this.configLang}/${this.metadata.logoName}`;
@@ -810,7 +812,8 @@ export default class MetadataEditorV extends Vue {
                         sourceCounts: this.sourceCounts,
                         metadata: this.metadata,
                         slides: this.slides,
-                        existing: this.editExisting
+                        existing: this.editExisting,
+                        unsavedChanges: this.unsavedChanges
                     };
                 }
             });
@@ -839,6 +842,7 @@ export default class MetadataEditorV extends Vue {
         if (this.loadExisting) {
             if (this.configs[this.configLang] !== undefined && this.uuid === this.configFileStructure?.uuid) {
                 this.loadEditor = true;
+                this.saveMetadata(false);
                 this.updateEditorPath();
             } else {
                 Message.error('No config exists for storylines product.');


### PR DESCRIPTION
### Related Item(s)
#276 

### Changes
- This PR fixes the saving issue with the metadata page. It will set `unsavedChanges` to true if any changes have been made to the metadata.

### Testing
Steps:
1. Load a product.
2. Make some changes to the metadata on the metadata page.
3. Click `next` to get to the main editor. The `unsaved changes` warning should appear at the top.
4. Ensure that the changes you've made to the metadata persist.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/279)
<!-- Reviewable:end -->
