### PR TITLE
correctly mark products with no logo as loaded

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -945,6 +945,9 @@ export default class MetadataEditorV extends Vue {
                     }
                 });
             }
+        } else {
+            // If there's no logo, mark the product as loaded.
+            this.loadStatus = 'loaded';
         }
     }
 


### PR DESCRIPTION
### Related Item(s)
#405 

### Changes
- When loading a product with no logo, its `loadStatus` will now be correctly marked as `loaded` when loading it through the editor. This should fix the issue we were having with the `rename` button not appearing.

### Testing
Steps:
1. Create a product with no logo and save it.
2. Go back to the home page and click Load an existing product and load your new Storylines product.
3. Ensure that once everything loads, the rename button appears under the UUID input.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/407)
<!-- Reviewable:end -->
