### PR TITLE
Fix config editor WAVE errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
                 "markdown-it": "^12.0.6",
                 "marked": "^4.0.10",
                 "nouislider": "^15.5.0",
-                "ramp-config-editor_editeur-config-pcar": "^3.5.2",
+                "ramp-config-editor_editeur-config-pcar": "^3.6.0",
                 "ramp-pcar": "^4.8.0",
                 "ramp-storylines_demo-scenarios-pcar": "^3.2.2",
                 "throttle-debounce": "^5.0.0",
@@ -8004,9 +8004,9 @@
             }
         },
         "node_modules/ramp-config-editor_editeur-config-pcar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/ramp-config-editor_editeur-config-pcar/-/ramp-config-editor_editeur-config-pcar-3.5.3.tgz",
-            "integrity": "sha512-2bd2wguMBBp5IbkuFso8jesUiK4HkDT9mKaiAgxnLgxdpHodXlc3aKUyjEVChu5sdoPePIMIvou3k4la0Uvfdg==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/ramp-config-editor_editeur-config-pcar/-/ramp-config-editor_editeur-config-pcar-3.6.0.tgz",
+            "integrity": "sha512-ULEi4ELCkhvqzOMxgYirk+sURdJ57IIkX/hDQbjxVu+xA7OgvVPFotHuv8XSCJO4Xbl6DXEFanJB7QlotsXYBQ==",
             "dependencies": {
                 "deepmerge": "^4.3.1",
                 "pinia": "^2.0.32",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "markdown-it": "^12.0.6",
         "marked": "^4.0.10",
         "nouislider": "^15.5.0",
-        "ramp-config-editor_editeur-config-pcar": "^3.5.2",
+        "ramp-config-editor_editeur-config-pcar": "^3.6.0",
         "ramp-pcar": "^4.8.0",
         "ramp-storylines_demo-scenarios-pcar": "^3.2.2",
         "throttle-debounce": "^5.0.0",


### PR DESCRIPTION
Closes [config-editor#48](https://github.com/ramp4-pcar4/config-editor/issues/48).

### Changes
- [FIX] Fixed all WAVE errors in the config editor.

### Testing
1. Open the config editor.
2. Run the WAVE evaluation tool on the different screens/templates.
3. Ensure no grouses are present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/395)
<!-- Reviewable:end -->
