### PR TITLE
Fix advanced editor for FR configs and loading FR configs

### DIFF
--- a/src/components/editor/helpers/custom-editor.vue
+++ b/src/components/editor/helpers/custom-editor.vue
@@ -2,7 +2,7 @@
     <div class="mt-4">
         <json-editor
             v-model="updatedConfig"
-            :lang="lang"
+            lang="en"
             :mode="'text'"
             :show-btns="true"
             :expandedOnStart="true"
@@ -32,7 +32,6 @@ import { Validator } from '@/definitions';
 export default class CustomEditorV extends Vue {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     @Prop() config!: string;
-    @Prop() lang!: string;
     @Prop() slideIndex!: number;
 
     schemaUrl = './StorylinesSlideSchema.json';

--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -322,7 +322,7 @@ export default class MetadataEditorV extends Vue {
 
         // Generate UUID for new product
         this.uuid = (this.$route.params.uid as string) ?? (this.loadExisting ? undefined : uuidv4());
-        this.configLang = this.$route.params.configLang ? (this.$route.params.configLang as string) : 'en';
+        this.configLang = (this.$route.params.lang as string) || 'en';
 
         // Initialize Storylines config and the configuration structure.
         this.configs = { en: undefined, fr: undefined };

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -253,7 +253,6 @@
                 <custom-editor
                     ref="editor"
                     :config="currentSlide"
-                    :lang="lang"
                     :slideIndex="slideIndex"
                     @slide-edit="$emit('slide-edit')"
                     @config-edited="(slideConfig: Slide, save?: boolean = false) => $emit('custom-slide-updated', slideConfig, save)"


### PR DESCRIPTION
### Changes
- [FIX] loading FR config products correctly
- [FIX] advanced editor functionality for FR configs

### Notes
The `vue3-json-editor` library does not have built-in support for French but this only impacts the save button label (which can be disabled) and the different modes of the editor (tree, form, code, etc.). 

### Testing
Steps:
1. Load FR configs 
2. Switch between configs and ensure advanced editor tab is functional

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/302)
<!-- Reviewable:end -->
