### PR TITLE
Fix basemap thubmnails

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "markdown-it": "^12.0.6",
                 "marked": "^4.0.10",
                 "nouislider": "^15.5.0",
-                "ramp-config-editor_editeur-config-pcar": "^2.0.0",
+                "ramp-config-editor_editeur-config-pcar": "^3.2.0",
                 "ramp-storylines_demo-scenarios-pcar": "^3.1.6",
                 "throttle-debounce": "^5.0.0",
                 "url": "^0.11.3",
@@ -6414,9 +6414,9 @@
             }
         },
         "node_modules/ramp-config-editor_editeur-config-pcar": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ramp-config-editor_editeur-config-pcar/-/ramp-config-editor_editeur-config-pcar-2.0.0.tgz",
-            "integrity": "sha512-7+H2IyyQkY4jyA5UiUFGwoW35rKxpwwbJHTZMrnKTYT/srPPfWw99bb4PRCvZUo1ITW0eeguhNafrOiPMO0laQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ramp-config-editor_editeur-config-pcar/-/ramp-config-editor_editeur-config-pcar-3.2.0.tgz",
+            "integrity": "sha512-L1HpOsI7uJnLzSX+6iWtPkJI369E+c6wZS2pHbHEE8CnQMKmv2NlaGELoKywC8hN9r5JgP1sUt6DDueSlJY+Nw==",
             "dependencies": {
                 "deepmerge": "^4.3.1",
                 "pinia": "^2.0.32",
@@ -12962,9 +12962,9 @@
             "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
         },
         "ramp-config-editor_editeur-config-pcar": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ramp-config-editor_editeur-config-pcar/-/ramp-config-editor_editeur-config-pcar-2.0.0.tgz",
-            "integrity": "sha512-7+H2IyyQkY4jyA5UiUFGwoW35rKxpwwbJHTZMrnKTYT/srPPfWw99bb4PRCvZUo1ITW0eeguhNafrOiPMO0laQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/ramp-config-editor_editeur-config-pcar/-/ramp-config-editor_editeur-config-pcar-3.2.0.tgz",
+            "integrity": "sha512-L1HpOsI7uJnLzSX+6iWtPkJI369E+c6wZS2pHbHEE8CnQMKmv2NlaGELoKywC8hN9r5JgP1sUt6DDueSlJY+Nw==",
             "requires": {
                 "deepmerge": "^4.3.1",
                 "pinia": "^2.0.32",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "markdown-it": "^12.0.6",
         "marked": "^4.0.10",
         "nouislider": "^15.5.0",
-        "ramp-config-editor_editeur-config-pcar": "^2.0.0",
+        "ramp-config-editor_editeur-config-pcar": "^3.2.0",
         "ramp-storylines_demo-scenarios-pcar": "^3.1.6",
         "throttle-debounce": "^5.0.0",
         "url": "^0.11.3",

--- a/ramp-default.json
+++ b/ramp-default.json
@@ -364,7 +364,7 @@
                         "name": "Lambert Maps",
                         "extentSetId": "EXT_NRCAN_Lambert_3978",
                         "lodSetId": "LOD_NRCAN_Lambert_3978",
-                        "thumbnailTileUrls": [],
+                        "thumbnailTileUrls": ["/tile/8/285/268", "/tile/8/285/269"],
                         "hasNorthPole": true
                     },
                     {
@@ -372,7 +372,7 @@
                         "name": "Web Mercator Maps",
                         "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
                         "lodSetId": "LOD_ESRI_World_AuxMerc_3857",
-                        "thumbnailTileUrls": [],
+                        "thumbnailTileUrls": ["/tile/8/91/74", "/tile/8/91/75"],
                         "hasNorthPole": false
                     }
                 ],


### PR DESCRIPTION
### Related Item(s)
[story-ramp#434](https://github.com/ramp4-pcar4/story-ramp/issues/434)

### Changes
- [FIX] Basemap logos will now be displayed appropriately by default.

### Testing
Steps:
1. Create a new map config and ensure that the basemap logos are displayed.
