### PR TITLE
dynamic panel editor enhancements

### DIFF
--- a/public/StorylinesSlideSchema.json
+++ b/public/StorylinesSlideSchema.json
@@ -93,8 +93,7 @@
                     "description": "The panels to display dynamically.",
                     "items": {
                         "$ref": "#/$defs/dynamicChildItem"
-                    },
-                    "minItems": 1
+                    }
                 },
                 "type": {
                     "type": "string",

--- a/src/components/dynamic-editor.vue
+++ b/src/components/dynamic-editor.vue
@@ -39,8 +39,14 @@
                     <td>{{ determineEditorType(item.panel) }}</td>
                     <td>
                         <span @click="() => switchSlide(idx)">{{ $t('editor.chart.label.edit') }}</span> |
-                        <span @click="() => removeSlide(item, idx)">{{ $t('editor.remove') }}</span>
+                        <span @click="$vfm.open(`delete-item-${idx}`)">{{ $t('editor.remove') }}</span>
                     </td>
+
+                    <confirmation-modal
+                        :name="`delete-item-${idx}`"
+                        :message="$t('dynamic.panel.remove')"
+                        @ok="() => removeSlide(item as any, idx)"
+                    />
                 </tr>
                 <tr class="table-add-row">
                     <th class="flex flex-col items-center">
@@ -54,7 +60,11 @@
                             </option>
                         </select>
                     </th>
-                    <th><button class="editor-button" @click="createNewSlide" :disabled="idUsed">Add New</button></th>
+                    <th>
+                        <button class="editor-button" @click="createNewSlide" :disabled="idUsed || !newSlideName">
+                            {{ $t('dynamic.panel.add') }}
+                        </button>
+                    </th>
                 </tr>
             </table>
 
@@ -105,6 +115,7 @@ import TextEditorV from './text-editor.vue';
 import MapEditorV from './map-editor.vue';
 import VideoEditorV from './video-editor.vue';
 import SlideshowEditorV from './slideshow-editor.vue';
+import ConfirmationModalV from './helpers/confirmation-modal.vue';
 
 @Options({
     components: {
@@ -114,7 +125,8 @@ import SlideshowEditorV from './slideshow-editor.vue';
         'slideshow-editor': SlideshowEditorV,
         'dynamic-editor': DynamicEditorV,
         'map-editor': MapEditorV,
-        'video-editor': VideoEditorV
+        'video-editor': VideoEditorV,
+        'confirmation-modal': ConfirmationModalV
     }
 })
 export default class DynamicEditorV extends Vue {
@@ -252,7 +264,7 @@ export default class DynamicEditorV extends Vue {
             }
         }
 
-        if (index) {
+        if (index !== undefined) {
             // Remove the panel itself.
             this.panel.children = this.panel.children.filter((panel: DynamicChildItem, idx: number) => idx !== index);
 

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -13,8 +13,10 @@ dynamic.panel.collection,Panel Collection,1,Collection de panneaux,1
 dynamic.panel.id,Panel ID,1,No d’identification du panneau,1
 dynamic.panel.type,Panel Type,1,Type de panneaux,1
 dynamic.panel.actions,Panel Actions,1,Actions du panneau,1
-dynamic.panel.idTaken,Panel ID is already,1,Le nom du panneau est déjà utilisé,1
+dynamic.panel.idTaken,Panel ID is already in use,1,Le nom du panneau est déjà utilisé,1
 dynamic.panel.editor,Panel Editor:,1,Éditeur de panneaux:,1
+dynamic.panel.remove,Are you sure you want to remove this panel?,1,Etes-vous sûr de vouloir supprimer ce panneau?,0
+dynamic.panel.add,Add New,1,Ajouter un nouveau,0
 timeslider.expand,Expand,1,Développer,1
 timeslider.minimize,Minimize,1,Réduire,1
 timeslider.play,Play,1,Lecture,1


### PR DESCRIPTION
### Related Item(s)
#342 

### Changes
- Disable the "Add New" button if the ID isn't filled out when adding a new panel.
- Fix issue with duplicate ID string being cut off.
- Added an additional confirmation step before deleting subpanels.

### Testing
Steps:
1. Open the demo page and load a product.
2. Create a dynamic panel and add some subpanels.
3. Try to add a new subpanel with no name and ensure that you can't click `Add new`.
4. Try to add a new subpanel with the same name as another subpanel. Ensure the error message pops up and it's not cut off.
5. Try to remove a subpanel and ensure the additional confirmation message pops before it is removed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/358)
<!-- Reviewable:end -->
