### PR TITLE
Update link icon in text editor, Make external link open in new tab

### DIFF
--- a/src/components/text-editor.vue
+++ b/src/components/text-editor.vue
@@ -72,7 +72,7 @@ export default class TextEditorV extends Vue {
                             const content = selected || ``;
 
                             return {
-                                text: `[${content}](http://)`,
+                                text: `<a href='http://' target='_blank'>${content}</a>`,
                                 selected: selected
                             };
                         });
@@ -123,5 +123,8 @@ export default class TextEditorV extends Vue {
 <style lang="scss" scoped>
 label {
     text-align: left !important;
+}
+:deep(.v-md-icon-link::before) {
+    content: '\1F517';
 }
 </style>


### PR DESCRIPTION
### Related Item(s)
#384

### Changes
- Updated the link icon for the "Insert Link" dropdown of the text editor
- Made hyperlinks created using "Add External Link (New Tab)" option of the dropdown open in a new tab

### Notes
- The text editor, `vue-markdown-editor`, seems to use unicode characters for its icons. Initially, the link icon was `e6fe`. I've now switched it to `1f517`. 
- Before:
![image](https://github.com/user-attachments/assets/518a470d-15a9-4387-8e5a-6076f8c530e6)
- After:
![image](https://github.com/user-attachments/assets/39b326b6-da7a-40f7-99a5-6e31663afc4c)


### Testing
Steps:
1. Open an existing product (or create a new one)
2. Create a new text slide
3. Observe the new link icon
4. Open the "Insert Link" dropdown and click the "Add External Link (New Tab)" option
5. Enter `https://www.google.com/` as the hyperlink
6. Save the product and open the preview
7. Scroll down to the last slide and click the link you created. It should open in a new tab.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/406)
<!-- Reviewable:end -->
