### PR TITLE
fix map panel not saving correctly in slideshows

### DIFF
--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -230,7 +230,7 @@
                 <div class="flex mt-4">
                     <span class="font-bold text-xl">{{ $t('editor.slides.content') }}:</span>
                     <span class="ml-auto flex-grow"></span>
-                    <div v-if="(panelIndex === 1 && !advancedEditorView) || rightOnly" class="flex flex-col mr-8">
+                    <div v-if="!advancedEditorView || rightOnly" class="flex flex-col mr-8">
                         <label class="editor-label text-left text-lg">{{ $t('editor.slides.contentType') }}:</label>
                         <select
                             ref="typeSelector"

--- a/src/components/editor/slideshow-editor.vue
+++ b/src/components/editor/slideshow-editor.vue
@@ -259,12 +259,16 @@ export default class SlideshowEditorV extends Vue {
             itemConfig = (this.$refs.slideEditor as any).panel;
         }
 
-        if (itemConfig.type !== PanelType.Text && itemConfig.type !== PanelType.Map) {
+        if (itemConfig.type !== PanelType.Text) {
             if (
                 this.$refs.slideEditor !== undefined &&
                 typeof (this.$refs.slideEditor as ImageEditorV | ChartEditorV).saveChanges === 'function'
             ) {
                 (this.$refs.slideEditor as ImageEditorV | ChartEditorV).saveChanges();
+
+                if (itemConfig.type === PanelType.Map) {
+                    this.$emit('slide-edit');
+                }
             }
         }
 


### PR DESCRIPTION
### Related Item(s)
#291 

### Changes
- This PR enables saving for map panels if they're being created in the slideshow editor.
- The ability to change the type of the left side was accidentally removed in a previous PR. I've re-enabled it now.

### Testing
Steps:
1. Open the demo page.
2. Create a new slideshow panel and add a `map` entry. 
3. Make some changes to the map and click `Save changes` at the bottom to add it to the slideshow. The `unsaved changes` warning should now appear.
4. Save the entire product and ensure the map changes persist.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/296)
<!-- Reviewable:end -->
