### PR TITLE
fix issue with images not saving when creating a new slide

### DIFF
--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -220,9 +220,7 @@ export default class EditorV extends Vue {
     selectSlide(index: number): void {
         // save changes to current slide before changing slides
         if (this.$refs.slide !== undefined) {
-            this.$nextTick(() => {
-                (this.$refs.slide as SlideEditorV).saveChanges();
-            });
+            (this.$refs.slide as SlideEditorV).saveChanges();
         }
 
         // Quickly swap to loading page, and then swap to new slide. Allows Vue to re-draw page correctly.

--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -1121,9 +1121,7 @@ export default class MetadataEditorV extends Vue {
 
         if (this.loadEditor) {
             (this.$refs.mainEditor as EditorV).updateSlides(this.slides);
-            this.$nextTick(() => {
-                (this.$refs.mainEditor as EditorV).selectSlide(-1);
-            });
+            (this.$refs.mainEditor as EditorV).selectSlide(-1);
         }
     }
 


### PR DESCRIPTION
### Related Item(s)
#344, #355 

### Changes
- Fixes an issue with images not saving correctly if you upload an image and then create a new slide right after.
- Also fixes a problem with images disappearing after swapping language configs.

### Notes
I couldn't figure out what exactly $nextTick was being used for here, but I've done a bunch of testing and everything seems to work properly. Let me know if you find anything.

### Testing
Steps:
1. Open the demo page and load a product.
2. Create an image panel and upload an image.
3. Before pressing save or switching off the panel, create a new slide.
4. Switch back to the image panel and ensure the image is still being displayed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/356)
<!-- Reviewable:end -->
