### PR TITLE
Option for centering content

### DIFF
--- a/src/components/editor/chart-editor.vue
+++ b/src/components/editor/chart-editor.vue
@@ -93,6 +93,8 @@ export default class ChartEditorV extends Vue {
     @Prop() lang!: string;
     @Prop() sourceCounts!: SourceCounts;
     @Prop({ default: true }) allowMany!: boolean;
+    @Prop({ default: false }) centerSlide!: boolean;
+    @Prop({ default: false }) dynamicSelected!: boolean;
 
     edited = false;
 
@@ -124,6 +126,16 @@ export default class ChartEditorV extends Vue {
                 : this.panel.src
                 ? [this.panel]
                 : [];
+
+        if (this.centerSlide && this.dynamicSelected) {
+            for (const c in charts) {
+                charts[c].customStyles += 'text-align: left;';
+            }
+        } else if (!this.centerSlide && this.dynamicSelected) {
+            for (const c in charts) {
+                charts[c].customStyles = (charts[c].customStyles || '').replace('text-align: left;', '');
+            }
+        }
 
         // load charts from existing storylines product
         if (charts !== undefined && charts.length) {

--- a/src/components/editor/dynamic-editor.vue
+++ b/src/components/editor/dynamic-editor.vue
@@ -72,6 +72,8 @@
                     :configFileStructure="configFileStructure"
                     :lang="lang"
                     :sourceCounts="sourceCounts"
+                    :centerSlide="centerSlide"
+                    :dynamicSelected="dynamicSelected"
                     @slide-edit="$emit('slide-edit')"
                 ></component>
             </div>
@@ -120,6 +122,8 @@ export default class DynamicEditorV extends Vue {
     @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
     @Prop() sourceCounts!: SourceCounts;
+    @Prop() centerSlide!: boolean;
+    @Prop() dynamicSelected!: boolean;
 
     editors: Record<string, string> = {
         text: 'text-editor',

--- a/src/components/editor/image-editor.vue
+++ b/src/components/editor/image-editor.vue
@@ -97,6 +97,8 @@ export default class ImageEditorV extends Vue {
     @Prop() lang!: string;
     @Prop() sourceCounts!: SourceCounts;
     @Prop({ default: true }) allowMany!: boolean;
+    @Prop({ default: false }) centerSlide!: boolean;
+    @Prop({ default: false }) dynamicSelected!: boolean;
 
     dragging = false;
     edited = false;
@@ -118,6 +120,16 @@ export default class ImageEditorV extends Vue {
                 : this.panel.src
                 ? [this.panel]
                 : [];
+
+        if (this.centerSlide && this.dynamicSelected) {
+            for (const i in images) {
+                images[i].customStyles += 'text-align: left;';
+            }
+        } else if (!this.centerSlide && this.dynamicSelected) {
+            for (const i in images) {
+                images[i].customStyles = (images[i].customStyles || '').replace('text-align: left;', '');
+            }
+        }
 
         if (images !== undefined && images.length) {
             // Set images as loading until they are all loaded and resolve.

--- a/src/components/editor/map-editor.vue
+++ b/src/components/editor/map-editor.vue
@@ -65,6 +65,8 @@ export default class MapEditorV extends Vue {
     @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
     @Prop() sourceCounts!: SourceCounts;
+    @Prop({ default: false }) centerSlide!: boolean;
+    @Prop({ default: false }) dynamicSelected!: boolean;
 
     // config editor
     rampEditorApi: any = '';
@@ -92,6 +94,12 @@ export default class MapEditorV extends Vue {
 
         if (this.status === 'creating') {
             this.createNewConfig();
+        }
+
+        if (this.centerSlide && this.dynamicSelected) {
+            this.panel.customStyles += 'text-align: left !important;';
+        } else if (!this.centerSlide && this.dynamicSelected) {
+            this.panel.customStyles = (this.panel.customStyles || '').replace('text-align: left !important;', '');
         }
 
         this.openEditor();

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -36,6 +36,22 @@
                             :disabled="rightOnly && determineEditorType(currentSlide.panel[panelIndex]) === 'dynamic'"
                             @change.stop="$vfm.open(`right-only-${slideIndex}`)"
                         />
+                        <span class="mx-2 font-bold">{{ $t('editor.slides.centerSlide') }}</span>
+                        <input
+                            type="checkbox"
+                            class="editor-input rounded-none cursor-pointer w-4 h-4"
+                            v-model="centerSlide"
+                            :disabled="centerPanel"
+                            @change.stop="toggleCenterSlide()"
+                        />
+                        <span class="mx-2 font-bold">{{ $t('editor.slides.centerPanel') }}</span>
+                        <input
+                            type="checkbox"
+                            class="editor-input rounded-none cursor-pointer w-4 h-4"
+                            v-model="centerPanel"
+                            :disabled="centerSlide"
+                            @change.stop="toggleCenterPanel()"
+                        />
                     </div>
                 </div>
             </div>
@@ -215,6 +231,8 @@
                     :lang="lang"
                     :uid="uid"
                     :sourceCounts="sourceCounts"
+                    :centerSlide="centerSlide"
+                    :dynamicSelected="dynamicSelected"
                     @slide-edit="$emit('slide-edit')"
                 ></component>
             </div>
@@ -229,7 +247,11 @@
                     title: currentSlide.title
                 })
             "
-            @ok="changePanelType(determineEditorType(currentSlide.panel[panelIndex]), newType)"
+            @ok="
+                changePanelType(determineEditorType(currentSlide.panel[panelIndex]), newType);
+                toggleCenterPanel();
+                toggleCenterSlide();
+            "
             @Cancel="cancelTypeChange"
         />
         <confirmation-modal
@@ -302,6 +324,9 @@ export default class SlideEditorV extends Vue {
     panelIndex = 0;
     newType = '';
     rightOnly = false;
+    centerSlide = false;
+    centerPanel = false;
+    dynamicSelected = false;
 
     editors: Record<string, string> = {
         text: 'text-editor',
@@ -373,6 +398,7 @@ export default class SlideEditorV extends Vue {
         if (newType === 'dynamic') {
             this.panelIndex = 0;
             this.currentSlide['panel'] = [startingConfig[newType as keyof DefaultConfigs]];
+            this.dynamicSelected = true;
         } else {
             // Switching panel type when dynamic panels are not involved.
             this.currentSlide.panel[this.panelIndex] = startingConfig[newType as keyof DefaultConfigs];
@@ -501,6 +527,65 @@ export default class SlideEditorV extends Vue {
                 ),
                 Object.assign({}, this.currentSlide.panel[0])
             ];
+        }
+    }
+
+    toggleCenterSlide(): void {
+        if (this.determineEditorType(this.currentSlide.panel[this.panelIndex]) === 'dynamic') {
+            if (this.centerSlide) {
+                this.currentSlide.panel[0].customStyles = 'text-align: right;';
+            } else {
+                this.currentSlide.panel[0].customStyles = (this.currentSlide.panel[0].customStyles || '').replace(
+                    'text-align: right;',
+                    ''
+                );
+            }
+        } else if (this.rightOnly) {
+            if (this.centerSlide) {
+                this.currentSlide.panel[0].customStyles = 'text-align: center;';
+            } else {
+                this.currentSlide.panel[0].customStyles = (this.currentSlide.panel[0].customStyles || '').replace(
+                    'text-align: right;',
+                    ''
+                );
+                this.currentSlide.panel[0].customStyles = (this.currentSlide.panel[0].customStyles || '').replace(
+                    'text-align: left;',
+                    ''
+                );
+                this.currentSlide.panel[0].customStyles = (this.currentSlide.panel[0].customStyles || '').replace(
+                    'text-align: center;',
+                    ''
+                );
+            }
+        } else {
+            if (this.centerSlide) {
+                this.currentSlide.panel[0].customStyles = 'text-align: right;';
+                this.currentSlide.panel[1].customStyles = 'text-align: left;';
+            } else {
+                this.currentSlide.panel[0].customStyles = (this.currentSlide.panel[0].customStyles || '').replace(
+                    'text-align: right;',
+                    ''
+                );
+                this.currentSlide.panel[1].customStyles = (this.currentSlide.panel[1].customStyles || '').replace(
+                    'text-align: left;',
+                    ''
+                );
+            }
+        }
+    }
+
+    toggleCenterPanel(): void {
+        if (this.centerPanel) {
+            for (const p in this.currentSlide.panel) {
+                this.currentSlide.panel[p].customStyles = 'text-align: center;';
+            }
+        } else {
+            for (const p in this.currentSlide.panel) {
+                this.currentSlide.panel[p].customStyles = (this.currentSlide.panel[p].customStyles || '').replace(
+                    'text-align: center;',
+                    ''
+                );
+            }
         }
     }
 }

--- a/src/components/editor/text-editor.vue
+++ b/src/components/editor/text-editor.vue
@@ -22,6 +22,8 @@ interface MDEditor {
 
 export default class TextEditorV extends Vue {
     @Prop() panel!: TextPanel;
+    @Prop({ default: false }) centerSlide!: boolean;
+    @Prop({ default: false }) dynamicSelected!: boolean;
 
     toolbar = {
         subsuper: {
@@ -107,6 +109,14 @@ export default class TextEditorV extends Vue {
             ]
         }
     };
+
+    mounted(): void {
+        if (this.centerSlide && this.dynamicSelected) {
+            this.panel.customStyles += 'text-align: left !important;';
+        } else if (!this.centerSlide && this.dynamicSelected) {
+            this.panel.customStyles = (this.panel.customStyles || '').replace('text-align: left !important;', '');
+        }
+    }
 }
 </script>
 

--- a/src/components/editor/video-editor.vue
+++ b/src/components/editor/video-editor.vue
@@ -98,6 +98,8 @@ export default class VideoEditorV extends Vue {
     @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
     @Prop() sourceCounts!: SourceCounts;
+    @Prop({ default: false }) centerSlide!: boolean;
+    @Prop({ default: false }) dynamicSelected!: boolean;
 
     dragging = false;
     edited = false;
@@ -147,6 +149,11 @@ export default class VideoEditorV extends Vue {
                     src: this.panel.src
                 };
             }
+        }
+        if (this.centerSlide && this.dynamicSelected) {
+            this.panel.customStyles += 'text-align: left !important;';
+        } else if (!this.centerSlide && this.dynamicSelected) {
+            this.panel.customStyles = (this.panel.customStyles || '').replace('text-align: left !important;', '');
         }
     }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -148,6 +148,7 @@ export enum PanelType {
 export interface BasePanel {
     type: string;
     width?: number;
+    customStyles?: string;
 }
 
 export interface TextPanel extends BasePanel {
@@ -155,6 +156,7 @@ export interface TextPanel extends BasePanel {
     title: string;
     titleTag?: string;
     content: string; // in md format
+    customStyles?: string;
 }
 
 export interface MapPanel extends BasePanel {
@@ -164,6 +166,7 @@ export interface MapPanel extends BasePanel {
     timeSlider?: TimeSliderConfig;
     title: string;
     scrollguard: boolean;
+    customStyles?: string;
 }
 export interface TimeSliderConfig {
     range: number[];
@@ -178,6 +181,7 @@ export interface DynamicPanel extends BasePanel {
     titleTag?: string;
     content: string;
     children: DynamicChildItem[];
+    customStyles?: string;
 }
 
 export interface DynamicChildItem {
@@ -193,6 +197,7 @@ export interface ImagePanel extends BasePanel {
     fullscreen?: boolean;
     altText?: string;
     caption?: string;
+    customStyles?: string;
 }
 
 export interface VideoPanel extends BasePanel {
@@ -204,12 +209,14 @@ export interface VideoPanel extends BasePanel {
     videoType: string;
     caption?: string;
     transcript?: string;
+    customStyles?: string;
 }
 
 export interface AudioPanel extends BasePanel {
     type: PanelType.Audio;
     src: string;
     caption?: string;
+    customStyles?: string;
 }
 
 export interface SlideshowPanel extends BasePanel {
@@ -218,6 +225,7 @@ export interface SlideshowPanel extends BasePanel {
     loop?: boolean;
     caption?: string;
     userCreated?: boolean; // used to determine whether this was automatically converted to slideshow or not
+    customStyles?: string;
 }
 
 export interface ChartPanel extends BasePanel {
@@ -227,6 +235,7 @@ export interface ChartPanel extends BasePanel {
     config?: any;
     name?: string;
     options?: DQVOptions;
+    customStyles?: string;
 }
 
 export interface ChartConfig {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -111,6 +111,8 @@ editor.slides.copyFromLang,"Copy slides from the other language",1,"Copier les d
 editor.slides.deleteSlide.confirm,"Are you sure you want to delete the slide {title}?",1,"Voulez-vous vraiment supprimer la diapositive {titre}?",1
 editor.slides.changeSlide.confirm,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",1,"Voulez-vous vraiment modifier la diapositive {titre}? Toute modification non enregistrée sera perdue.",1
 editor.slides.makeFull,Make the right panel the full slide,1,Mettre la diapositive complète dans le panneau de droite,1
+editor.slides.centerPanel,Center panel content,1,Contenu de la diapositive centrale,0
+editor.slides.centerSlide,Center slide content,1,Contenu du panneau central,0
 editor.slides.copyAll,Copy all,1,Copier tout,1
 editor.slides.copy,Copy,1,Copier,1
 editor.slides.slide,Slide,1,Diapositive,1


### PR DESCRIPTION
### Related Item(s)
[#403](https://github.com/ramp4-pcar4/story-ramp/issues/403) in `story-ramp` repo

### Changes
- This issue is logged in the `story-ramp` repo, however the changes needed to be implemented in `storylines-editor` to allow users to manipulate the `customStyles` property for each panel
- `centerPanel` allows the user to center content in each panel 
- `centerSlide` allows the user to center content in the overall slide (if the slide has two panels then the left panel is right-aligned and the right panel is left-aligned)

### Notes
Without centering:
![alignment normal](https://github.com/ramp4-pcar4/storylines-editor/assets/83516523/256c0a7c-9948-4f2e-9f84-6ebe29e14ed5)

When `centerPanel` is selected:
![alignment panel](https://github.com/ramp4-pcar4/storylines-editor/assets/83516523/7aa7dc65-0bc3-44c9-bfb3-cb56b9685f35)

When `centerSlide` is selected:
![alignment slide](https://github.com/ramp4-pcar4/storylines-editor/assets/83516523/fb2bdf88-9e82-422a-b298-a6e980b35126)

When there is only one panel and `centerSlide` or `centerPanel` is selected:
![alignment one](https://github.com/ramp4-pcar4/storylines-editor/assets/83516523/f5580a32-37ad-42fb-9de4-495a8d2f61c7)

### Testing
Steps:
1. Create a new slide
2. Select `Center panel content` and preview to check the alignment of the content on the panel (should be centered relative to the panel).
3. Select `Center slide content` and preview to check the alignment of the content on the slide (left slide should be right-aligned and right slide should be left-aligned).
4. Experiment with dynamic panels in particular to ensure the panels in `children` are being aligned correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/285)
<!-- Reviewable:end -->
