### PR TITLE
remove Thumbs.db when retrieving product folder

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,10 +12,22 @@ require('dotenv').config();
 
 // CONFIGURATION
 PORT = process.env.port ? process.env.port : 6040; // the Express server will run on this port.
-UPLOAD_PATH = process.env.SERVER_CURR_ENV && process.env.SERVER_CURR_ENV !== '#{CURR_ENV}#' ? process.env.SERVER_UPLOAD_PATH : './files'; // files uploaded from the app will be uploaded to this folder (deleted after processing)
-TARGET_PATH = process.env.SERVER_CURR_ENV && process.env.SERVER_CURR_ENV !== '#{CURR_ENV}#' ? process.env.SERVER_TARGET_PATH : './public'; // ZIP files in the UPLOAD_PATH folder will be extracted here.
-LOG_PATH = process.env.SERVER_CURR_ENV && process.env.SERVER_CURR_ENV !== '#{CURR_ENV}#' ? process.env.SERVER_LOG_PATH : './logfile.txt'; // the path to the logfile
-ROUTE_PREFIX = process.env.SERVER_CURR_ENV && process.env.SERVER_CURR_ENV !== '#{CURR_ENV}#' ? '/Storylines-Editor-STB-Server' : '';
+UPLOAD_PATH =
+    process.env.SERVER_CURR_ENV && process.env.SERVER_CURR_ENV !== '#{CURR_ENV}#'
+        ? process.env.SERVER_UPLOAD_PATH
+        : './files'; // files uploaded from the app will be uploaded to this folder (deleted after processing)
+TARGET_PATH =
+    process.env.SERVER_CURR_ENV && process.env.SERVER_CURR_ENV !== '#{CURR_ENV}#'
+        ? process.env.SERVER_TARGET_PATH
+        : './public'; // ZIP files in the UPLOAD_PATH folder will be extracted here.
+LOG_PATH =
+    process.env.SERVER_CURR_ENV && process.env.SERVER_CURR_ENV !== '#{CURR_ENV}#'
+        ? process.env.SERVER_LOG_PATH
+        : './logfile.txt'; // the path to the logfile
+ROUTE_PREFIX =
+    process.env.SERVER_CURR_ENV && process.env.SERVER_CURR_ENV !== '#{CURR_ENV}#'
+        ? '/Storylines-Editor-STB-Server'
+        : '';
 
 // Create express app.
 var app = express();
@@ -135,7 +147,10 @@ app.route(ROUTE_PREFIX + '/retrieve/:id').get(function (req, res, next) {
 
                 // Write the product data to the ZIP file.
                 archive.pipe(output);
-                archive.directory(PRODUCT_PATH, false);
+                archive.glob('**', {
+                    cwd: PRODUCT_PATH,
+                    ignore: ['**/Thumbs.db']
+                });
                 archive.finalize();
 
                 responseMessages.push({ type: 'INFO', message: `Successfully loaded product ${req.params.id}` });


### PR DESCRIPTION
### Related Item(s)
#397 

### Changes
- Modified the `/retrieve` endpoint code to filter out Thumbs.db from the product to prevent the Express server from crashing.

### Testing
Steps:
1. Copy the server changes in this PR to your local machine.
2. Copy the `TCEI-IECT` product from the dev server to your local server `public` folder.
3. Load the product in the editor.
4. Click the `Save` button and ensure the server does not crash.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/398)
<!-- Reviewable:end -->
