### PR TITLE
fix editor breaking when switching config language

### DIFF
--- a/src/components/editor/metadata-editor.vue
+++ b/src/components/editor/metadata-editor.vue
@@ -446,6 +446,7 @@ export default class MetadataEditorV extends Vue {
             // Properties already passed in props, load editor view (could use a refactor to clean up this workflow process)
             if (props && props.configs && props.configFileStructure) {
                 this.configs = props.configs;
+                this.configLang = props.configLang;
                 this.configFileStructure = props.configFileStructure;
                 this.metadata = props.metadata;
                 this.slides = props.slides;


### PR DESCRIPTION
### Related Item(s)
Closes #307 (2/2)

### Changes
- This PR fixes an issue where if you load a product with a logo, switch config languages, and then click 'Next`, the app would break.

### Testing
Steps:
1. Open the sample page.
2. Load a product that has a logo in both the French and English configs.
3. Switch the config language and then click the 'Next' button.
4. Ensure that the app loads correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/309)
<!-- Reviewable:end -->
