### PR TITLE
Fix Vue 3 router redirect

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -12,7 +12,9 @@ const routes = [
     },
     {
         path: '/:lang/editor/:uid',
-        redirect: '/:lang/editor-metadata/:uid'
+        redirect: (to: RouteLocationNormalized) => {
+            return '/' + to.params.lang + '/editor-metadata/' + to.params.uid;
+        }
     },
     {
         path: '/:lang/editor-metadata',


### PR DESCRIPTION
### Related Item(s)
Closes #277 

### Changes
- [FIX] router redirect for the `'/:lang/editor/:uid'` route to correctly redirect to metadata page for given UID

### Testing
Steps:
1. Load https://ramp4-pcar4.github.io/storylines-editor/fix-router-redirect/#/en/editor/00000000-0000-0000-0000-000000000000
2. Test that redirected page to metadata is working and loads product

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/282)
<!-- Reviewable:end -->
