### PR TITLE
Fix basemap logos

### DIFF
--- a/ramp-default.json
+++ b/ramp-default.json
@@ -364,7 +364,7 @@
                         "name": "Lambert Maps",
                         "extentSetId": "EXT_NRCAN_Lambert_3978",
                         "lodSetId": "LOD_NRCAN_Lambert_3978",
-                        "thumbnailTileUrls": [],
+                        "thumbnailTileUrls": ["/tile/8/285/268", "/tile/8/285/269"],
                         "hasNorthPole": true
                     },
                     {
@@ -372,7 +372,7 @@
                         "name": "Web Mercator Maps",
                         "extentSetId": "EXT_ESRI_World_AuxMerc_3857",
                         "lodSetId": "LOD_ESRI_World_AuxMerc_3857",
-                        "thumbnailTileUrls": [],
+                        "thumbnailTileUrls": ["/tile/8/91/74", "/tile/8/91/75"],
                         "hasNorthPole": false
                     }
                 ],


### PR DESCRIPTION
### Related Item(s)
[story-ramp#434](https://github.com/ramp4-pcar4/story-ramp/issues/434)

### Changes
- [FIX] Basemap logos will now be displayed appropriately by default.

### Testing
Steps:
1. Create a new map config and ensure that the basemap logos are displayed by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/378)
<!-- Reviewable:end -->
