### PR TITLE
Keep advanced editor changes up-to-date

### DIFF
--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -155,6 +155,7 @@
                 <button
                     @click="
                         () => {
+                            panelIndex = 0;
                             advancedEditorView = true;
                             saveChanges();
                         }
@@ -230,7 +231,7 @@
                 <div class="flex mt-4">
                     <span class="font-bold text-xl">{{ $t('editor.slides.content') }}:</span>
                     <span class="ml-auto flex-grow"></span>
-                    <div v-if="!advancedEditorView || rightOnly" class="flex flex-col mr-8">
+                    <div v-if="!advancedEditorView" class="flex flex-col mr-8">
                         <label class="editor-label text-left text-lg">{{ $t('editor.slides.contentType') }}:</label>
                         <select
                             ref="typeSelector"
@@ -253,7 +254,6 @@
                 <custom-editor
                     ref="editor"
                     :config="currentSlide"
-                    :slideIndex="slideIndex"
                     @slide-edit="$emit('slide-edit')"
                     @config-edited="(slideConfig: Slide, save?: boolean = false) => $emit('custom-slide-updated', slideConfig, save)"
                     v-if="advancedEditorView"


### PR DESCRIPTION
### Related Item(s)
Closes #321 

### Changes
- [FIX] reflect any (valid) changes in advanced editor immediately in editor

### Testing
Steps:
1. Remove a slide in advanced editor
2. Notice the fullscreen panel immediately appears in slide menu

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/366)
<!-- Reviewable:end -->
