### PR TITLE
Disable dragging feature of slide toc

### DIFF
--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -70,7 +70,7 @@
             </vue-final-modal>
         </div>
         <ul class="max-h-screen overflow-y-auto">
-            <draggable v-model="slides" @update="$emit('slides-updated', slides)" item-key="title" v-focus-list>
+            <draggable :list="slides" @update="$emit('slides-updated', slides)" :item-key="getSlideId" v-focus-list>
                 <template #item="{ element, index }">
                     <li
                         class="toc-slide border-t flex px-2 cursor-pointer hover:bg-gray-300"
@@ -323,6 +323,10 @@ export default class SlideTocV extends Vue {
     moveDown(index: number): void {
         this.slides.splice(index + 1, 0, this.slides.splice(index, 1)[0]);
         this.$emit('slides-updated', this.slides);
+    }
+
+    getSlideId(slide: Slide): string {
+        return slide.title + this.slides.indexOf(slide);
     }
 }
 </script>


### PR DESCRIPTION
### Related Item(s)
#323

### Changes
- Replaced `v-model` attribute with `list` attribute
- Set `item-key` to a function that returns a slide's title + index within the `slides` array

### Testing
Steps:
1. Click to edit any storyline, and open dev tools
2. Proceed to edit existing slides
3. Try to click and drag any slide up or down
4. Observe that the slide will be correctly dragged to the desired location. 
5. Also observe there are no 'duplicate key' warnings, implying that the keys are indeed unique

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/372)
<!-- Reviewable:end -->
