### PR TITLE
Hide panel change warnings when no changes made

### DIFF
--- a/src/components/chart-editor.vue
+++ b/src/components/chart-editor.vue
@@ -296,7 +296,7 @@ export default class ChartEditorV extends Vue {
 
     onChartsEdited(): void {
         this.edited = true;
-        this.$emit('slide-edit');
+        this.$emit('slide-edit', this.chartConfigs.length !== 0);
     }
 }
 </script>

--- a/src/components/dynamic-editor.vue
+++ b/src/components/dynamic-editor.vue
@@ -95,6 +95,7 @@
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import {
     BasePanel,
+    BaseStartingConfig,
     ChartPanel,
     ConfigFileStructure,
     DefaultConfigs,
@@ -146,45 +147,7 @@ export default class DynamicEditorV extends Vue {
         video: 'video-editor'
     };
 
-    startingConfig: DefaultConfigs = {
-        text: {
-            type: PanelType.Text,
-            title: '',
-            content: ''
-        },
-        dynamic: {
-            type: PanelType.Dynamic,
-            title: '',
-            titleTag: '',
-            content: '',
-            children: []
-        },
-        slideshow: {
-            type: PanelType.Slideshow,
-            items: [],
-            userCreated: true
-        },
-        image: {
-            type: PanelType.Image,
-            src: ''
-        },
-        chart: {
-            type: PanelType.Chart,
-            src: ''
-        },
-        map: {
-            type: PanelType.Map,
-            config: '',
-            title: '',
-            scrollguard: false
-        },
-        video: {
-            type: PanelType.Video,
-            title: '',
-            videoType: '',
-            src: ''
-        }
-    };
+    startingConfig: DefaultConfigs = JSON.parse(JSON.stringify(BaseStartingConfig));
 
     editingStatus = 'text';
     editingSlide = -1;

--- a/src/components/image-editor.vue
+++ b/src/components/image-editor.vue
@@ -293,7 +293,7 @@ export default class ImageEditorV extends Vue {
 
     onImagesEdited(): void {
         this.edited = true;
-        this.$emit('slide-edit');
+        this.$emit('slide-edit', this.imagePreviews.length !== 0);
     }
 }
 </script>

--- a/src/components/slideshow-editor.vue
+++ b/src/components/slideshow-editor.vue
@@ -124,6 +124,7 @@
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import {
     BasePanel,
+    BaseStartingConfig,
     ChartPanel,
     ConfigFileStructure,
     DefaultConfigs,
@@ -163,43 +164,17 @@ export default class SlideshowEditorV extends Vue {
         video: 'video-editor'
     };
 
-    // TODO: we use this and a few other functions (updating source counts, etc.) in multiple places. We should probably look in to putting this somewhere else.
     startingConfig: DefaultConfigs = {
-        text: {
-            type: PanelType.Text,
-            title: '',
-            content: ''
-        },
-        dynamic: {
-            type: PanelType.Dynamic,
-            title: '',
-            titleTag: '',
-            content: '',
-            children: []
-        },
+        ...JSON.parse(JSON.stringify(BaseStartingConfig)),
         slideshow: {
             type: PanelType.Slideshow,
             items: []
-        },
-        chart: {
-            type: PanelType.Chart,
-            src: ''
-        },
-        image: {
-            type: PanelType.Image,
-            src: ''
         },
         map: {
             type: PanelType.Map,
             config: '',
             title: '',
             scrollguard: true // default to ON for slideshows. Allows users to use the cursor to switch slides.
-        },
-        video: {
-            type: PanelType.Video,
-            title: '',
-            videoType: '',
-            src: ''
         }
     };
 
@@ -289,7 +264,7 @@ export default class SlideshowEditorV extends Vue {
                 (this.$refs.slideEditor as ImageEditorV | ChartEditorV).saveChanges();
 
                 if (itemConfig.type === PanelType.Map) {
-                    this.$emit('slide-edit');
+                    this.$emit('slide-edit', false);
                 }
             }
         }

--- a/src/components/video-editor.vue
+++ b/src/components/video-editor.vue
@@ -273,7 +273,10 @@ export default class VideoEditorV extends Vue {
 
     onVideoEdited(): void {
         this.edited = true;
-        this.$emit('slide-edit');
+        this.$emit(
+            'slide-edit',
+            (this.videoPreview?.videoType || this.videoPreview?.title?.length) ? true : false
+        );
     }
 }
 </script>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -156,6 +156,7 @@ export interface BasePanel {
     type: string;
     width?: number;
     customStyles?: string;
+    modified?: boolean;
 }
 
 export interface TextPanel extends BasePanel {
@@ -282,3 +283,44 @@ export interface DefaultConfigs {
     video: VideoPanel;
     image: ImagePanel;
 }
+
+export const BaseStartingConfig: DefaultConfigs = {
+    text: {
+        type: PanelType.Text,
+        title: '',
+        content: ''
+    },
+    dynamic: {
+        type: PanelType.Dynamic,
+        title: '',
+        titleTag: '',
+        content: '',
+        children: []
+    },
+    slideshow: {
+        type: PanelType.Slideshow,
+        items: [],
+        caption: '',
+        userCreated: true
+    },
+    image: {
+        type: PanelType.Image,
+        src: ''
+    },
+    chart: {
+        type: PanelType.Chart,
+        src: ''
+    },
+    map: {
+        type: PanelType.Map,
+        config: '',
+        title: '',
+        scrollguard: false
+    },
+    video: {
+        type: PanelType.Video,
+        title: '',
+        videoType: '',
+        src: ''
+    }
+};


### PR DESCRIPTION
### Related Item(s)
Issue #331 

### Changes
- [FEATURE] Hide "Panel changes will be deleted" warnings when there have been no changes made to the relevant panel. This affects two app interactions:
    - Changing the panel type via the `Content Type` dropdown
    - Changing the `Make the right panel the full slide` checkbox

### Testing
Steps:
1. Open any storylines product (I used `00000000-0000-0000-0000-000000000000`).
2. Click `New Slide` to add a new slide. Go to that new slide. 
3. Use the `Content Type` dropdown to change the panel type a few times. As long as you don't add any content, the panel type should change without a pop-up coming up.
4. Change to the slide to the "Text" type. Add something to the panel (e.g. change the panel title). Now try changing the panel type again; the popup should show up now.
5. Change to the right panel and try steps 3-4 again; results should be the same.
6. Click `New Slide` to add a new slide. Add some content to the right panel, then switch back to the left panel and try changing the panel type to "Dynamic". A warning message **should** pop up, as changing to dynamic overwrites both panels, not just the one you're on.
7. Click `New Slide` to add a new slide. Click the `Make the right panel the full slide` checkbox. As long as no changes are made to the **left** panel when there are both panels, there should be no pop-up warning. 
8. Try adding a change to the **left** panel and then clicking the checkbox; the pop-up should show up. (**Note**: The pop-up should now never show up when the left panel is hidden, unless there are changes and you are changing panel types).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/383)
<!-- Reviewable:end -->
