### PR TITLE
Update toc schema option + add option to toggle nav top

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "nouislider": "^15.5.0",
                 "ramp-config-editor_editeur-config-pcar": "^3.5.2",
                 "ramp-pcar": "^4.8.0",
-                "ramp-storylines_demo-scenarios-pcar": "^3.2.2",
+                "ramp-storylines_demo-scenarios-pcar": "^3.2.4",
                 "throttle-debounce": "^5.0.0",
                 "url": "^0.11.3",
                 "uuid": "^9.0.0",
@@ -8072,9 +8072,9 @@
             }
         },
         "node_modules/ramp-storylines_demo-scenarios-pcar": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.2.2.tgz",
-            "integrity": "sha512-fM9VmNw+JLV5ZkOgwKYYT/4q0rUiI/LsRh+hrwJ5AAwvt6/r3tIjZYfjorHisJtduV49FQBP2IMytoXE+wuatA==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.2.4.tgz",
+            "integrity": "sha512-lj8lJrPcoFTk7s5RXx++c7Jw12Kt220jj+OVUqnoNccT496JRua4PkG/24PBPNEPH/n9tBq38yTbCYhMBZGtSg==",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",
                 "@tailwindcss/typography": "^0.4.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "nouislider": "^15.5.0",
         "ramp-config-editor_editeur-config-pcar": "^3.5.2",
         "ramp-pcar": "^4.8.0",
-        "ramp-storylines_demo-scenarios-pcar": "^3.2.2",
+        "ramp-storylines_demo-scenarios-pcar": "^3.2.4",
         "throttle-debounce": "^5.0.0",
         "url": "^0.11.3",
         "uuid": "^9.0.0",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -39,11 +39,11 @@
                     "content": "The default RAMP4 sample.",
                     "type": "text"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Dynamic Panel Test",
-            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
             "panel": [
                 {
                     "title": "This Slide Is Dynamic!",
@@ -126,12 +126,11 @@
                         }
                     ]
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Video Panel",
-            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
-
             "panel": [
                 {
                     "title": "Video Test for YoutTube content",
@@ -145,7 +144,8 @@
                     "src": "https://www.youtube.com/embed/dQw4w9WgXcQ",
                     "height": 700
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Oil sands deposits",
@@ -160,7 +160,8 @@
                     "type": "map",
                     "scrollguard": true
                 }
-            ]
+            ],
+            "includeInToc": true
         },
         {
             "title": "Oil sands extraction",
@@ -210,7 +211,6 @@
         },
         {
             "title": "NPRI substances reported for oil sands mining facilities",
-            "backgroundImage": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
             "panel": [
                 {
                     "title": "NPRI substances reported for oil sands mining facilities",
@@ -246,27 +246,14 @@
                         {
                             "src": "00000000-0000-0000-0000-000000000000/assets/en/substances/7_Syncrude_RelDisp.PNG",
                             "type": "image"
-                        },
-                        {
-                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
-                            "type": "map",
-                            "scrollguard": true
-                        },
-                        {
-                            "title": "Text Section",
-                            "content": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. In pulvinar ultricies dolor, vel vehicula quam convallis sit amet. Cras pellentesque congue tellus ut elementum. Phasellus sagittis, odio quis fermentum maximus, metus eros fermentum lorem, eget interdum metus orci eget risus. Integer ut ante aliquam, pretium diam vitae, gravida sapien. Curabitur ac ipsum sit amet arcu laoreet sollicitudin id imperdiet quam. Duis magna ipsum, laoreet eu malesuada vitae, tristique nec felis. Integer quis neque egestas, imperdiet arcu et, faucibus elit. Duis et fermentum urna. Nulla vulputate sapien eget laoreet interdum. Vivamus tempus nulla ante, sagittis rutrum justo semper in. Cras eu iaculis massa.</p><p>Sed dictum dictum rhoncus. Praesent sit amet accumsan elit. Nulla facilisi. Vestibulum tincidunt tincidunt leo vel placerat. Integer sit amet aliquet felis, quis finibus turpis. Vivamus sit amet sodales nisl. Mauris imperdiet, nisl vulputate dignissim consectetur, mi urna tempus felis, non cursus sapien ante sodales erat. Cras a nisi id purus vehicula aliquet et sit amet dolor. Vestibulum vehicula vel lectus sed tempus. Mauris sodales vulputate augue eu sagittis. Aenean bibendum viverra laoreet. Nunc scelerisque arcu sed libero porttitor, eget tincidunt felis congue. Cras nec nulla eget lacus tincidunt condimentum vel eget orci. Vestibulum fermentum non elit non ultricies. Ut eu ante porttitor, pretium ipsum eget, commodo magna. In eget tristique mauris.</p><p>Donec id quam tempor, mollis urna et, dapibus massa. Mauris venenatis condimentum ex, vel ullamcorper sem porta vitae. Donec ac dapibus nisl, ut placerat quam. Proin consequat accumsan nibh in interdum. Ut quis justo vitae lorem vestibulum molestie blandit a nunc. Aliquam vel rutrum ex. Nunc tempus, sapien vitae pretium blandit, nisl orci lacinia lorem, et bibendum libero lectus sed nulla. Integer ut eros pretium, consequat erat id, fringilla odio. Donec convallis tortor ex, hendrerit viverra velit hendrerit sit amet. Mauris volutpat dignissim metus molestie aliquet. Etiam pulvinar urna ut vehicula venenatis. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed pharetra elit ac nunc pulvinar egestas.</p><p>Phasellus vitae tincidunt massa. Mauris consectetur, ex sit amet rutrum condimentum, magna nisi tincidunt eros, euismod maximus nisl augue eu magna. Integer volutpat pretium risus, ut volutpat lacus rhoncus id. Morbi accumsan commodo orci, sit amet ultricies sapien pellentesque a. Curabitur sit amet arcu luctus, consectetur sapien ut, varius urna. Integer id tempus quam. Mauris hendrerit purus nisl, non euismod diam luctus vel.</p><p>Praesent convallis ante ac augue porttitor sagittis. Aliquam erat volutpat. Nullam odio urna, molestie facilisis mi id, semper malesuada sapien. Phasellus ipsum odio, maximus eget malesuada at, auctor quis odio. Nullam at mi nec magna fermentum luctus. Cras aliquam magna eros, et pharetra libero blandit eu. Pellentesque euismod condimentum congue. Maecenas hendrerit volutpat turpis non venenatis. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>",
-                            "type": "text"
-                        },
-                        {
-                            "type": "chart",
-                            "src": "00000000-0000-0000-0000-000000000000/charts/en/hybridChartConfig.json"
                         }
                     ],
                     "loop": true,
                     "caption": "NPRI substances reported for oil sands mining facilities",
                     "type": "slideshow"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "NPRI substances reported for oil sands mining facilities",
@@ -294,64 +281,19 @@
                     "src": "00000000-0000-0000-0000-000000000000/assets/en/slide 6 - mining trends.jpg",
                     "type": "image"
                 }
-            ]
-        },
-        {
-            "title": "Mine tailings reported",
-            "panel": [
-                {
-                    "title": "Mine tailings reported",
-                    "content": "Processing mined oil sands to remove the bitumen leaves behind a mix of water, sand, and clay with trace amounts of metals, polycyclic aromatic hydrocarbons (PAHs) and other volatile organic compounds (VOCs). This left-over mixture, known as mine tailings, is disposed of in purpose-built, monitored [tailings impoundment areas](https://www.nrcan.gc.ca/mining-materials/publications/13924).\n\nIn 2019, oil sands mining operations reporting to the NPRI reported information on 49 substances disposed of in tailings impoundment areas, totalling 67,940 tonnes.\n\nSubstances disposed of as tailings can be grouped into four broad categories:\n\n1. Metals (40,257 tonnes);\n2. Volatile organic compounds (VOCs) (8,099 tonnes);\n3. Polycyclic Aromatic Hydrocarbons (PAHs) (360 tonnes); and\n4. Others (16,118 tonnes).\n\nWhile the tailings reported by these mines have large amounts of manganese, ammonia (NH₃), and phosphorus, the substances of greater concern are some of the volatile organics, such as benzene (C<sub>6</sub>H<sub>6</sub>), toluene (C<sub>7</sub>H<sub>8</sub>), ethylbenzene (C<sub>8</sub>H<sub>10</sub>), and xylene (C<sub>8</sub>H<sub>10</sub>) (labelled as BTEX in the figure), and 19 different polycyclic aromatic hydrocarbons (PAHs).",
-                    "type": "text"
-                },
-                {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/Top10SubstancesTailings2019.png",
-                    "type": "image"
-                }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Reported mine tailings from oil sands surface mining facilities",
             "panel": [
                 {
-                    "title": "Reported mine tailings from oil sands surface mining facilities",
-                    "content": "Similar to comparing release and transfer profiles, it is difficult to compare the seven oil sands surface mining facilities in terms of what they dispose of in their tailings impoundment areas. These facilities vary greatly in their size and in how much bitumen processing occurs on-site. Breakdowns of reported tailings for each facility are provided below.\n\n- Canadian Natural Resources Muskeg River and Jackpine Mines, and Horizon Oil Sands Processing Plant and Mine;\n- Fort Hills Oil Sands Mine;\n- Imperial Oil Kearl Processing Plant and Mine;\n- Suncor Energy Inc. Oil Sands; and\n- Syncrude Canada Aurora North Mine Site, and Syncrude Canada Ltd. (formerly Mildred Lake).",
-                    "type": "text"
+                    "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/AuroraNorth_Tailings.PNG",
+                    "type": "image"
                 },
                 {
-                    "items": [
-                        {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/AuroraNorth_Tailings.PNG",
-                            "type": "image"
-                        },
-                        {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/FortHills_Tailings.PNG",
-                            "type": "image"
-                        },
-                        {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Horizon_Tailings.PNG",
-                            "type": "image"
-                        },
-                        {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Kearl_Tailings.PNG",
-                            "type": "image"
-                        },
-                        {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Muskeg_Tailings.PNG",
-                            "type": "image"
-                        },
-                        {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Suncor_Tailings.PNG",
-                            "type": "image"
-                        },
-                        {
-                            "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/Syncrude_Tailings.PNG",
-                            "type": "image"
-                        }
-                    ],
-                    "loop": true,
-                    "caption": "Reported mine tailings from oil sands surface mining facilities",
-                    "type": "slideshow"
+                    "src": "00000000-0000-0000-0000-000000000000/assets/en/tailings/FortHills_Tailings.PNG",
+                    "type": "image"
                 }
             ]
         },
@@ -367,7 +309,8 @@
                     "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
                     "type": "map"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Trends in mine tailings reported from surface mining facilities",
@@ -386,7 +329,8 @@
                     },
                     "type": "map"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "In situ facilities",
@@ -400,7 +344,8 @@
                     "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide 10 - SAGD vs CSS.jpg",
                     "type": "image"
                 }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "NPRI releases from in-situ facilities",
@@ -414,66 +359,8 @@
                     "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasestoAirbyInSituFacilitiesforAllSubstancesin2019.json",
                     "type": "map"
                 }
-            ]
-        },
-        {
-            "title": "Trends in NPRI substances released from in-situ facilities",
-            "panel": [
-                {
-                    "title": "Trends in NPRI substances released from in-situ facilities",
-                    "content": "The number of in-situ facilities reporting to the NPRI remained the same in 2019 as in 2010, at 30 facilities.  The number of facilities peaked in 2015 at 38. For the purpose of this overview and incorporating all facilities that support oil sands extraction, batteries and compressor stations are included in the data.\n\nThis change in the number of facilities reporting over time follows changes in the sector as a whole. The price of oil rose significantly in 2009 and 2010, and remained high until 2015. This fueled significant growth in this sector, with many new facilities coming online and reporting for the first time. A significant drop in the price of oil in 2015 led to a slowdown in the number of new facilities coming online, and even to some facilities suspending operations.",
-                    "type": "text"
-                },
-                {
-                    "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasestoAirbyInSituFacilitiesforAllSubstances2010to2019(timeslider).json",
-                    "type": "map"
-                }
-            ]
-        },
-        {
-            "title": "NPRI releases from in-situ facilities",
-            "panel": [
-                {
-                    "title": "NPRI releases from in-situ facilities",
-                    "content": "Reported CAC emissions from in-situ operations have increased along with the increase in the number of facilities reporting since 2010.\n\nThe increase in emissions seen in 2017 is likely due to a rebound in the price of oil in that year. Between 2018 and 2019, 18 in situ facilities reporting to the NPRI increased their reported CAC emissions.\n\nWhile in-situ facilities have reported an increase in reported CAC emissions, this has been coupled with an even larger and steady increase in bitumen production. Bitumen production from in-situ operations increased over 102% between 2010 and 2019. CAC releases per barrel produced have decreased substantially over this time, almost 21%.",
-                    "type": "text"
-                },
-                {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/Slide%2013%20-%20InSitu%20Trends__1554406944277__w594.jpg",
-                    "type": "image"
-                }
-            ]
-        },
-        {
-            "title": "Managing environmental impacts",
-            "panel": [
-                {
-                    "title": "Managing environmental impacts",
-                    "content": "The Government of Canada’s policy towards oil sands development is that private companies make business decisions given regulations that protect current and future Canadian interests. The provinces have jurisdiction over oil and gas development within their provincial boundaries, and environmental protection is a shared responsibility by the Government of Canada and the provinces. The federal government participates in the environmental assessment process through the Joint Review Panel for proposed surface mine developments, while the Government of Alberta is responsible for the assessment of proposed in-situ developments.\n\nGovernments at all levels are committed to balancing economic benefits and environmental stewardship from the development of this sector. Oil sands projects undergo significant environmental assessments before they are approved and they are subject to extensive environmental monitoring throughout the project’s life. Please visit the **[Canada-Alberta Oil Sands Monitoring Program](https://www.canada.ca/en/environment-climate-change/services/oil-sands-monitoring.html)** for more information.\n\nWhile emissions of pollutants have risen from this sector as it has grown, the oil sands industry has been very successful in reducing its emissions per barrel of oil produced.\n\nOil sands surface mining facilities in Alberta take much of their water from the Athabasca River. The provincial government sets limits on how much water can be drawn, based on the season, through the **[Surface Water Quantity Management Framework for the Lower Athabasca River](https://open.alberta.ca/publications/9781460121733)**, which insures that annual withdrawals never exceed 3% of the river’s flow.",
-                    "type": "text"
-                },
-                {
-                    "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
-                    "type": "image"
-                }
-            ]
-        },
-        {
-            "title": "Pollution in your neighbourhood",
-            "panel": [
-                {
-                    "title": "Pollution in your neighbourhood",
-                    "content": "You can identify the facilities and pollutants in your community by entering your postal code in the NPRI online data search. For further analysis, check out [other NPRI maps and datasets](https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html).",
-                    "type": "text",
-                    "customStyles": "border: 2px solid #555; border-radius: 10px; margin-right: 5px;"
-                },
-                {
-                    "title": "NPRI data",
-                    "content": "We have packaged the data in different ways for different uses. You can search the entire database, download subsets of data, or view the data on maps.\n\n### Search NPRI data\n\n[Search our database](https://pollution-waste.canada.ca/national-release-inventory/archives/index.cfm?lang=En) for 1994 to 2017 pollutant releases in your area, as well as information about the facility(s).\n\n### Download NPRI data\n\nThese easy-to-use files let you dig deeper into the data in a variety of ways\n\n- [Single year tables](https://open.canada.ca/data/en/dataset/1fb7d8d4-7713-4ec6-b957-4a882a84fed3 'Single year tables'),\n\t- annual tables of our most popular data fields. One table for each of the last 3 years\n- [Five year summaries](https://open.canada.ca/data/en/dataset/ea0dc8ae-d93c-4e24-9f61-946f1736a26f 'Five year summaries')\n\t- summaries by air, water or land releases grouped by province, industry type or substance\n- [All years datasets](https://open.canada.ca/data/en/dataset/40e01423-7728-429c-ac9d-2954385ccdfb 'All years datasets')\n\t- annual data since 1994 on pollutant quantities, comments and geolocations\n- [Complete reported datasets](https://open.canada.ca/data/en/dataset/06022cc0-a31e-4b4c-850d-d4dccda5f3ac 'Complete reported datasets')\n\t- comprehensive datasets going back to 1994",
-                    "type": "text",
-                    "customStyles": "border: 2px solid black;"
-                }
-            ]
+            ],
+            "includeInToc": false
         },
         {
             "title": "Chart Gallery",
@@ -517,19 +404,57 @@
             "title": "Hybrid chart with bar and line",
             "panel": [
                 {
-                    "title": "Hybrid chart with bar and line",
-                    "content": "Demo of a hybrid chart consisting of both a bar and line chart using a custom configured highcharts json file.",
+                    "title": "Dynamic slideshow with hybrid chart",
+                    "content": "Demo of a dynamic slideshow featuring hybrid chart consisting of both a bar and line chart using a custom configured highcharts json file.",
                     "type": "text"
                 },
                 {
-                    "type": "chart",
-                    "src": "00000000-0000-0000-0000-000000000000/charts/en/hybridChartConfig.json"
+                    "type": "slideshow",
+                    "items": [
+                        {
+                            "type": "chart",
+                            "src": "00000000-0000-0000-0000-000000000000/charts/en/hybridChartConfig.json"
+                        },
+                        {
+                            "title": "NPRI data",
+                            "content": "We have packaged the data in different ways for different uses. You can search the entire database, download subsets of data, or view the data on maps.\n\n### Search NPRI data\n\n[Search our database](https://pollution-waste.canada.ca/national-release-inventory/archives/index.cfm?lang=En) for 1994 to 2017 pollutant releases in your area, as well as information about the facility(s).\n\n### Download NPRI data\n\nThese easy-to-use files let you dig deeper into the data in a variety of ways\n\n- [Single year tables](https://open.canada.ca/data/en/dataset/1fb7d8d4-7713-4ec6-b957-4a882a84fed3 'Single year tables'),\n\t- annual tables of our most popular data fields. One table for each of the last 3 years\n- [Five year summaries](https://open.canada.ca/data/en/dataset/ea0dc8ae-d93c-4e24-9f61-946f1736a26f 'Five year summaries')\n\t- summaries by air, water or land releases grouped by province, industry type or substance\n- [All years datasets](https://open.canada.ca/data/en/dataset/40e01423-7728-429c-ac9d-2954385ccdfb 'All years datasets')\n\t- annual data since 1994 on pollutant quantities, comments and geolocations\n- [Complete reported datasets](https://open.canada.ca/data/en/dataset/06022cc0-a31e-4b4c-850d-d4dccda5f3ac 'Complete reported datasets')\n\t- comprehensive datasets going back to 1994",
+                            "type": "text",
+                            "customStyles": "border: 2px solid black;"
+                        },
+                        {
+                            "config": "00000000-0000-0000-0000-000000000000/ramp-config/ReleasesandDisposalsbyMiningFacilitiesin2019(satellite).json",
+                            "type": "map",
+                            "scrollguard": true
+                        },
+                        {
+                            "src": "00000000-0000-0000-0000-000000000000/assets/en/Top10SubstancesTailings2019.png",
+                            "type": "image"
+                        }
+                    ]
                 }
-            ]
+            ],
+            "includeInToc": false
+        },
+        {
+            "title": "Managing environmental impacts",
+            "panel": [
+                {
+                    "title": "Managing environmental impacts",
+                    "content": "The Government of Canada’s policy towards oil sands development is that private companies make business decisions given regulations that protect current and future Canadian interests. The provinces have jurisdiction over oil and gas development within their provincial boundaries, and environmental protection is a shared responsibility by the Government of Canada and the provinces. The federal government participates in the environmental assessment process through the Joint Review Panel for proposed surface mine developments, while the Government of Alberta is responsible for the assessment of proposed in-situ developments.\n\nGovernments at all levels are committed to balancing economic benefits and environmental stewardship from the development of this sector. Oil sands projects undergo significant environmental assessments before they are approved and they are subject to extensive environmental monitoring throughout the project’s life. Please visit the **[Canada-Alberta Oil Sands Monitoring Program](https://www.canada.ca/en/environment-climate-change/services/oil-sands-monitoring.html)** for more information.\n\nWhile emissions of pollutants have risen from this sector as it has grown, the oil sands industry has been very successful in reducing its emissions per barrel of oil produced.\n\nOil sands surface mining facilities in Alberta take much of their water from the Athabasca River. The provincial government sets limits on how much water can be drawn, based on the season, through the **[Surface Water Quantity Management Framework for the Lower Athabasca River](https://open.alberta.ca/publications/9781460121733)**, which insures that annual withdrawals never exceed 3% of the river’s flow.",
+                    "type": "text"
+                },
+                {
+                    "src": "00000000-0000-0000-0000-000000000000/assets/en/GettyImages-516166467__1554821531978__w1920.jpg",
+                    "type": "image"
+                }
+            ],
+            "includeInToc": false
         }
     ],
+    "tocOrientation": "horizontal",
+    "returnTop": false,
     "contextLink": "https://www.canada.ca/en/environment-climate-change/services/national-pollutant-release-inventory/tools-resources-data/exploredata.html",
     "contextLabel": "Explore National Pollutant Release Inventory data",
     "lang": "en",
-    "dateModified": "2022-02-14"
+    "dateModified": "2024-09-09"
 }

--- a/public/StorylinesSlideSchema.json
+++ b/public/StorylinesSlideSchema.json
@@ -499,6 +499,11 @@
         "backgroundImage": {
             "type": "string",
             "description": "An image to display in the background of the slide."
+        },
+        "includeInToc": {
+            "type": "boolean",
+            "description": "Optional attribute that indicates whether or not to include slide in table of contents. Defaults to true.",
+            "default": true
         }
     },
 

--- a/src/components/helpers/metadata-content.vue
+++ b/src/components/helpers/metadata-content.vue
@@ -115,6 +115,13 @@
             <option value="vertical">{{ $t('editor.tocOrientation.vertical') }}</option>
             <option value="horizontal">{{ $t('editor.tocOrientation.horizontal') }}</option>
         </select>
+        <label class="editor-label ml-25">{{ $t('editor.returnTop') }}</label>
+        <input
+            type="checkbox"
+            class="editor-input rounded-none cursor-pointer w-4 h-4"
+            v-model="metadata.returnTop"
+            @change="metadataChanged"
+        />
         <br />
         <label class="editor-label mb-5"></label>
         <p class="inline-block">
@@ -134,21 +141,11 @@
 </template>
 
 <script lang="ts">
+import { MetadataContent } from '@/definitions';
 import { Prop, Vue } from 'vue-property-decorator';
 
 export default class MetadataEditorV extends Vue {
-    @Prop() metadata!: {
-        title: string;
-        introTitle: string;
-        introSubtitle: string;
-        logoName: string;
-        logoPreview: string;
-        logoAltText: string;
-        contextLink: string;
-        contextLabel: string;
-        tocOrientation: string;
-        dateModified: string;
-    };
+    @Prop() metadata!: MetadataContent;
 
     openFileSelector(): void {
         document.getElementById('logoUpload')?.click();

--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -413,6 +413,7 @@ export default class MetadataEditorV extends Vue {
         contextLink: '',
         contextLabel: '',
         tocOrientation: '',
+        returnTop: true,
         dateModified: ''
     };
     // add more required metadata fields to here as needed
@@ -443,6 +444,7 @@ export default class MetadataEditorV extends Vue {
             this.metadata.dateModified = `${year}-${month}-${day}`;
             // set vertical as the default table of contents orientation
             this.metadata.tocOrientation = 'vertical';
+            this.metadata.returnTop = true;
         }
 
         // Find which view to render based on route
@@ -553,6 +555,7 @@ export default class MetadataEditorV extends Vue {
             contextLabel: this.metadata.contextLabel,
             contextLink: this.metadata.contextLink,
             tocOrientation: this.metadata.tocOrientation,
+            returnTop: this.metadata.returnTop,
             dateModified: this.metadata.dateModified
         };
     }
@@ -909,6 +912,7 @@ export default class MetadataEditorV extends Vue {
         this.metadata.contextLink = config.contextLink;
         this.metadata.contextLabel = config.contextLabel;
         this.metadata.tocOrientation = config.tocOrientation;
+        this.metadata.returnTop = config.returnTop ?? true;
         this.metadata.dateModified = config.dateModified;
 
         this.slides = config.slides;
@@ -1052,17 +1056,7 @@ export default class MetadataEditorV extends Vue {
         return this.configFileStructure as ConfigFileStructure;
     }
 
-    updateMetadata(
-        key:
-            | 'title'
-            | 'introTitle'
-            | 'introSubtitle'
-            | 'contextLink'
-            | 'contextLabel'
-            | 'tocOrientation'
-            | 'dateModified',
-        value: string
-    ): void {
+    updateMetadata<K extends keyof MetadataContent>(key: K, value: MetadataContent[K]): void {
         this.metadata[key] = value;
         this.unsavedChanges = true;
     }
@@ -1081,6 +1075,7 @@ export default class MetadataEditorV extends Vue {
             config.contextLink = this.metadata.contextLink;
             config.contextLabel = this.metadata.contextLabel;
             config.tocOrientation = this.metadata.tocOrientation;
+            config.returnTop = this.metadata.returnTop;
             config.dateModified = this.metadata.dateModified;
 
             // If the logo section is missing, create it here before overwriting values.
@@ -1128,7 +1123,8 @@ export default class MetadataEditorV extends Vue {
             logoPreview: '',
             logoName: '',
             logoAltText: '',
-            tocOrientation: ''
+            tocOrientation: '',
+            returnTop: true
         };
         this.configs = { en: undefined, fr: undefined };
         this.slides = [];

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -8,6 +8,7 @@ export interface StoryRampConfig {
     contextLink: string;
     contextLabel: string;
     tocOrientation: string;
+    returnTop: boolean;
     dateModified: string;
 }
 
@@ -38,6 +39,7 @@ export interface MetadataContent {
     contextLink: string;
     contextLabel: string;
     tocOrientation: string;
+    returnTop: boolean;
     dateModified: string;
 }
 
@@ -138,6 +140,7 @@ export interface Slide {
     // tuple definition to restrict array size
     // panel: [BasePanel, BasePanel | undefined];
     panel: BasePanel[];
+    includeInToc?: boolean;
 }
 
 export enum PanelType {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -149,12 +149,14 @@ editor.slides.panel.body,Panel body,1,Corps du panneau,1
 editor.slides.panel.title,Panel title,1,Titre du panneau,1
 editor.slides.intro,Intro subtitle,1,Sous-titre de l’introduction,1
 editor.slides.title,Intro title,1,Titre de l’introduction,1
+editor.slides.includeInToc,Include in table of contents,1,Inclure dans la table des matières,0
 editor.slide.untitled,Untitled slide,1,Diapositive sans titre,0
 editor.slide.copy.success,Slide copied successfully!,1,Diapositive copiée avec succès !,0
 editor.tocOrientation,Table of Contents Orientation,1,Orientation de la table des matières,0
 editor.tocOrientation.info,The table of contents orientation will be set to vertical in mobile view.,1,L'orientation de la table des matières sera définie sur verticale en vue mobile.,0
 editor.tocOrientation.vertical,Vertical,1,Vertical,0
 editor.tocOrientation.horizontal,Horizontal,1,Horizontal,0
+editor.returnTop,Include return to top navigation,1,Inclure le retour en haut de la navigation,0
 editor.landing.greeting,Hello,1,Bonjour,1
 help.title,Help,1,Aide,1
 help.search,Search Help,1,Aide à la recherche,1


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/tcei-tmx-cwa-storylines/issues/9

### Changes
- [FEATURE] Add return to top navigation option 
- Updated Storylines version (includes styling fixes, ToC configurable options, background image preview fixes) 

### Notes
Also wanted to add a minimum UI feature for toggling individual slides to be included/excluded from ToC in preview; however, discovered a shared state / reactivity issue https://github.com/ramp4-pcar4/storylines-editor/issues/394 that needs to be fixed first. Since we need these changes for demo tomorrow, we can just modify the new `includeInToc` flag through the advanced editor for now. 

### Testing
Try customizing the table of contents navigation menu in preview mode by adding `includeInToc: false` through advanced editor for slides as well as toggling the return to top option on the metadata content. Also, ensure background image previews are fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/396)
<!-- Reviewable:end -->
