### PR TITLE
fix advanced editor not saving correctly

### DIFF
--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -245,9 +245,9 @@ export default class EditorV extends Vue {
      */
     updateCustomSlide(slideConfig: Slide, save?: boolean): void {
         this.currentSlide = slideConfig;
+        this.slides[this.slideIndex] = slideConfig;
         // save changes emitted from advanced editor
         if (save) {
-            this.slides[this.slideIndex] = slideConfig;
             this.$emit('save-changes');
         }
     }

--- a/src/components/helpers/custom-editor.vue
+++ b/src/components/helpers/custom-editor.vue
@@ -4,7 +4,7 @@
             v-model="updatedConfig"
             lang="en"
             :mode="'text'"
-            :show-btns="true"
+            :show-btns="false"
             :expandedOnStart="true"
             @json-change="
                 (json: any) => {


### PR DESCRIPTION
### Related Item(s)
#312 

### Changes
- This PR fixes an issue where changes in the advanced editor weren't saving correctly.
- This PR also removes the redundant `save` button at the bottom of the advanced editor.

### Notes
It doesn't seem like the JSON is being validated when you swap between tabs. I'm going to create a new issue for this.

### Testing
Steps:
1. Go to the Editor
2. Load a product, click Next, select a slide on the left.
3. Select the "Advanced" tab and make any change. Ensure that changes are being saved correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/317)
<!-- Reviewable:end -->
