### PR TITLE
Add slide control for including in toc, create config properties for controls

### DIFF
--- a/public/StorylinesSlideSchema.json
+++ b/public/StorylinesSlideSchema.json
@@ -504,7 +504,23 @@
             "type": "boolean",
             "description": "Optional attribute that indicates whether or not to include slide in table of contents. Defaults to true.",
             "default": true
+        },
+        "rightOnly": {
+            "type": "boolean",
+            "description": "Optional attribute that indicates whether or not the right panel should take up all of the space in the slide. Defaults to false.",
+            "default": false
+        },
+        "centerSlide": {
+            "type": "boolean",
+            "description": "Optional attribute that indicates whether or not to center the content of the slide. Defaults to false. Must be false if centerPanel (below) is true",
+            "default": false
+        },
+        "centerPanel": {
+            "type": "boolean",
+            "description": "Optional attribute that indicates whether or not to center the content of each panel. Defaults to false. Must be false if centerSlide (above) is true",
+            "default": false
         }
+        
     },
 
     "required": ["title", "panel"]

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -52,6 +52,13 @@
                             :disabled="centerSlide"
                             @change.stop="toggleCenterPanel()"
                         />
+                        <span class="mx-2 font-bold"> {{ $t('editor.slides.includeInToc') }}</span>
+                        <input
+                            type="checkbox"
+                            class="editor-input rounded-none cursor-pointer w-4 h-4"
+                            v-model="includeInToc"
+                            @change.stop="toggleIncludeInToc()"
+                        />
                     </div>
                 </div>
             </div>
@@ -365,6 +372,7 @@ export default class SlideEditorV extends Vue {
     rightOnly = false;
     centerSlide = false;
     centerPanel = false;
+    includeInToc = true;
     dynamicSelected = false;
 
     editors: Record<string, string> = {
@@ -381,6 +389,10 @@ export default class SlideEditorV extends Vue {
     @Watch('currentSlide', { deep: true })
     onSlideChange(): void {
         this.currentSlide ? (this.rightOnly = this.currentSlide.panel.length === 1) : false;
+        this.centerPanel = this.currentSlide.centerPanel ?? false;
+        this.centerSlide = this.currentSlide.centerSlide ?? false;
+        this.includeInToc = this.currentSlide.includeInToc ?? true;
+        this.rightOnly = this.currentSlide.rightOnly ?? false;
     }
 
     changePanelType(prevType: string, newType: string): void {
@@ -551,6 +563,7 @@ export default class SlideEditorV extends Vue {
     }
 
     toggleRightOnly(): void {
+        this.currentSlide.rightOnly = this.rightOnly;
         this.saveChanges();
         if (this.rightOnly) {
             this.panelIndex = 0;
@@ -571,6 +584,7 @@ export default class SlideEditorV extends Vue {
     }
 
     toggleCenterSlide(): void {
+        this.currentSlide.centerSlide = this.centerSlide;
         if (this.determineEditorType(this.currentSlide.panel[this.panelIndex]) === 'dynamic') {
             if (this.centerSlide) {
                 this.currentSlide.panel[0].customStyles = 'text-align: right;';
@@ -615,6 +629,7 @@ export default class SlideEditorV extends Vue {
     }
 
     toggleCenterPanel(): void {
+        this.currentSlide.centerPanel = this.centerPanel;
         if (this.centerPanel) {
             for (const p in this.currentSlide.panel) {
                 this.currentSlide.panel[p].customStyles = 'text-align: center;';
@@ -627,6 +642,10 @@ export default class SlideEditorV extends Vue {
                 );
             }
         }
+    }
+
+    toggleIncludeInToc(): void {
+        this.currentSlide.includeInToc = this.includeInToc;
     }
 }
 </script>


### PR DESCRIPTION
### Related Item(s)
#370 
#394

### Changes
- Added a slide control checkbox for including a slide in the table of contents (defaults to true)
- Added all slide controls to the slide's config, so that each slide 

### Testing
Steps:
1. Open any product (ex. 00000000-0000-0000-0000-000000000000)
2. Open the product's config (in vscode)
3. Go to the first slide and toggle the 'Include in Table of Contents' checkbox to be off
4. Click save
5. In the config, observe that for the first slide, `includeInToc` is now false
6. Go to any other slide, and observe that the 'Include in Table of Contents' checkbox is on
7. Toggle the 'Center Slide Content'  checkbox to be on
8. Click save
9. In the config, observe that for the corresponding slide, `centerSlide` is now true
10. Copy the directory containing the config for this product into your local `story-ramp` repo, within the `public` directory
11. Using your local `story-ramp` repo, open the preview for this product, and observe that the only slides in the toc are the ones for which `includeInToc` is set to true 
