### PR TITLE
fix language prop in preview component

### DIFF
--- a/src/components/editor/preview.vue
+++ b/src/components/editor/preview.vue
@@ -78,7 +78,7 @@ export default class StoryPreviewV extends Vue {
 
     created(): void {
         const uid = this.$route.params.uid as string;
-        const lang = this.$route.params.lang as string;
+        this.lang = this.$route.params.lang as string;
         const JSZip = require('jszip');
         const axios = require('axios').default;
 
@@ -114,7 +114,7 @@ export default class StoryPreviewV extends Vue {
                                 rampConfig: rampConfigFolder
                             };
 
-                            const filePath = `${uid}_${lang}.json`;
+                            const filePath = `${uid}_${this.lang}.json`;
                             configZip
                                 .file(filePath)
                                 .async('string')


### PR DESCRIPTION
### Related Item(s)
#305 

### Changes
- Fixes an issue where the app wasn't correctly grabbing the language from the URL in the preview component.

### Testing
Steps:
1. Open the demo page in French.
2. Load a product that has a map in it and press the "Preview" button in the top right.
3. Scroll to the map and ensure that it is displaying in French.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/306)
<!-- Reviewable:end -->
