### PR TITLE
fix preview button not working after switching language

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -265,7 +265,7 @@ export default class EditorV extends Vue {
      */
     preview(): void {
         // save current slide final changes before previewing product
-        if (this.$refs.slide !== undefined) {
+        if (this.$refs.slide != null && this.currentSlide !== '') {
             (this.$refs.slide as SlideEditorV).saveChanges();
         }
 

--- a/src/components/editor/slide-editor.vue
+++ b/src/components/editor/slide-editor.vue
@@ -515,7 +515,7 @@ export default class SlideEditorV extends Vue {
 
     saveChanges(): void {
         if (
-            this.$refs.editor !== undefined &&
+            this.$refs.editor != null &&
             typeof (this.$refs.editor as ImageEditorV | ChartEditorV | VideoEditorV | CustomEditorV).saveChanges ===
                 'function'
         ) {


### PR DESCRIPTION
### Related Item(s)
#307 (1/2)

### Changes
- Fixes an issue where you couldn't preview a product after switching the config language.

### Testing
Steps:
1. Load an Storylines product and enter the slide editing screen
2. Select "View French Config"
3. Press "Preview", and the preview should open as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/308)
<!-- Reviewable:end -->
