### PR TITLE
fix UI issues with slide copy modal; add success message

### DIFF
--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -35,36 +35,37 @@
             >
                 <h2 slot="header" class="text-xl font-bold">{{ $t('editor.slides.copyFromLang') }}</h2>
                 <div class="flex flex-col">
-                    <button
-                        class="editor-toc-button editor-button w-32 h-12 ml-0"
-                        @click="copyAllFromOtherLang(configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides)"
-                    >
+                    <button class="editor-toc-button editor-button h-12 ml-0" @click="$vfm.open(`confirm-copy-all`)">
                         {{ $t('editor.slides.copyAll') }}
                     </button>
-                    <span class="text-lg font-bold my-6"> {{ $t('editor.or') }} </span>
-                    <div class="flex">
-                        <select v-model="selectedForCopying" class="overflow-ellipsis copy-select">
-                            <option
-                                v-for="(slide, index) in configFileStructure.configs[lang === 'en' ? 'fr' : 'en']
-                                    .slides"
-                                :value="index"
-                                :key="slide.title + index"
-                            >
-                                {{ $t('editor.slides.slide') }} {{ index + ': ' + slide.title }}
-                            </option>
-                        </select>
+                    <span class="text-lg font-bold my-3 text-center"> {{ $t('editor.label.or') }} </span>
 
-                        <button
-                            class="editor-toc-button"
-                            @click="
-                                copyFromOtherLang(
-                                    configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides[selectedForCopying]
-                                )
-                            "
+                    <select v-model="selectedForCopying" class="overflow-ellipsis copy-select border-2 p-2">
+                        <option
+                            v-for="(slide, index) in configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides"
+                            :value="index"
+                            :key="slide.title + index"
                         >
-                            {{ $t('editor.slides.copy') }}
-                        </button>
-                    </div>
+                            {{ $t('editor.slides.slide') + ` ${index}: ` }}
+                            {{ slide.title ? slide.title : $t('editor.slide.untitled') }}
+                        </option>
+                    </select>
+
+                    <button
+                        class="editor-toc-button"
+                        @click="
+                            copyFromOtherLang(
+                                configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides[selectedForCopying]
+                            )
+                        "
+                    >
+                        {{ $t('editor.slides.copy') }}
+                    </button>
+                    <confirmation-modal
+                        :name="`confirm-copy-all`"
+                        :message="$t('editor.slides.copyAll.confirm')"
+                        @ok="copyAllFromOtherLang(configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides)"
+                    />
                 </div>
             </vue-final-modal>
         </div>
@@ -156,6 +157,8 @@ import {
     TextPanel,
     VideoPanel
 } from '@/definitions';
+
+import Message from 'vue-m-message';
 import { VueFinalModal } from 'vue-final-modal';
 import cloneDeep from 'clone-deep';
 import draggable from 'vuedraggable';
@@ -209,6 +212,7 @@ export default class SlideTocV extends Vue {
         if (slide) {
             this.slides.splice(this.slides.length, 0, cloneDeep(slide));
             this.$emit('slides-updated', this.slides);
+            Message.success(this.$t('editor.slide.copy.success'));
         }
     }
 
@@ -216,12 +220,14 @@ export default class SlideTocV extends Vue {
         if (slides) {
             this.slides.splice(this.slides.length, 0, ...slides.map((slide) => cloneDeep(slide)));
             this.$emit('slides-updated', this.slides);
+            Message.success(this.$t('editor.slide.copy.success'));
         }
     }
 
     copySlide(index: number): void {
         this.slides.splice(index + 1, 0, cloneDeep(this.slides[index]));
         this.$emit('slides-updated', this.slides);
+        Message.success(this.$t('editor.slide.copy.success'));
     }
 
     removeSlide(index: number): void {
@@ -336,7 +342,12 @@ export default class SlideTocV extends Vue {
 .copy-select {
     width: 450px;
 }
+
 .focused {
     outline: 2px solid black;
+}
+
+.editor-toc-button {
+    margin: 10px 0px 0px 0px !important;
 }
 </style>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -126,6 +126,7 @@ editor.slides.makeFull,Make the right panel the full slide,1,Mettre la diapositi
 editor.slides.centerPanel,Center panel content,1,Contenu de la diapositive centrale,0
 editor.slides.centerSlide,Center slide content,1,Contenu du panneau central,0
 editor.slides.copyAll,Copy all,1,Copier tout,1
+editor.slides.copyAll.confirm,Are you sure you want to copy all slides?,1,Êtes-vous sûr de vouloir copier toutes les diapositives ?,0
 editor.slides.copy,Copy,1,Copier,1
 editor.slides.slide,Slide,1,Diapositive,1
 editor.slides.previousSlide,Previous slide,1,Diapositive précédente,1
@@ -145,6 +146,8 @@ editor.slides.panel.body,Panel body,1,Corps du panneau,1
 editor.slides.panel.title,Panel title,1,Titre du panneau,1
 editor.slides.intro,Intro subtitle,1,Sous-titre de l’introduction,1
 editor.slides.title,Intro title,1,Titre de l’introduction,1
+editor.slide.untitled,Untitled slide,1,Diapositive sans titre,0
+editor.slide.copy.success,Slide copied successfully!,1,Diapositive copiée avec succès !,0
 editor.tocOrientation,Table of Contents Orientation,1,Orientation de la table des matières,0
 editor.tocOrientation.info,The table of contents orientation will be set to vertical in mobile view.,1,L'orientation de la table des matières sera définie sur verticale en vue mobile.,0
 editor.tocOrientation.vertical,Vertical,1,Vertical,0


### PR DESCRIPTION
### Related Item(s)
#348, #349 

### Changes
- Made some CSS changes to the slide copy modal. The select component now has a border, and buttons have been changed to take up the entire width of the modal.
- Fixed the `or` label.
- If a slide doesn't have a name, it will display as `Slide x: Untitled slide` instead of just `Slide x: `.
- A success message will now pop up when the slide is copied.

### Testing
Steps:
1. Open the demo page and load a product.
2. Click on the `Copy slide` button next to the `Add slide` button.
3. Ensure that UI components are displaying in a respectful manner.
4. Click on `Copy all` and ensure slides are copied and a success message appears.
5. Copy a specific slide and ensure that a success message appears.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/357)
<!-- Reviewable:end -->
