### PR TITLE
Implement ToC redesign/refactor, both-language previews

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "nouislider": "^15.5.0",
                 "ramp-config-editor_editeur-config-pcar": "^3.6.0",
                 "ramp-pcar": "^4.8.0",
-                "ramp-storylines_demo-scenarios-pcar": "^3.2.4",
+                "ramp-storylines_demo-scenarios-pcar": "^3.2.8",
                 "throttle-debounce": "^5.0.0",
                 "url": "^0.11.3",
                 "uuid": "^9.0.0",
@@ -8072,9 +8072,10 @@
             }
         },
         "node_modules/ramp-storylines_demo-scenarios-pcar": {
-            "version": "3.2.4",
-            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.2.4.tgz",
-            "integrity": "sha512-lj8lJrPcoFTk7s5RXx++c7Jw12Kt220jj+OVUqnoNccT496JRua4PkG/24PBPNEPH/n9tBq38yTbCYhMBZGtSg==",
+            "version": "3.2.8",
+            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.2.8.tgz",
+            "integrity": "sha512-GChEZiJQKWdzciSj0P5uSpzvayfiJ7AmClDF5y+gv/RcM9dBPFJkVPW0egSmFcf1pHbaR9Ln9sElkL/ab+Sg0A==",
+            "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",
                 "@tailwindcss/typography": "^0.4.0",
@@ -8540,7 +8541,8 @@
         "node_modules/scrollama": {
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/scrollama/-/scrollama-3.2.0.tgz",
-            "integrity": "sha512-PIPwB1kYBnbw/ezvPBJa5dCN5qEwokfpAkI3BmpZWAwcVID4nDf1qH6WV16A2fQaJmsKx0un5S/zhxN+PQeKDQ=="
+            "integrity": "sha512-PIPwB1kYBnbw/ezvPBJa5dCN5qEwokfpAkI3BmpZWAwcVID4nDf1qH6WV16A2fQaJmsKx0un5S/zhxN+PQeKDQ==",
+            "license": "MIT"
         },
         "node_modules/section-matter": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "nouislider": "^15.5.0",
         "ramp-config-editor_editeur-config-pcar": "^3.6.0",
         "ramp-pcar": "^4.8.0",
-        "ramp-storylines_demo-scenarios-pcar": "^3.2.4",
+        "ramp-storylines_demo-scenarios-pcar": "^3.2.8",
         "throttle-debounce": "^5.0.0",
         "url": "^0.11.3",
         "uuid": "^9.0.0",

--- a/src/app.vue
+++ b/src/app.vue
@@ -26,6 +26,8 @@ export default class App extends Vue {
         }
     }
 }
+
+
 </script>
 
 <style lang="scss">

--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -1,10 +1,17 @@
 <template>
     <div class="editor-container">
-        <div class="editor-header sticky flex items-center border-b border-black bg-gray-200 py-2 px-2 z-10">
-            <span class="mx-1">
+        <!-- Background overlay for when the mobile sidebar drawer is open -->
+        <!-- Should prevent stuff in the background from being scrolled or interacted with. Click it to close the sidebar -->
+        <div id="overlay" class="overlay" @click="closeSidebar"></div>
+        <!-- Header bar -->
+        <div
+            class="editor-header md:sticky flex md:gap-3 items-center border-b border-black bg-gray-200 py-2 px-2 z-10 flex-wrap"
+        >
+            <div class="flex flex-col gap-2 mx-0.5">
+                <!-- Back to landing page button -->
                 <router-link
                     :to="{ name: 'home' }"
-                    class="mt-1 flex justify-center h-full w-full"
+                    class="flex justify-center h-full w-full"
                     v-tippy="{
                         delay: '200',
                         placement: 'right',
@@ -22,106 +29,166 @@
                         />
                     </svg>
                 </router-link>
-            </span>
-            <div class="ml-3 flex flex-col">
-                <span class="font-semibold text-lg">{{ metadata.title }}</span>
-                <span :class="metadata.title ? 'text-xs' : ''">UUID: {{ uuid }}</span>
-            </div>
-            <span class="ml-auto"></span>
-            <button
-                v-if="unsavedChanges"
-                @click="$vfm.open(`reload-config`)"
-                class="editor-button border-2 border-red-700 text-red-700 rounded p-1 mr-2"
-                v-tippy="{
-                    delay: '200',
-                    placement: 'bottom',
-                    content: $t('editor.resetChanges'),
-                    animateFill: true
-                }"
-            >
-                <svg class="inline" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="18px" height="18px">
-                    <path
-                        d="M 2 2 L 4.9394531 4.9394531 C 3.1262684 6.7482143 2 9.2427079 2 12 C 2 17.514 6.486 22 12 22 C 17.514 22 22 17.514 22 12 C 22 6.486 17.514 2 12 2 L 12 4 C 16.411 4 20 7.589 20 12 C 20 16.411 16.411 20 12 20 C 7.589 20 4 16.411 4 12 C 4 9.7940092 4.9004767 7.7972757 6.3496094 6.3496094 L 9 9 L 9 2 L 2 2 z"
-                    />
-                </svg>
-                <span class="font-normal ml-1">{{ $t('editor.resetChanges') }}</span>
-            </button>
-            <transition name="fade">
-                <span v-if="unsavedChanges" class="border-2 border-red-700 text-red-700 rounded p-1 mr-2">
-                    <span class="align-middle inline-block mr-1 pb-1 fill-current"
-                        ><svg
-                            clip-rule="evenodd"
-                            fill-rule="evenodd"
-                            class="fill-red-600"
-                            width="18"
-                            height="18"
-                            stroke-linejoin="round"
-                            stroke-miterlimit="2"
-                            viewBox="0 0 24 24"
-                            xmlns="http://www.w3.org/2000/svg"
-                        >
-                            <path
-                                d="m12.002 21.534c5.518 0 9.998-4.48 9.998-9.998s-4.48-9.997-9.998-9.997c-5.517 0-9.997 4.479-9.997 9.997s4.48 9.998 9.997 9.998zm0-1.5c-4.69 0-8.497-3.808-8.497-8.498s3.807-8.497 8.497-8.497 8.498 3.807 8.498 8.497-3.808 8.498-8.498 8.498zm0-6.5c-.414 0-.75-.336-.75-.75v-5.5c0-.414.336-.75.75-.75s.75.336.75.75v5.5c0 .414-.336.75-.75.75zm-.002 3c.552 0 1-.448 1-1s-.448-1-1-1-1 .448-1 1 .448 1 1 1z"
-                                fill-rule="nonzero"
-                            />
-                        </svg>
-                    </span>
-                    <span class="align-center inline-block select-none">{{ $t('editor.unsavedChanges') }}</span>
-                </span>
-            </transition>
-            <slot name="langModal" v-bind="{ unsavedChanges: unsavedChanges }"></slot>
-            <!-- Preview dropdown -->
-            <div class="dropdown editor-button">
-                <button class="dropbtn flex gap-2 items-center">
-                    <p>{{ $t('editor.preview') }}</p>
+                <!-- Open mobile sidebar hamburger button -->
+                <!-- Only shows up on small viewport widths -->
+                <button
+                    @click="openSidebar"
+                    class="editor-button toc-popup-button bg-transparent border-none md:hidden"
+                >
                     <svg
+                        class="m-2"
                         xmlns="http://www.w3.org/2000/svg"
                         xmlns:xlink="http://www.w3.org/1999/xlink"
                         x="0px"
                         y="0px"
-                        viewBox="0 0 122.88 66.91"
-                        style="enable-background: new 0 0 122.88 66.91"
+                        width="16"
+                        height="16"
+                        viewBox="0 0 122.88 95.95"
+                        style="enable-background: new 0 0 122.88 95.95"
                         xml:space="preserve"
-                        height="12"
-                        width="12"
-                        class="fill-current transform rotate-180"
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
                     >
                         <g>
                             <path
-                                d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95 c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73 c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"
+                                class="st0"
+                                d="M8.94,0h105c4.92,0,8.94,4.02,8.94,8.94l0,0c0,4.92-4.02,8.94-8.94,8.94h-105C4.02,17.88,0,13.86,0,8.94l0,0 C0,4.02,4.02,0,8.94,0L8.94,0z M8.94,78.07h105c4.92,0,8.94,4.02,8.94,8.94l0,0c0,4.92-4.02,8.94-8.94,8.94h-105 C4.02,95.95,0,91.93,0,87.01l0,0C0,82.09,4.02,78.07,8.94,78.07L8.94,78.07z M8.94,39.03h105c4.92,0,8.94,4.02,8.94,8.94l0,0 c0,4.92-4.02,8.94-8.94,8.94h-105C4.02,56.91,0,52.89,0,47.97l0,0C0,43.06,4.02,39.03,8.94,39.03L8.94,39.03z"
                             />
                         </g>
                     </svg>
                 </button>
-                <div class="dropdown-content">
-                    <button @click.stop="preview('en')" class="border-b border-gray-400">
-                        {{ $t('editor.lang.en') }}
+            </div>
+
+            <div class="flex flex-1 flex-col gap-0.5 md:flex-row justify-between">
+                <!-- Storylines project title and UUID -->
+                <div class="flex flex-col">
+                    <span class="font-semibold text-lg">{{ metadata.title }}</span>
+                    <span :class="metadata.title ? 'text-xs' : ''">UUID: {{ uuid }}</span>
+                </div>
+                <span class="ml-auto"></span>
+                <div class="flex items-center flex-wrap gap-1">
+                    <!-- Reset changes button -->
+                    <button
+                        v-if="unsavedChanges"
+                        @click="$vfm.open(`reload-config`)"
+                        class="editor-button border-2 border-red-700 text-red-700 rounded p-1 m-0"
+                        v-tippy="{
+                            delay: '200',
+                            placement: 'bottom',
+                            content: $t('editor.resetChanges'),
+                            animateFill: true
+                        }"
+                    >
+                        <svg
+                            class="inline"
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
+                            width="18px"
+                            height="18px"
+                        >
+                            <path
+                                d="M 2 2 L 4.9394531 4.9394531 C 3.1262684 6.7482143 2 9.2427079 2 12 C 2 17.514 6.486 22 12 22 C 17.514 22 22 17.514 22 12 C 22 6.486 17.514 2 12 2 L 12 4 C 16.411 4 20 7.589 20 12 C 20 16.411 16.411 20 12 20 C 7.589 20 4 16.411 4 12 C 4 9.7940092 4.9004767 7.7972757 6.3496094 6.3496094 L 9 9 L 9 2 L 2 2 z"
+                            />
+                        </svg>
+                        <span class="font-normal ml-1">{{ $t('editor.resetChanges') }}</span>
                     </button>
-                    <button @click.stop="preview('fr')">{{ $t('editor.lang.fr') }}</button>
+                    <!-- Unsaved changes indicator -->
+                    <transition name="fade">
+                        <span v-if="unsavedChanges" class="border-2 border-red-700 text-red-700 rounded p-1">
+                            <span class="align-middle inline-block mr-1 pb-1 fill-current"
+                                ><svg
+                                    clip-rule="evenodd"
+                                    fill-rule="evenodd"
+                                    class="fill-red-600"
+                                    width="18"
+                                    height="18"
+                                    stroke-linejoin="round"
+                                    stroke-miterlimit="2"
+                                    viewBox="0 0 24 24"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                >
+                                    <path
+                                        d="m12.002 21.534c5.518 0 9.998-4.48 9.998-9.998s-4.48-9.997-9.998-9.997c-5.517 0-9.997 4.479-9.997 9.997s4.48 9.998 9.997 9.998zm0-1.5c-4.69 0-8.497-3.808-8.497-8.498s3.807-8.497 8.497-8.497 8.498 3.807 8.498 8.497-3.808 8.498-8.498 8.498zm0-6.5c-.414 0-.75-.336-.75-.75v-5.5c0-.414.336-.75.75-.75s.75.336.75.75v5.5c0 .414-.336.75-.75.75zm-.002 3c.552 0 1-.448 1-1s-.448-1-1-1-1 .448-1 1 .448 1 1 1z"
+                                        fill-rule="nonzero"
+                                    />
+                                </svg>
+                            </span>
+                            <span class="align-center inline-block select-none">{{ $t('editor.unsavedChanges') }}</span>
+                        </span>
+                    </transition>
+                    <slot name="langModal" v-bind="{ unsavedChanges: unsavedChanges }"></slot>
+                    <!-- Preview dropdown -->
+                    <div class="dropdown editor-button">
+                        <!-- The "Preview" button - hover over it to show the options -->
+                        <button class="dropbtn flex gap-2 items-center cursor-default">
+                            <p>{{ $t('editor.preview') }}</p>
+                            <svg
+                                xmlns="http://www.w3.org/2000/svg"
+                                xmlns:xlink="http://www.w3.org/1999/xlink"
+                                x="0px"
+                                y="0px"
+                                viewBox="0 0 122.88 66.91"
+                                style="enable-background: new 0 0 122.88 66.91"
+                                xml:space="preserve"
+                                height="12"
+                                width="12"
+                                class="fill-current transform rotate-180"
+                            >
+                                <g>
+                                    <path
+                                        d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95 c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73 c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"
+                                    />
+                                </g>
+                            </svg>
+                        </button>
+                        <!-- The two preview language config options: English and French -->
+                        <div class="dropdown-content">
+                            <!-- English config button -->
+                            <button @click.stop="preview('en')" class="border-b border-gray-400">
+                                {{ $t('editor.lang.en') }}
+                            </button>
+                            <!-- French config button -->
+                            <button @click.stop="preview('fr')">{{ $t('editor.lang.fr') }}</button>
+                        </div>
+                    </div>
+                    <!-- Save changes button -->
+                    <button
+                        @click="saveChanges"
+                        class="editor-button m-0 bg-black text-white hover:bg-gray-900"
+                        :disabled="saving"
+                    >
+                        <span class="inline-block">{{
+                            saving ? $t('editor.savingChanges') : $t('editor.saveChanges')
+                        }}</span>
+                        <span v-if="saving" class="align-middle inline-block px-1">
+                            <spinner size="16px" color="#009cd1" class="ml-1 mb-1"></spinner>
+                        </span>
+                    </button>
+                    <!-- Help button -->
+                    <button
+                        @click="$vfm.open(`help-panel`)"
+                        class="bg-white border border-black rounded-full w-9 h-9 hover:bg-gray-100"
+                        v-tippy="{
+                            delay: '200',
+                            placement: 'top',
+                            content: $t('help.title'),
+                            animateFill: true
+                        }"
+                    >
+                        <span class="bottom-0 question-mark-button"> ? </span>
+                    </button>
                 </div>
             </div>
-            <button @click="saveChanges" class="editor-button bg-black text-white hover:bg-gray-900" :disabled="saving">
-                <span class="inline-block">{{ saving ? $t('editor.savingChanges') : $t('editor.saveChanges') }}</span>
-                <span v-if="saving" class="align-middle inline-block px-1">
-                    <spinner size="16px" color="#009cd1" class="ml-1 mb-1"></spinner>
-                </span>
-            </button>
-            <button
-                @click="$vfm.open(`help-panel`)"
-                class="bg-white border border-black rounded-full w-9 h-9 hover:bg-gray-100"
-                v-tippy="{
-                    delay: '200',
-                    placement: 'top',
-                    content: $t('help.title'),
-                    animateFill: true
-                }"
-            >
-                <span class="bottom-0 question-mark-button"> ? </span>
-            </button>
         </div>
+        <!-- Body content -->
         <div class="flex">
-            <div class="w-80 flex-shrink-0 border-r border-black editor-toc">
+            <!-- Left side -->
+
+            <!-- Sidebar, desktop version -->
+            <div id="sidebar-desktop" class="w-80 flex-shrink-0 border-r border-black editor-toc hidden md:block">
                 <div class="flex items-center justify-center border-b p-2">
+                    <!-- Edit metadata button -->
+                    <!-- Opens the edit metadata modal -->
                     <button class="toc-popup-button" @click.stop="$vfm.open('metadata-edit-modal')">
                         <span class="align-middle inline-block pr-1"
                             ><svg
@@ -143,8 +210,9 @@
                         <span class="align-middle inline-block">{{ $t('editor.editMetadata') }}</span>
                     </button>
                 </div>
+                <!-- ToC -->
                 <slide-toc
-                    :bothLanguageSlides="bothLanguageSlides"
+                    :slides="slides"
                     :currentSlide="currentSlide"
                     :slideIndex="slideIndex"
                     @slide-change="selectSlide"
@@ -154,21 +222,88 @@
                     :sourceCounts="sourceCounts"
                 ></slide-toc>
             </div>
-            <div class="flex flex-col space-between w-full">
+            <!-- Sidebar, mobile version -->
+            <div id="sidebar-mobile" class="w-0 flex-shrink-0 border-r border-black editor-toc md:hidden">
+                <div class="flex items-center justify-between border-b p-2">
+                    <!-- Edit metadata button -->
+                    <!-- Opens the edit metadata modal -->
+                    <button class="toc-popup-button" @click.stop="$vfm.open('metadata-edit-modal')">
+                        <span class="align-middle inline-block pr-1"
+                            ><svg
+                                clip-rule="evenodd"
+                                fill-rule="evenodd"
+                                width="16"
+                                height="16"
+                                stroke-linejoin="round"
+                                stroke-miterlimit="2"
+                                viewBox="0 0 24 24"
+                                xmlns="http://www.w3.org/2000/svg"
+                            >
+                                <path
+                                    d="m4.481 15.659c-1.334 3.916-1.48 4.232-1.48 4.587 0 .528.46.749.749.749.352 0 .668-.137 4.574-1.492zm1.06-1.061 3.846 3.846 11.321-11.311c.195-.195.293-.45.293-.707 0-.255-.098-.51-.293-.706-.692-.691-1.742-1.74-2.435-2.432-.195-.195-.451-.293-.707-.293-.254 0-.51.098-.706.293z"
+                                    fill-rule="nonzero"
+                                />
+                            </svg>
+                        </span>
+                        <span class="align-middle inline-block">{{ $t('editor.editMetadata') }}</span>
+                    </button>
+                    <!-- Close ToC sidebar button -->
+                    <button class="editor-button toc-popup-button p-3 bg-transparent" @click="closeSidebar">
+                        <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            xmlns:xlink="http://www.w3.org/1999/xlink"
+                            x="0px"
+                            y="0px"
+                            width="16"
+                            height="16"
+                            viewBox="0 0 122.88 122.88"
+                            style="enable-background: new 0 0 122.88 122.88"
+                            xml:space="preserve"
+                            fill-rule="evenodd"
+                            clip-rule="evenodd"
+                        >
+                            <g>
+                                <path
+                                    class="st0"
+                                    d="M1.63,97.99l36.55-36.55L1.63,24.89c-2.17-2.17-2.17-5.73,0-7.9L16.99,1.63c2.17-2.17,5.73-2.17,7.9,0 l36.55,36.55L97.99,1.63c2.17-2.17,5.73-2.17,7.9,0l15.36,15.36c2.17,2.17,2.17,5.73,0,7.9L84.7,61.44l36.55,36.55 c2.17,2.17,2.17,5.73,0,7.9l-15.36,15.36c-2.17,2.17-5.73,2.17-7.9,0L61.44,84.7l-36.55,36.55c-2.17,2.17-5.73,2.17-7.9,0 L1.63,105.89C-0.54,103.72-0.54,100.16,1.63,97.99L1.63,97.99z"
+                                />
+                            </g>
+                        </svg>
+                    </button>
+                </div>
+                <!-- Mobile ToC -->
+                <!-- Bigger buttons, more visual dividers, more colors -->
+                <slide-toc
+                    :slides="slides"
+                    :currentSlide="currentSlide"
+                    :slideIndex="slideIndex"
+                    @slide-change="selectSlide"
+                    @slides-updated="updateSlides"
+                    :configFileStructure="configFileStructure"
+                    :lang="configLang"
+                    :sourceCounts="sourceCounts"
+                    :closeSidebar="closeSidebar"
+                    :isMobileSidebar="true"
+                ></slide-toc>
+            </div>
+            <!-- Right side -->
+            <div class="editor-area flex flex-col space-between w-full overflow-y-auto">
+                <!-- Slide editor -->
                 <slide-editor
-                    class="flex-1 w-full"
+                    class="flex-1 w-full overflow-y-auto"
                     ref="slide"
                     :configFileStructure="configFileStructure"
                     :currentSlide="currentSlide"
-                    :lang="bothLanguageSlides.find((slides) => slides.fr === currentSlide) ? 'fr' : 'en'"
+                    :lang="slides.find((slide) => slide.fr === currentSlide) ? 'fr' : 'en'"
                     :slideIndex="slideIndex"
-                    :isLast="slideIndex === bothLanguageSlides.length - 1"
+                    :isLast="slideIndex === slides.length - 1"
                     :uid="uuid"
                     @slide-change="selectSlide"
                     @slide-edit="onSlidesEdited"
                     @custom-slide-updated="updateCustomSlide"
                     :sourceCounts="sourceCounts"
                 ></slide-editor>
+                <!-- Give feedback button -->
                 <div class="footer text-right pr-5 editor-button h-fit">
                     <a
                         :href="`mailto:applicationsdecartographieweb-webmappingapplications@ec.gc.ca?subject=${$t(
@@ -181,8 +316,11 @@
             </div>
         </div>
 
+        <!-- Edit metadata modal -->
         <slot name="metadataModal"></slot>
+        <!-- Help modal -->
         <help-panel :helpSections="helpSections" :originalTextArray="originalTextArray"></help-panel>
+        <!-- Reload config confirmation modal -->
         <confirmation-modal
             :name="`reload-config`"
             :message="$t('editor.refreshChanges.modal')"
@@ -200,7 +338,8 @@ import {
     Slide,
     SlideForBothLanguages,
     SourceCounts,
-    StoryRampConfig
+    StoryRampConfig,
+    TextPanel
 } from '@/definitions';
 import { VueSpinnerOval } from 'vue3-spinners';
 import axios from 'axios';
@@ -232,8 +371,7 @@ export default class EditorV extends Vue {
     @Prop() sourceCounts!: SourceCounts;
     @Prop() metadata!: MetadataContent;
 
-    @Prop() bothLanguageSlides!: SlideForBothLanguages[];
-    @Prop() slides!: Slide[];
+    @Prop() slides!: SlideForBothLanguages[];
     @Prop() configLang!: string;
     @Prop() saving!: boolean;
     @Prop() unsavedChanges!: boolean;
@@ -248,7 +386,23 @@ export default class EditorV extends Vue {
     helpMd = '';
     originalTextArray: string[] = [];
 
-    @Watch('bothLanguageSlides', { deep: true })
+    defaultBlankSlide: Slide = {
+        title: '',
+        panel: [
+            {
+                type: 'text',
+                title: '',
+                content: ''
+            } as TextPanel,
+            {
+                type: 'text',
+                title: '',
+                content: ''
+            } as TextPanel
+        ]
+    };
+
+    @Watch('slides', { deep: true })
     onSlidesEdited(): void {
         this.$emit('save-status', true);
     }
@@ -259,7 +413,7 @@ export default class EditorV extends Vue {
     }
 
     created(): void {
-        this.loadSlides = this.bothLanguageSlides;
+        this.loadSlides = this.slides;
         this.uuid = this.$route.params.uid as string;
 
         window.addEventListener('beforeunload', this.beforeWindowUnload);
@@ -281,6 +435,24 @@ export default class EditorV extends Vue {
     }
 
     /**
+     * Opens the mobile sidebar drawer.
+     */
+    openSidebar(): void {
+        document.getElementById('sidebar-mobile')!.style.width = '20rem';
+        document.getElementById('overlay')!.style.display = 'block'; // Show the overlay
+        document.body.style.overflow = 'hidden'; // Disable background scrolling
+    }
+
+    /**
+     * Closes the mobile sidebar drawer.
+     */
+    closeSidebar(): void {
+        document.getElementById('sidebar-mobile')!.style.width = '0px';
+        document.getElementById('overlay')!.style.display = 'none'; // Hide the overlay
+        document.body.style.overflow = ''; // Re-enable background scrolling
+    }
+
+    /**
      * Change current slide to selected slide.
      */
     selectSlide(index: number, lang?: string): void {
@@ -296,20 +468,13 @@ export default class EditorV extends Vue {
         };
 
         setTimeout(() => {
-            if (
-                index === -1 ||
-                !this.loadSlides ||
-                !this.loadSlides?.[index] ||
-                !this.loadSlides?.[index][
-                    (lang as keyof SlideForBothLanguages) ?? (this.configLang as keyof SlideForBothLanguages)
-                ]
-            ) {
+            if (index === -1 || !this.loadSlides) {
                 this.currentSlide = '';
             } else {
-                this.currentSlide =
-                    this.loadSlides[index][
-                        (lang as keyof SlideForBothLanguages) ?? (this.configLang as keyof SlideForBothLanguages)
-                    ]!;
+                const selectedLang =
+                    (lang as keyof SlideForBothLanguages) ?? (this.configLang as keyof SlideForBothLanguages);
+                const selectedSlide = this.loadSlides[index][selectedLang];
+                this.currentSlide = selectedSlide ?? '';
             }
 
             this.slideIndex = index;
@@ -322,9 +487,11 @@ export default class EditorV extends Vue {
     /**
      * Update slide for a custom config made through advanced editor.
      */
-    updateCustomSlide(slideConfig: Slide, save?: boolean): void {
+    updateCustomSlide(slideConfig: Slide, save?: boolean, lang?: string): void {
         this.currentSlide = slideConfig;
-        this.bothLanguageSlides[this.slideIndex][this.configLang as keyof SlideForBothLanguages] = slideConfig;
+        this.slides[this.slideIndex][
+            (lang as keyof SlideForBothLanguages) ?? (this.configLang as keyof SlideForBothLanguages)
+        ] = slideConfig;
         // save changes emitted from advanced editor
         if (save) {
             this.$emit('save-changes');
@@ -340,8 +507,8 @@ export default class EditorV extends Vue {
             (bothSlides) =>
                 (this.currentSlide as Slide) === bothSlides['en'] || (this.currentSlide as Slide) === bothSlides['fr']
         );
-        this.configs.en!.slides = this.bothLanguageSlides.filter((slides) => slides.en).map((slides) => slides.en!);
-        this.configs.fr!.slides = this.bothLanguageSlides.filter((slides) => slides.fr).map((slides) => slides.fr!);
+        this.configs.en!.slides = this.slides.map((slides) => slides.en!);
+        this.configs.fr!.slides = this.slides.map((slides) => slides.fr!);
     }
 
     /**
@@ -386,6 +553,15 @@ export default class EditorV extends Vue {
             (this.$refs.slide as SlideEditorV).saveChanges();
         }
 
+        const previewConfigs = this.configs;
+        // Replace undefined slides with empty slides, just like in final save
+        previewConfigs.en!.slides = previewConfigs.en!.slides.map((slide) => {
+            return slide ?? JSON.parse(JSON.stringify(this.defaultBlankSlide));
+        });
+        previewConfigs.fr!.slides = previewConfigs.fr!.slides.map((slide) => {
+            return slide ?? JSON.parse(JSON.stringify(this.defaultBlankSlide));
+        });
+
         setTimeout(() => {
             const routeData = this.$router.resolve({
                 name: 'preview',
@@ -393,7 +569,7 @@ export default class EditorV extends Vue {
             });
             const previewTab = window.open(routeData.href, '_blank');
             (previewTab as Window).props = {
-                configs: this.configs,
+                configs: previewConfigs,
                 configFileStructure: this.configFileStructure
             };
         }, 5);
@@ -416,6 +592,18 @@ export default class EditorV extends Vue {
         }
     }
 }
+
+// More accurate page height for mobile
+// Counts the URL bar for mobile browsers (e.g. iOS Safari) so the content doesn't vertically overshoot
+// and get covered by the URL bar when it's opened
+
+let vh = window.innerHeight * 0.01;
+document.documentElement.style.setProperty('--vh', `${vh}px`);
+
+window.addEventListener('resize', () => {
+    let vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+});
 </script>
 
 <style lang="scss">
@@ -510,10 +698,20 @@ export default class EditorV extends Vue {
     background-color: rgb(221, 221, 221);
 }
 
-/* 
+// Independent scrollable editor area only on desktop, so that header isn't fixed on mobile
+// (takes up too much space)
+@media only screen and (min-width: 768px) {
+    .editor-area {
+        overflow-y: auto;
+        height: calc(100vh - 63px);
+        height: calc(calc(var(--vh, 1vh) * 100) - 63px);
+    }
+}
+
+/*
  * Preview language selection dropdown styling
- * Base (pre-styling) code graciously provided by 
- * https://www.w3schools.com/howto/howto_css_dropdown.asp 
+ * Base (pre-styling) code graciously provided by
+ * https://www.w3schools.com/howto/howto_css_dropdown.asp
  */
 
 /* Dropdown Button */
@@ -570,5 +768,29 @@ export default class EditorV extends Vue {
 /* Change the background color of the dropdown button when the dropdown content is shown */
 .dropdown:hover .dropbtn {
     background-color: #dbdbdb;
+}
+
+#sidebar-mobile {
+    z-index: 21; // should be on top
+    height: 100%;
+    width: 0; /* Initial width is 0 to be hidden */
+    max-width: 100%;
+    position: fixed; /* Sidebar is fixed, hovering over content */
+    top: 0;
+    left: 0;
+    overflow-x: hidden;
+    transition: 0.5s; /* Smooth transition when opening/closing */
+    background-color: white;
+}
+
+.overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5); /* Translucent black */
+    z-index: 20; /* Ensure it appears just under the sidebar */
+    display: none; /* Initially hidden */
 }
 </style>

--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -336,7 +336,7 @@ import {
     HelpSection,
     MetadataContent,
     Slide,
-    SlideForBothLanguages,
+    MultiLanguageSlide,
     SourceCounts,
     StoryRampConfig,
     TextPanel
@@ -371,7 +371,7 @@ export default class EditorV extends Vue {
     @Prop() sourceCounts!: SourceCounts;
     @Prop() metadata!: MetadataContent;
 
-    @Prop() slides!: SlideForBothLanguages[];
+    @Prop() slides!: MultiLanguageSlide[];
     @Prop() configLang!: string;
     @Prop() saving!: boolean;
     @Prop() unsavedChanges!: boolean;
@@ -379,7 +379,7 @@ export default class EditorV extends Vue {
     // Form properties.
     uuid = '';
     logoImage: undefined | File = undefined;
-    loadSlides: undefined | SlideForBothLanguages[] = undefined;
+    loadSlides: undefined | MultiLanguageSlide[] = undefined;
     currentSlide: Slide | string = '';
     slideIndex = -1;
     helpSections: HelpSection[] = [];
@@ -471,8 +471,7 @@ export default class EditorV extends Vue {
             if (index === -1 || !this.loadSlides) {
                 this.currentSlide = '';
             } else {
-                const selectedLang =
-                    (lang as keyof SlideForBothLanguages) ?? (this.configLang as keyof SlideForBothLanguages);
+                const selectedLang = (lang ?? this.configLang) as keyof MultiLanguageSlide;
                 const selectedSlide = this.loadSlides[index][selectedLang];
                 this.currentSlide = selectedSlide ?? '';
             }
@@ -489,9 +488,10 @@ export default class EditorV extends Vue {
      */
     updateCustomSlide(slideConfig: Slide, save?: boolean, lang?: string): void {
         this.currentSlide = slideConfig;
-        this.slides[this.slideIndex][
-            (lang as keyof SlideForBothLanguages) ?? (this.configLang as keyof SlideForBothLanguages)
-        ] = slideConfig;
+        this.slides[this.slideIndex][(lang ?? this.configLang) as keyof MultiLanguageSlide] = slideConfig;
+
+        this.configs[(lang ?? this.configLang) as keyof MultiLanguageSlide]!.slides[this.slideIndex] = slideConfig;
+
         // save changes emitted from advanced editor
         if (save) {
             this.$emit('save-changes');
@@ -501,7 +501,7 @@ export default class EditorV extends Vue {
     /**
      * Updates slides after adding, removing, or reordering.
      */
-    updateSlides(slides: SlideForBothLanguages[]): void {
+    updateSlides(slides: MultiLanguageSlide[]): void {
         this.loadSlides = slides;
         this.slideIndex = this.loadSlides.findIndex(
             (bothSlides) =>

--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -70,9 +70,36 @@
                 </span>
             </transition>
             <slot name="langModal" v-bind="{ unsavedChanges: unsavedChanges }"></slot>
-            <button @click="preview" class="editor-button bg-white border border-black hover:bg-gray-100">
-                {{ $t('editor.preview') }}
-            </button>
+            <!-- Preview dropdown -->
+            <div class="dropdown editor-button">
+                <button class="dropbtn flex gap-2 items-center">
+                    <p>{{ $t('editor.preview') }}</p>
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                        x="0px"
+                        y="0px"
+                        viewBox="0 0 122.88 66.91"
+                        style="enable-background: new 0 0 122.88 66.91"
+                        xml:space="preserve"
+                        height="12"
+                        width="12"
+                        class="fill-current transform rotate-180"
+                    >
+                        <g>
+                            <path
+                                d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95 c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73 c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"
+                            />
+                        </g>
+                    </svg>
+                </button>
+                <div class="dropdown-content">
+                    <button @click.stop="preview('en')" class="border-b border-gray-400">
+                        {{ $t('editor.lang.en') }}
+                    </button>
+                    <button @click.stop="preview('fr')">{{ $t('editor.lang.fr') }}</button>
+                </div>
+            </div>
             <button @click="saveChanges" class="editor-button bg-black text-white hover:bg-gray-900" :disabled="saving">
                 <span class="inline-block">{{ saving ? $t('editor.savingChanges') : $t('editor.saveChanges') }}</span>
                 <span v-if="saving" class="align-middle inline-block px-1">
@@ -95,8 +122,8 @@
         <div class="flex">
             <div class="w-80 flex-shrink-0 border-r border-black editor-toc">
                 <div class="flex items-center justify-center border-b p-2">
-                    <button class="editor-toc-button editor-button" @click.stop="$vfm.open('metadata-edit-modal')">
-                        <span class="align-middle inline-block px-1"
+                    <button class="toc-popup-button" @click.stop="$vfm.open('metadata-edit-modal')">
+                        <span class="align-middle inline-block pr-1"
                             ><svg
                                 clip-rule="evenodd"
                                 fill-rule="evenodd"
@@ -117,7 +144,7 @@
                     </button>
                 </div>
                 <slide-toc
-                    :slides="slides"
+                    :bothLanguageSlides="bothLanguageSlides"
                     :currentSlide="currentSlide"
                     :slideIndex="slideIndex"
                     @slide-change="selectSlide"
@@ -127,29 +154,33 @@
                     :sourceCounts="sourceCounts"
                 ></slide-toc>
             </div>
-            <slide-editor
-                ref="slide"
-                :configFileStructure="configFileStructure"
-                :currentSlide="currentSlide"
-                :lang="configLang"
-                :slideIndex="slideIndex"
-                :isLast="slideIndex === slides.length - 1"
-                :uid="uuid"
-                @slide-change="selectSlide"
-                @slide-edit="onSlidesEdited"
-                @custom-slide-updated="updateCustomSlide"
-                :sourceCounts="sourceCounts"
-            ></slide-editor>
+            <div class="flex flex-col space-between w-full">
+                <slide-editor
+                    class="flex-1 w-full"
+                    ref="slide"
+                    :configFileStructure="configFileStructure"
+                    :currentSlide="currentSlide"
+                    :lang="bothLanguageSlides.find((slides) => slides.fr === currentSlide) ? 'fr' : 'en'"
+                    :slideIndex="slideIndex"
+                    :isLast="slideIndex === bothLanguageSlides.length - 1"
+                    :uid="uuid"
+                    @slide-change="selectSlide"
+                    @slide-edit="onSlidesEdited"
+                    @custom-slide-updated="updateCustomSlide"
+                    :sourceCounts="sourceCounts"
+                ></slide-editor>
+                <div class="footer text-right pr-5 editor-button h-fit">
+                    <a
+                        :href="`mailto:applicationsdecartographieweb-webmappingapplications@ec.gc.ca?subject=${$t(
+                            'editor.feedback.subject'
+                        )}`"
+                    >
+                        {{ $t('editor.feedback') }}
+                    </a>
+                </div>
+            </div>
         </div>
-        <div class="footer text-right pr-5 editor-button">
-            <a
-                :href="`mailto:applicationsdecartographieweb-webmappingapplications@ec.gc.ca?subject=${$t(
-                    'editor.feedback.subject'
-                )}`"
-            >
-                {{ $t('editor.feedback') }}
-            </a>
-        </div>
+
         <slot name="metadataModal"></slot>
         <help-panel :helpSections="helpSections" :originalTextArray="originalTextArray"></help-panel>
         <confirmation-modal
@@ -162,7 +193,15 @@
 
 <script lang="ts">
 import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
-import { ConfigFileStructure, HelpSection, MetadataContent, Slide, SourceCounts, StoryRampConfig } from '@/definitions';
+import {
+    ConfigFileStructure,
+    HelpSection,
+    MetadataContent,
+    Slide,
+    SlideForBothLanguages,
+    SourceCounts,
+    StoryRampConfig
+} from '@/definitions';
 import { VueSpinnerOval } from 'vue3-spinners';
 import axios from 'axios';
 import { marked } from 'marked';
@@ -192,6 +231,8 @@ export default class EditorV extends Vue {
     @Prop() configFileStructure!: ConfigFileStructure | undefined;
     @Prop() sourceCounts!: SourceCounts;
     @Prop() metadata!: MetadataContent;
+
+    @Prop() bothLanguageSlides!: SlideForBothLanguages[];
     @Prop() slides!: Slide[];
     @Prop() configLang!: string;
     @Prop() saving!: boolean;
@@ -200,14 +241,14 @@ export default class EditorV extends Vue {
     // Form properties.
     uuid = '';
     logoImage: undefined | File = undefined;
-    loadSlides: undefined | Slide[] = undefined;
+    loadSlides: undefined | SlideForBothLanguages[] = undefined;
     currentSlide: Slide | string = '';
     slideIndex = -1;
     helpSections: HelpSection[] = [];
     helpMd = '';
     originalTextArray: string[] = [];
 
-    @Watch('slides', { deep: true })
+    @Watch('bothLanguageSlides', { deep: true })
     onSlidesEdited(): void {
         this.$emit('save-status', true);
     }
@@ -218,7 +259,7 @@ export default class EditorV extends Vue {
     }
 
     created(): void {
-        this.loadSlides = this.slides;
+        this.loadSlides = this.bothLanguageSlides;
         this.uuid = this.$route.params.uid as string;
 
         window.addEventListener('beforeunload', this.beforeWindowUnload);
@@ -242,7 +283,7 @@ export default class EditorV extends Vue {
     /**
      * Change current slide to selected slide.
      */
-    selectSlide(index: number): void {
+    selectSlide(index: number, lang?: string): void {
         // save changes to current slide before changing slides
         if (this.$refs.slide !== undefined) {
             (this.$refs.slide as SlideEditorV).saveChanges();
@@ -255,7 +296,22 @@ export default class EditorV extends Vue {
         };
 
         setTimeout(() => {
-            this.currentSlide = index === -1 ? '' : (this.loadSlides as Slide[])[index];
+            if (
+                index === -1 ||
+                !this.loadSlides ||
+                !this.loadSlides?.[index] ||
+                !this.loadSlides?.[index][
+                    (lang as keyof SlideForBothLanguages) ?? (this.configLang as keyof SlideForBothLanguages)
+                ]
+            ) {
+                this.currentSlide = '';
+            } else {
+                this.currentSlide =
+                    this.loadSlides[index][
+                        (lang as keyof SlideForBothLanguages) ?? (this.configLang as keyof SlideForBothLanguages)
+                    ]!;
+            }
+
             this.slideIndex = index;
             (this.$refs.slide as SlideEditorV).panelIndex = 0;
             (this.$refs.slide as SlideEditorV).advancedEditorView = false;
@@ -268,7 +324,7 @@ export default class EditorV extends Vue {
      */
     updateCustomSlide(slideConfig: Slide, save?: boolean): void {
         this.currentSlide = slideConfig;
-        this.slides[this.slideIndex] = slideConfig;
+        this.bothLanguageSlides[this.slideIndex][this.configLang as keyof SlideForBothLanguages] = slideConfig;
         // save changes emitted from advanced editor
         if (save) {
             this.$emit('save-changes');
@@ -278,9 +334,14 @@ export default class EditorV extends Vue {
     /**
      * Updates slides after adding, removing, or reordering.
      */
-    updateSlides(slides: Slide[]): void {
+    updateSlides(slides: SlideForBothLanguages[]): void {
         this.loadSlides = slides;
-        this.slideIndex = this.loadSlides.indexOf(this.currentSlide as Slide);
+        this.slideIndex = this.loadSlides.findIndex(
+            (bothSlides) =>
+                (this.currentSlide as Slide) === bothSlides['en'] || (this.currentSlide as Slide) === bothSlides['fr']
+        );
+        this.configs.en!.slides = this.bothLanguageSlides.filter((slides) => slides.en).map((slides) => slides.en!);
+        this.configs.fr!.slides = this.bothLanguageSlides.filter((slides) => slides.fr).map((slides) => slides.fr!);
     }
 
     /**
@@ -317,8 +378,9 @@ export default class EditorV extends Vue {
 
     /**
      * Open current editor config as a new Storylines product in new tab.
+     * @param language The config language to preview (either 'en' or 'fr')
      */
-    preview(): void {
+    preview(language: string): void {
         // save current slide final changes before previewing product
         if (this.$refs.slide != null && this.currentSlide !== '') {
             (this.$refs.slide as SlideEditorV).saveChanges();
@@ -327,7 +389,7 @@ export default class EditorV extends Vue {
         setTimeout(() => {
             const routeData = this.$router.resolve({
                 name: 'preview',
-                params: { lang: this.configLang, uid: this.uuid }
+                params: { lang: language, uid: this.uuid }
             });
             const previewTab = window.open(routeData.href, '_blank');
             (previewTab as Window).props = {
@@ -433,5 +495,80 @@ export default class EditorV extends Vue {
 .question-mark-button {
     font-size: 24px;
     line-height: 1.8rem;
+}
+
+.toc-popup-button {
+    border: 1px solid rgb(135, 135, 135);
+    background-color: rgb(243, 243, 243);
+    border-radius: 3px;
+    padding: 3px 12px;
+}
+.toc-popup-button:hover {
+    background-color: rgb(234, 234, 234);
+}
+.toc-popup-button:active {
+    background-color: rgb(221, 221, 221);
+}
+
+/* 
+ * Preview language selection dropdown styling
+ * Base (pre-styling) code graciously provided by 
+ * https://www.w3schools.com/howto/howto_css_dropdown.asp 
+ */
+
+/* Dropdown Button */
+.dropbtn {
+    background-color: white;
+    color: black;
+    padding: 5px 14px;
+    font-size: 16px;
+    font-weight: 600;
+    border: 1px solid black;
+    transition: background-color 0.2s;
+}
+
+/* Main dropdown icon - required for positioning */
+.dropdown {
+    position: relative;
+    display: inline-block;
+    margin: 0;
+    padding: 0;
+}
+
+/* The dropdown box with the links */
+.dropdown-content {
+    display: none;
+    position: absolute;
+    background-color: white;
+    min-width: 110px;
+    box-shadow: 0px 8px 16px 0px rgba(0, 0, 0, 0.2);
+    z-index: 1;
+    border: 1px solid lightgray;
+}
+
+/* Links inside the dropdown */
+.dropdown-content button {
+    color: black;
+    padding: 7px 10px;
+    text-decoration: none;
+    display: block;
+    text-align: center;
+    font-weight: 500;
+    width: 100%;
+}
+
+/* Change color of dropdown links on hover */
+.dropdown-content button:hover {
+    background-color: #e6e5e5;
+}
+
+/* Show the dropdown menu on hover */
+.dropdown:hover .dropdown-content {
+    display: block;
+}
+
+/* Change the background color of the dropdown button when the dropdown content is shown */
+.dropdown:hover .dropbtn {
+    background-color: #dbdbdb;
 }
 </style>

--- a/src/components/helpers/action-modal.vue
+++ b/src/components/helpers/action-modal.vue
@@ -1,0 +1,73 @@
+<template>
+    <vue-final-modal
+        :modalId="name"
+        content-class="flex flex-col max-h-full overflow-y-auto max-w-xl mx-4 p-4 bg-white border rounded-lg space-y-2"
+        class="flex justify-center items-center"
+    >
+        <div class="mx-5 my-2">
+            <h2 slot="header" class="text-2xl font-bold mb-1">{{ title }}</h2>
+            <p>{{ message }}</p>
+            <div class="w-full flex justify-end mt-3">
+                <button class="editor-button bg-black text-white hover:bg-gray-800" @click="onOk">
+                    {{ $t('editor.slides.continue') }}
+                </button>
+                <button class="editor-button hover:bg-gray-800" @click="onCancel">
+                    {{ $t('editor.cancel') }}
+                </button>
+            </div>
+        </div>
+    </vue-final-modal>
+</template>
+
+<script lang="ts">
+import { Options, Prop, Vue } from 'vue-property-decorator';
+import { VueFinalModal } from 'vue-final-modal';
+// import { Options } from 'vue-property-decorator';
+
+@Options({
+    components: {
+        'vue-final-modal': VueFinalModal
+    }
+})
+export default class MetadataEditorV extends Vue {
+    @Prop() name!: string;
+    @Prop() title!: string;
+    @Prop() message!: string;
+
+    onOk(): void {
+        this.$emit('ok');
+        this.$vfm.close(this.name);
+    }
+
+    onCancel(): void {
+        this.$emit('Cancel');
+        this.$vfm.close(this.name);
+    }
+}
+</script>
+
+<style scoped lang="css">
+h2 {
+    line-height: 1.3;
+    border-bottom: 0px;
+}
+
+button {
+    border-radius: 3px;
+    padding: 5px 12px;
+    margin: 0px 10px;
+    font-weight: 600;
+    transition-duration: 0.2s;
+}
+
+.vfm__content button:hover:enabled {
+    background-color: #dbdbdb;
+    color: black;
+}
+
+.vfm__content button:disabled {
+    border: 1px solid gray;
+    color: gray;
+    cursor: not-allowed;
+}
+</style>

--- a/src/components/helpers/dropdown-menu.vue
+++ b/src/components/helpers/dropdown-menu.vue
@@ -1,0 +1,201 @@
+<template>
+    <div ref="el">
+        <button
+            type="button"
+            class="text-gray-500 hover:text-black dropdown-button"
+            @click="toggleDropdown"
+            :content="tooltip"
+            :aria-label="ariaLabel ? String(ariaLabel) : String(tooltip)"
+            v-tippy="{
+                placement: tooltipPlacement,
+                appendTo: 'parent',
+                trigger: 'manual',
+                delay: '200',
+                touch: ['hold', 500]
+            }"
+            ref="dropdownTrigger"
+        >
+            <slot name="header"></slot>
+        </button>
+        <div
+            v-show="open"
+            @click="
+                popper.update();
+                open = false;
+            "
+            class="rv-dropdown shadow-md border border-gray:200 py-1 bg-white rounded z-10"
+            :class="{ 'text-center': centered }"
+            ref="dropdown"
+        >
+            <slot v-bind:close="() => (open = !open)"></slot>
+        </div>
+    </div>
+</template>
+
+<script setup lang="ts">
+import { ref, reactive, watch, nextTick, onMounted, onBeforeUnmount } from 'vue';
+import type { Placement, Modifier, State } from '@popperjs/core';
+import { createPopper, detectOverflow } from '@popperjs/core';
+
+const open = ref<boolean>(false);
+const popper = ref<any>(null);
+const watchers = reactive<Array<Function>>([]);
+
+const el = ref();
+const dropdown = ref<HTMLElement>();
+const dropdownTrigger = ref<Element>();
+
+const props = defineProps({
+    position: {
+        type: String,
+        default: 'top-start'
+    },
+    popperOptions: {
+        type: Object,
+        default() {
+            return {};
+        }
+    },
+    tooltip: { type: String },
+    tooltipPlacement: { type: String, default: 'bottom' },
+    tooltipPlacementAlt: { type: String, default: 'top' },
+    centered: { type: Boolean, default: true },
+    ariaLabel: { type: String }
+});
+
+watchers.push(
+    watch(open, () => {
+        popper.value.update();
+    })
+);
+
+const toggleDropdown = () => {
+    open.value = !open.value;
+    (dropdownTrigger.value as any)._tippy.hide();
+};
+
+const focusDropdownTrigger = () => {
+    (dropdownTrigger.value as any)._tippy.setProps({
+        placement: open.value ? props.tooltipPlacementAlt : props.tooltipPlacement
+    });
+    (dropdownTrigger.value as any)._tippy.show();
+};
+
+const blurDropdownTrigger = () => {
+    (dropdownTrigger.value as any)._tippy.hide();
+};
+
+onMounted(() => {
+    window.addEventListener(
+        'click',
+        (event) => {
+            if (!el.value || !el.value.contains(event.target)) {
+                open.value = false;
+            }
+        },
+        { capture: true }
+    );
+
+    window.addEventListener('blur', () => {
+        open.value = false;
+    });
+
+    window.addEventListener('focusin', (event) => {
+        if (!el.value || !el.value.contains(event.target)) {
+            open.value = false;
+        }
+    });
+
+    dropdownTrigger.value!.addEventListener('focus', focusDropdownTrigger);
+
+    dropdownTrigger.value!.addEventListener('blur', blurDropdownTrigger);
+
+    dropdownTrigger.value!.addEventListener('mouseover', focusDropdownTrigger);
+
+    dropdownTrigger.value!.addEventListener('mouseleave', blurDropdownTrigger);
+
+    // nextTick should prevent any race conditions by letting the child elements render before trying to place them using popper
+    nextTick(() => {
+        const overflowScrollModifier: Modifier<'overflowScroll', {}> = {
+            name: 'overflowScroll',
+            enabled: true,
+            phase: 'main',
+            fn({ state }: { state: State }) {
+                const { bottom } = detectOverflow(state);
+
+                if (bottom > 0) {
+                    state.styles.popper.overflowY = bottom > 100 ? 'auto' : undefined;
+                    state.styles.popper.overflowX = 'hidden';
+                    state.styles.popper.height = `${state.rects.popper.height - bottom - 8}px`;
+                } else {
+                    state.styles.popper.height = 'auto';
+                }
+            }
+        };
+
+        if (dropdownTrigger.value && dropdown.value) {
+            popper.value = createPopper(dropdownTrigger.value as Element, dropdown.value as HTMLElement, {
+                placement: (props.position || 'bottom') as Placement,
+                modifiers: [
+                    overflowScrollModifier,
+                    {
+                        name: 'offset',
+                        options: {
+                            offset: [0, 5]
+                        }
+                    }
+                ],
+                ...props.popperOptions
+            });
+        }
+    });
+});
+
+onBeforeUnmount(() => {
+    watchers.forEach((unwatch) => unwatch());
+
+    window.removeEventListener(
+        'click',
+        (event) => {
+            if (!el.value || !el.value.contains(event.target)) {
+                open.value = false;
+            }
+        },
+        { capture: true }
+    );
+
+    window.removeEventListener('blur', () => {
+        open.value = false;
+    });
+
+    window.removeEventListener('focusin', (event) => {
+        if (!el.value || !el.value.contains(event.target)) {
+            open.value = false;
+        }
+    });
+
+    dropdownTrigger.value!.removeEventListener('focus', focusDropdownTrigger);
+
+    dropdownTrigger.value!.removeEventListener('blur', blurDropdownTrigger);
+
+    dropdownTrigger.value!.removeEventListener('mouseover', focusDropdownTrigger);
+
+    dropdownTrigger.value!.removeEventListener('mouseleave', blurDropdownTrigger);
+
+    open.value = false;
+});
+</script>
+
+<style lang="scss">
+.rv-dropdown > * {
+    padding: 0.5rem 1rem;
+    display: block !important;
+    text-decoration: none !important;
+}
+.rv-dropdown > :not(.disabled) {
+    color: #2d3748 !important;
+}
+.rv-dropdown > *:hover:not(.disabled) {
+    background-color: #eee;
+}
+</style>

--- a/src/components/helpers/toc-options.vue
+++ b/src/components/helpers/toc-options.vue
@@ -1,0 +1,124 @@
+<template>
+    <div @click.stop @mouseover.stop class="slide-toc-button cursor-auto">
+        <dropdown-menu
+            class="flex-shrink-0"
+            position="bottom-start"
+            :tooltip="$t('editor.slides.toc.dropdownTooltip')"
+            tooltipPlacement="top-start"
+            tooltipPlacementAlt="left"
+            ref="dropdown"
+        >
+            <template #header>
+                <div class="slide-toc-button flex justify-center items-center">
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                        x="0px"
+                        y="0px"
+                        width="14"
+                        height="14"
+                        viewBox="0 0 122.88 29.956"
+                        enable-background="new 0 0 122.88 29.956"
+                        xml:space="preserve"
+                        class="mb-0 leading-none"
+                    >
+                        <g>
+                            <path
+                                fill-rule="evenodd"
+                                clip-rule="evenodd"
+                                d="M122.88,14.978c0,8.271-6.708,14.979-14.979,14.979s-14.976-6.708-14.976-14.979 C92.926,6.708,99.631,0,107.901,0S122.88,6.708,122.88,14.978L122.88,14.978z M29.954,14.978c0,8.271-6.708,14.979-14.979,14.979 S0,23.248,0,14.978C0,6.708,6.705,0,14.976,0S29.954,6.708,29.954,14.978L29.954,14.978z M76.417,14.978 c0,8.271-6.708,14.979-14.979,14.979c-8.27,0-14.978-6.708-14.978-14.979C46.46,6.708,53.168,0,61.438,0 C69.709,0,76.417,6.708,76.417,14.978L76.417,14.978z"
+                            />
+                        </g>
+                    </svg>
+                </div>
+            </template>
+            <a
+                href="javascript:;"
+                class="flex items-center space-x-2 leading-snug text-left w-auto"
+                :class="{
+                    'disabled click-events-none cursor-not-allowed opacity-60': !copyAllowed
+                }"
+                @click="copyAllowed && copySlide()"
+                role="button"
+                aria-label="copy-contents"
+            >
+                <span class="flex items-center gap-1">
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        height="17"
+                        width="17"
+                        viewBox="0 0 24 24"
+                        class="flex-shrink-0 mx-2 my-1"
+                    >
+                        <path
+                            d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
+                        />
+                    </svg>
+                    <span>{{ $t('editor.slides.toc.dropdown.copy') }}</span>
+                </span>
+            </a>
+            <a
+                href="javascript:;"
+                class="flex leading-snug items-center text-left w-auto"
+                :class="{
+                    'disabled click-events-none cursor-not-allowed opacity-60': !deleteAllowed
+                }"
+                @click="deleteAllowed && clearSlide()"
+                role="button"
+                aria-label="DELETE"
+            >
+                <span class="flex items-center gap-1.5">
+                    <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 110.61 122.88"
+                        width="15"
+                        height="15"
+                        class="mx-2 my-1"
+                    >
+                        <path
+                            d="M39.27,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Zm63.6-19.86L98,103a22.29,22.29,0,0,1-6.33,14.1,19.41,19.41,0,0,1-13.88,5.78h-45a19.4,19.4,0,0,1-13.86-5.78l0,0A22.31,22.31,0,0,1,12.59,103L7.74,38.78H0V25c0-3.32,1.63-4.58,4.84-4.58H27.58V10.79A10.82,10.82,0,0,1,38.37,0H72.24A10.82,10.82,0,0,1,83,10.79v9.62h23.35a6.19,6.19,0,0,1,1,.06A3.86,3.86,0,0,1,110.59,24c0,.2,0,.38,0,.57V38.78Zm-9.5.17H17.24L22,102.3a12.82,12.82,0,0,0,3.57,8.1l0,0a10,10,0,0,0,7.19,3h45a10.06,10.06,0,0,0,7.19-3,12.8,12.8,0,0,0,3.59-8.1L93.37,39ZM71,20.41V12.05H39.64v8.36ZM61.87,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Z"
+                        />
+                    </svg>
+                    <span>{{ $t('editor.slides.toc.dropdown.clear') }}</span>
+                </span>
+            </a>
+        </dropdown-menu>
+    </div>
+</template>
+
+<script lang="ts">
+import { Options, Prop, Vue } from 'vue-property-decorator';
+import DropdownMenu from '@/components/helpers/dropdown-menu.vue';
+
+@Options({
+    components: {
+        'dropdown-menu': DropdownMenu
+    }
+})
+export default class TocOptionsV extends Vue {
+    @Prop({ default: true }) copyAllowed!: boolean;
+    @Prop({ default: true }) deleteAllowed!: boolean;
+
+    copySlide() {
+        this.$emit('copy');
+    }
+
+    clearSlide() {
+        this.$emit('clear');
+    }
+}
+</script>
+
+<style lang="css" scoped>
+.slide-toc-button {
+    border-radius: 3px;
+    padding: 2px;
+    line-height: 1;
+}
+.slide-toc-button:hover {
+    background-color: rgb(209, 213, 219);
+}
+span {
+    font-weight: 500;
+}
+</style>

--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -399,7 +399,7 @@
                 :configFileStructure="configFileStructure"
                 :sourceCounts="sourceCounts"
                 :metadata="metadata"
-                :slides="slides"
+                :bothLanguageSlides="bothLanguageSlides"
                 :configLang="configLang"
                 :saving="saving"
                 :unsavedChanges="unsavedChanges"
@@ -408,6 +408,7 @@
                 @refresh-config="refreshConfig"
                 ref="mainEditor"
             >
+<<<<<<< HEAD
                 <template v-slot:langModal="slotProps">
                     <button
                         class="editor-button editor-forms-button"
@@ -422,6 +423,8 @@
                     />
                 </template>
 
+=======
+>>>>>>> 665cd2c (Implement ToC redesign/refactor, both-language previews)
                 <template v-slot:metadataModal>
                     <vue-final-modal
                         modalId="metadata-edit-modal"
@@ -467,6 +470,7 @@ import {
     MetadataContent,
     PanelType,
     Slide,
+    SlideForBothLanguages,
     SlideshowPanel,
     SourceCounts,
     StoryRampConfig,
@@ -579,6 +583,8 @@ export default class MetadataEditorV extends Vue {
         uuid: true
     };
     slides: Slide[] = [];
+    bothLanguageSlides: SlideForBothLanguages[] = [];
+
     sourceCounts: SourceCounts = {};
 
     mounted(): void {
@@ -627,6 +633,22 @@ export default class MetadataEditorV extends Vue {
                 // Load product logo (if provided).
                 const logo = this.configs[this.configLang]?.introSlide.logo?.src;
                 const logoSrc = `assets/${this.configLang}/${this.metadata.logoName}`;
+
+                const frSlides = props.configs.en?.slides.map((engSlide) => {
+                    return {
+                        en: engSlide
+                    };
+                });
+                const engSlides = props.configs.fr?.slides.map((frSlide) => {
+                    return {
+                        fr: frSlide
+                    };
+                });
+
+                const maxLength = Math.max(frSlides!.length ?? 0, engSlides!.length ?? 0);
+                this.bothLanguageSlides = Array.from({ length: maxLength }, (_, index) =>
+                    Object.assign({}, engSlides?.[index] || { en: undefined }, frSlides?.[index] || { fr: undefined })
+                );
 
                 if (logo) {
                     const logoFile = this.configFileStructure?.zip.file(logoSrc);
@@ -1091,6 +1113,22 @@ export default class MetadataEditorV extends Vue {
 
         this.slides = config.slides;
 
+        const frSlides = this.configs.fr?.slides.map((frSlide) => {
+            return {
+                fr: frSlide
+            };
+        });
+        const engSlides = this.configs.en?.slides.map((enSlide) => {
+            return {
+                en: enSlide
+            };
+        });
+
+        const maxLength = Math.max(frSlides!.length ?? 0, engSlides!.length ?? 0);
+        this.bothLanguageSlides = Array.from({ length: maxLength }, (_, index) =>
+            Object.assign({}, engSlides?.[index] || { en: undefined }, frSlides?.[index] || { fr: undefined })
+        );
+
         const logo = config.introSlide.logo?.src;
         if (logo) {
             // Set the alt text for the logo.
@@ -1136,11 +1174,15 @@ export default class MetadataEditorV extends Vue {
     generateConfig(): ConfigFileStructure {
         this.saving = true;
 
-        // Update the configuration file.
-        const fileName = `${this.uuid}_${this.configLang}.json`;
-        const formattedConfigFile = JSON.stringify(this.configs[this.configLang], null, 4);
+        // Update the configuration files, for both languages.
+        const engFileName = `${this.uuid}_en.json`;
+        const frFileName = `${this.uuid}_fr.json`;
 
-        this.configFileStructure?.zip.file(fileName, formattedConfigFile);
+        const engFormattedConfigFile = JSON.stringify(this.configs.en, null, 4);
+        const frFormattedConfigFile = JSON.stringify(this.configs.fr, null, 4);
+
+        this.configFileStructure?.zip.file(engFileName, engFormattedConfigFile);
+        this.configFileStructure?.zip.file(frFileName, frFormattedConfigFile);
 
         // Upload the ZIP file.
         this.configFileStructure?.zip.generateAsync({ type: 'blob' }).then((content: Blob) => {
@@ -1304,7 +1346,7 @@ export default class MetadataEditorV extends Vue {
             returnTop: true
         };
         this.configs = { en: undefined, fr: undefined };
-        this.slides = [];
+        this.bothLanguageSlides = [];
     }
 
     /**
@@ -1318,7 +1360,7 @@ export default class MetadataEditorV extends Vue {
         this.loadConfig(this.configs[this.configLang]);
 
         if (this.loadEditor) {
-            (this.$refs.mainEditor as EditorV).updateSlides(this.slides);
+            (this.$refs.mainEditor as EditorV).updateSlides(this.bothLanguageSlides);
             (this.$refs.mainEditor as EditorV).selectSlide(-1);
         }
     }

--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -399,11 +399,11 @@
                 :configFileStructure="configFileStructure"
                 :sourceCounts="sourceCounts"
                 :metadata="metadata"
-                :bothLanguageSlides="bothLanguageSlides"
+                :slides="slides"
                 :configLang="configLang"
                 :saving="saving"
                 :unsavedChanges="unsavedChanges"
-                @save-changes="generateConfig"
+                @save-changes="onSave"
                 @save-status="updateSaveStatus"
                 @refresh-config="refreshConfig"
                 ref="mainEditor"
@@ -451,9 +451,17 @@
             </editor>
         </template>
     </div>
+    <!--Modal shows when undefined configs may be overwritten-->
+    <action-modal
+        name="overwrite-undefined-config"
+        :title="$t('editor.slides.overwrite.title')"
+        :message="$t('editor.slides.overwrite.text')"
+        @ok="generateConfig"
+    />
 </template>
 
 <script lang="ts">
+import ActionModal from '@/components/helpers/action-modal.vue';
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import { RouteLocationNormalized } from 'vue-router';
 import { AxiosResponse } from 'axios';
@@ -516,6 +524,7 @@ interface History {
 
 @Options({
     components: {
+        ActionModal,
         Editor: EditorV,
         'confirmation-modal': ConfirmationModalV,
         'metadata-content': MetadataContentV,
@@ -578,12 +587,26 @@ export default class MetadataEditorV extends Vue {
         returnTop: true,
         dateModified: ''
     };
+    defaultBlankSlide: Slide = {
+        title: '',
+        panel: [
+            {
+                type: 'text',
+                title: '',
+                content: ''
+            } as TextPanel,
+            {
+                type: 'text',
+                title: '',
+                content: ''
+            } as TextPanel
+        ]
+    };
     // add more required metadata fields to here as needed
     reqFields: { uuid: boolean } = {
         uuid: true
     };
-    slides: Slide[] = [];
-    bothLanguageSlides: SlideForBothLanguages[] = [];
+    slides: SlideForBothLanguages[] = [];
 
     sourceCounts: SourceCounts = {};
 
@@ -626,7 +649,7 @@ export default class MetadataEditorV extends Vue {
                 this.configLang = props.configLang;
                 this.configFileStructure = props.configFileStructure;
                 this.metadata = props.metadata;
-                this.slides = props.slides;
+                // this.slides = props.slides;
                 this.sourceCounts = props.sourceCounts;
                 this.loadExisting = props.existing;
                 this.unsavedChanges = props.unsavedChanges;
@@ -634,21 +657,7 @@ export default class MetadataEditorV extends Vue {
                 const logo = this.configs[this.configLang]?.introSlide.logo?.src;
                 const logoSrc = `assets/${this.configLang}/${this.metadata.logoName}`;
 
-                const frSlides = props.configs.en?.slides.map((engSlide) => {
-                    return {
-                        en: engSlide
-                    };
-                });
-                const engSlides = props.configs.fr?.slides.map((frSlide) => {
-                    return {
-                        fr: frSlide
-                    };
-                });
-
-                const maxLength = Math.max(frSlides!.length ?? 0, engSlides!.length ?? 0);
-                this.bothLanguageSlides = Array.from({ length: maxLength }, (_, index) =>
-                    Object.assign({}, engSlides?.[index] || { en: undefined }, frSlides?.[index] || { fr: undefined })
-                );
+                this.loadSlides(props.configs);
 
                 if (logo) {
                     const logoFile = this.configFileStructure?.zip.file(logoSrc);
@@ -686,6 +695,30 @@ export default class MetadataEditorV extends Vue {
         if (this.$route.params.uid) {
             this.generateRemoteConfig();
         }
+    }
+
+    /**
+     * Loads the slide variable with both EN and FR language configs.
+     * @param configs The config object with separate EN and FR StoryRamp configs.
+     */
+    loadSlides(configs: { [p: string]: StoryRampConfig | undefined }): void {
+        const engSlides =
+            configs.en?.slides.map((engSlide) => {
+                return {
+                    en: engSlide
+                };
+            }) ?? [];
+        const frSlides =
+            configs.fr?.slides.map((frSlide) => {
+                return {
+                    fr: frSlide
+                };
+            }) ?? [];
+
+        const maxLength = frSlides.length > engSlides.length ? frSlides.length : engSlides.length;
+        this.slides = Array.from({ length: maxLength }, (_, index) =>
+            Object.assign({}, engSlides?.[index] || { en: undefined }, frSlides?.[index] || { fr: undefined })
+        );
     }
 
     /**
@@ -1111,23 +1144,7 @@ export default class MetadataEditorV extends Vue {
         this.metadata.returnTop = config.returnTop ?? true;
         this.metadata.dateModified = config.dateModified;
 
-        this.slides = config.slides;
-
-        const frSlides = this.configs.fr?.slides.map((frSlide) => {
-            return {
-                fr: frSlide
-            };
-        });
-        const engSlides = this.configs.en?.slides.map((enSlide) => {
-            return {
-                en: enSlide
-            };
-        });
-
-        const maxLength = Math.max(frSlides!.length ?? 0, engSlides!.length ?? 0);
-        this.bothLanguageSlides = Array.from({ length: maxLength }, (_, index) =>
-            Object.assign({}, engSlides?.[index] || { en: undefined }, frSlides?.[index] || { fr: undefined })
-        );
+        this.loadSlides(this.configs);
 
         const logo = config.introSlide.logo?.src;
         if (logo) {
@@ -1168,6 +1185,21 @@ export default class MetadataEditorV extends Vue {
     }
 
     /**
+     * Conducts various checks before saving.
+     */
+    onSave(): void {
+        // Detect if there are any undefined configs
+        const engConfigHasUndefined = this.configs.en?.slides.some((slide) => !slide) as boolean;
+        const frConfigHasUndefined = this.configs.fr?.slides.some((slide) => !slide) as boolean;
+
+        if (engConfigHasUndefined || frConfigHasUndefined) {
+            this.$vfm.open('overwrite-undefined-config');
+        } else {
+            this.generateConfig();
+        }
+    }
+
+    /**
      * Called when `Save Changes` is pressed. Re-generates the Storylines configuration file
      * with the new changes, then generates and submits the product file to the server.
      */
@@ -1177,6 +1209,15 @@ export default class MetadataEditorV extends Vue {
         // Update the configuration files, for both languages.
         const engFileName = `${this.uuid}_en.json`;
         const frFileName = `${this.uuid}_fr.json`;
+
+        // Replace undefined slides with empty slides
+        this.configs.en!.slides = this.configs.en!.slides.map((slide) => {
+            return slide ?? JSON.parse(JSON.stringify(this.defaultBlankSlide));
+        });
+        this.configs.fr!.slides = this.configs.fr!.slides.map((slide) => {
+            return slide ?? JSON.parse(JSON.stringify(this.defaultBlankSlide));
+        });
+        this.loadSlides(this.configs);
 
         const engFormattedConfigFile = JSON.stringify(this.configs.en, null, 4);
         const frFormattedConfigFile = JSON.stringify(this.configs.fr, null, 4);
@@ -1346,7 +1387,7 @@ export default class MetadataEditorV extends Vue {
             returnTop: true
         };
         this.configs = { en: undefined, fr: undefined };
-        this.bothLanguageSlides = [];
+        this.slides = [];
     }
 
     /**
@@ -1360,7 +1401,7 @@ export default class MetadataEditorV extends Vue {
         this.loadConfig(this.configs[this.configLang]);
 
         if (this.loadEditor) {
-            (this.$refs.mainEditor as EditorV).updateSlides(this.bothLanguageSlides);
+            (this.$refs.mainEditor as EditorV).updateSlides(this.slides);
             (this.$refs.mainEditor as EditorV).selectSlide(-1);
         }
     }
@@ -1591,7 +1632,7 @@ $font-list: 'Segoe UI', system-ui, ui-sans-serif, Tahoma, Geneva, Verdana, sans-
     h5,
     h6 {
         font-family: $font-list;
-        line-height: 1.5;
+        line-height: 1.3;
         border-bottom: 0px;
     }
 
@@ -1629,6 +1670,7 @@ $font-list: 'Segoe UI', system-ui, ui-sans-serif, Tahoma, Geneva, Verdana, sans-
     }
 
     .vfm__content button {
+        border-radius: 3px;
         padding: 5px 12px;
         margin: 0px 10px;
         font-weight: 600;

--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -158,6 +158,17 @@ export default class StoryPreviewV extends Vue {
             });
         }
 
+        // Purge undefined slides from configs
+        if (this.config) {
+            this.config.slides = this.config.slides.filter((slide) => slide && Object.keys(slide).length);
+        }
+        if (this.configs['en']) {
+            this.configs['en'].slides = this.configs['en'].slides.filter((slide) => slide && Object.keys(slide).length);
+        }
+        if (this.configs['fr']) {
+            this.configs['fr'].slides = this.configs['fr'].slides.filter((slide) => slide && Object.keys(slide).length);
+        }
+
         // set page lang
         const html = document.documentElement;
         html.setAttribute('lang', this.lang);

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -1,8 +1,9 @@
 <template>
-    <div class="sticky top-20 h-auto self-start flex-grow m-5">
+    <div class="overflow-y-auto top-20 h-auto self-start flex-grow p-5">
         <div v-if="!!currentSlide">
             <div class="flex">
                 <div class="flex flex-col w-full">
+                    <h2 class="font-bold mb-3">{{ $t('editor.slides.currentLangLabel', { lang: langTranslate }) }}</h2>
                     <label class="editor-label" for="slideTitle">{{ $t('editor.slides.slideTitle') }}:</label>
                     <div class="flex">
                         <input
@@ -417,6 +418,8 @@ export default class SlideEditorV extends Vue {
     includeInToc = true;
     dynamicSelected = false;
 
+    langTranslate = '';
+
     editors: Record<string, string> = {
         text: 'text-editor',
         image: 'image-editor',
@@ -428,8 +431,13 @@ export default class SlideEditorV extends Vue {
         dynamic: 'dynamic-editor'
     };
 
+    mounted() {
+        this.langTranslate = this.$t(`editor.lang.${this.lang}`);
+    }
+
     @Watch('currentSlide', { deep: true })
     onSlideChange(): void {
+        this.langTranslate = this.$t(`editor.lang.${this.lang}`);
         this.currentSlide ? (this.rightOnly = this.currentSlide.panel.length === 1) : false;
         this.centerPanel = this.currentSlide.centerPanel ?? false;
         this.centerSlide = this.currentSlide.centerSlide ?? false;

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -295,7 +295,7 @@
                     ref="editor"
                     :config="currentSlide"
                     @slide-edit="$emit('slide-edit')"
-                    @config-edited="(slideConfig: Slide, save?: boolean = false) => $emit('custom-slide-updated', slideConfig, save)"
+                    @config-edited="(slideConfig: Slide, save?: boolean = false) => $emit('custom-slide-updated', slideConfig, save, lang)"
                     v-if="advancedEditorView"
                 ></custom-editor>
                 <component

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -1,140 +1,513 @@
 <template>
     <div>
-        <div class="flex toc-header p-2 mt-10">
-            <span class="flex items-center justify-center font-bold"> {{ $t('editor.slides.title') }}</span>
-            <span class="flex-1"></span>
-            <span class="ml-auto"></span>
-            <button class="editor-button" v-on:click="addNewSlide">
-                <span class="align-middle inline-block px-1"
+        <div class="flex toc-header px-3 pt-2 mt-5 pb-2 border-b align-bottom items-end">
+            <p class="flex items-center justify-center font-bold">{{ $t('editor.slides.slideHeader') }}</p>
+            <p class="flex-1"></p>
+            <p class="ml-auto"></p>
+            <button class="mx-auto toc-popup-button py-0 px-2" @click="addNewSlide">
+                <span class="inline-block pr-1"
                     ><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24">
                         <path d="M24 10h-10v-10h-4v10h-10v4h10v10h4v-10h10z" />
                     </svg>
                 </span>
-                <span class="align-middle inline-block">{{ $t('editor.slides.addSlide') }}</span>
+                <span class="inline-block text-sm font-normal">{{ $t('editor.slides.addSlide') }}</span>
             </button>
-            <button
-                class="editor-button"
-                @click.stop="$vfm.open(`copy-from-other-lang`)"
-                v-tippy="{
-                    delay: '200',
-                    placement: 'right',
-                    content: $t('editor.slides.copyFromLang'),
-                    animateFill: true
-                }"
-                :aria-label="$t('editor.slides.copyFromLang')"
-            >
-                <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24">
-                    <path
-                        d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
-                    />
-                </svg>
-            </button>
-            <vue-final-modal
-                modalId="copy-from-other-lang"
-                content-class="flex flex-col max-w-xl mx-4 p-4 bg-white border rounded-lg space-y-2"
-                class="flex justify-center items-center"
-            >
-                <h2 slot="header" class="text-xl font-bold">{{ $t('editor.slides.copyFromLang') }}</h2>
-                <div class="flex flex-col">
-                    <button class="editor-toc-button editor-button h-12 ml-0" @click="$vfm.open(`confirm-copy-all`)">
-                        {{ $t('editor.slides.copyAll') }}
-                    </button>
-                    <span class="text-lg font-bold my-3 text-center"> {{ $t('editor.label.or') }} </span>
-
-                    <select v-model="selectedForCopying" class="overflow-ellipsis copy-select border-2 p-2">
-                        <option
-                            v-for="(slide, index) in configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides"
-                            :value="index"
-                            :key="slide.title + index"
-                        >
-                            {{ $t('editor.slides.slide') + ` ${index}: ` }}
-                            {{ slide.title ? slide.title : $t('editor.slide.untitled') }}
-                        </option>
-                    </select>
-
-                    <button
-                        class="editor-toc-button"
-                        @click="
-                            copyFromOtherLang(
-                                configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides[selectedForCopying]
-                            )
-                        "
-                    >
-                        {{ $t('editor.slides.copy') }}
-                    </button>
-                    <confirmation-modal
-                        :name="`confirm-copy-all`"
-                        :message="$t('editor.slides.copyAll.confirm')"
-                        @ok="copyAllFromOtherLang(configFileStructure.configs[lang === 'en' ? 'fr' : 'en'].slides)"
-                    />
-                </div>
-            </vue-final-modal>
+            <br />
         </div>
-        <ul class="max-h-screen overflow-y-auto">
-            <draggable :list="slides" @update="$emit('slides-updated', slides)" :item-key="getSlideId" v-focus-list>
+
+        <ul class="toc-list">
+            <draggable
+                :list="bothLanguageSlides"
+                @update="$emit('slides-updated', bothLanguageSlides)"
+                :item-key="getSlideId"
+                v-focus-list
+            >
                 <template #item="{ element, index }">
                     <li
-                        class="toc-slide border-t flex px-2 cursor-pointer hover:bg-gray-300"
-                        :class="currentSlide === element ? 'bg-gray-300' : ''"
-                        @click="selectSlide(index)"
-                        :key="element.title + index"
-                        v-tippy="{
-                            delay: '200',
-                            placement: 'right',
-                            content: element.title,
-                            animateFill: true
-                        }"
+                        class="toc-slide border-t flex px-3 py-2 cursor-pointer hover:bg-gray-50"
+                        :class="slideIndex === index ? 'bg-gray-100 border-gray-300' : ''"
+                        :id="'slide' + index"
+                        :key="'slide' + index"
                         v-focus-item
                     >
-                        <div class="self-center overflow-ellipsis whitespace-nowrap overflow-hidden flex-grow ml-2">
-                            {{ $t('editor.slides.slide') }} {{ index + 1 }}:
-                            <span class="font-bold overflow-hidden">{{
-                                element.title || $t('editor.slides.addSlideTitle')
-                            }}</span>
-                        </div>
-                        <div class="flex">
-                            <div class="flex flex-col">
-                                <button class="slide-toc-button" @click.stop="$vfm.open(`delete-slide-${index}`)">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24">
-                                        <path
-                                            d="M3 6l3 18h12l3-18h-18zm19-4v2h-20v-2h5.711c.9 0 1.631-1.099 1.631-2h5.316c0 .901.73 2 1.631 2h5.711z"
-                                        />
-                                    </svg>
-                                </button>
-                                <button class="slide-toc-button" @click.stop="copySlide(index)">
-                                    <svg xmlns="http://www.w3.org/2000/svg" height="24" width="24">
-                                        <path
-                                            d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
-                                        />
-                                    </svg>
-                                </button>
+                        <div class="flex space-between w-full align-center text-base">
+                            <div class="flex flex-col flex-1">
+                                <section class="flex space-between mb-1">
+                                    <p class="font-semibold overflow-ellipsis whitespace-nowrap overflow-hidden flex-1">
+                                        {{ $t('editor.slides.slide') }} {{ index + 1 }}
+                                    </p>
+                                    <div class="flex align-center mr-4">
+                                        <button
+                                            class="slide-toc-button px-5"
+                                            @click.stop="copySlide(index)"
+                                            v-tippy="{
+                                                delay: '200',
+                                                placement: 'top-start',
+                                                content: $t('editor.slides.toc.copySlide')
+                                            }"
+                                        >
+                                            <svg
+                                                xmlns="http://www.w3.org/2000/svg"
+                                                height="17"
+                                                width="17"
+                                                viewBox="0 0 24 24"
+                                                class="mx-1"
+                                            >
+                                                <path
+                                                    d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
+                                                />
+                                            </svg>
+                                        </button>
+                                        <button
+                                            class="slide-toc-button"
+                                            @click.stop="$vfm.open(`delete-slide-${index}`)"
+                                            v-tippy="{
+                                                delay: '200',
+                                                placement: 'top-start',
+                                                content: $t('editor.slides.toc.deleteSlide')
+                                            }"
+                                        >
+                                            <svg
+                                                xmlns="http://www.w3.org/2000/svg"
+                                                viewBox="0 0 110.61 122.88"
+                                                width="15"
+                                                height="15"
+                                                class="mx-1"
+                                            >
+                                                <path
+                                                    d="M39.27,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Zm63.6-19.86L98,103a22.29,22.29,0,0,1-6.33,14.1,19.41,19.41,0,0,1-13.88,5.78h-45a19.4,19.4,0,0,1-13.86-5.78l0,0A22.31,22.31,0,0,1,12.59,103L7.74,38.78H0V25c0-3.32,1.63-4.58,4.84-4.58H27.58V10.79A10.82,10.82,0,0,1,38.37,0H72.24A10.82,10.82,0,0,1,83,10.79v9.62h23.35a6.19,6.19,0,0,1,1,.06A3.86,3.86,0,0,1,110.59,24c0,.2,0,.38,0,.57V38.78Zm-9.5.17H17.24L22,102.3a12.82,12.82,0,0,0,3.57,8.1l0,0a10,10,0,0,0,7.19,3h45a10.06,10.06,0,0,0,7.19-3,12.8,12.8,0,0,0,3.59-8.1L93.37,39ZM71,20.41V12.05H39.64v8.36ZM61.87,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Z"
+                                                />
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </section>
+
+                                <section class="flex flex-col gap-0.5 text-sm">
+                                    <!-- ENG config for slide -->
+                                    <button
+                                        class="flex gap-2 px-2 py-1 rounded-md bg-transparent hover:bg-gray-200"
+                                        :class="{
+                                            'selected-toc-config-item': element.en === currentSlide,
+                                            'cursor-not-allowed border-2 border-red-400': !element.en
+                                        }"
+                                        v-tippy="{
+                                            delay: '200',
+                                            placement: 'right',
+                                            content:
+                                                element.en?.title ||
+                                                (element.en?.title === ''
+                                                    ? $t('editor.slides.toc.newENGSlideText')
+                                                    : $t('editor.slides.toc.noENGslide')),
+                                            animateFill: true,
+                                            offset: [0, 50]
+                                        }"
+                                        @click.stop="selectSlide(index, 'en')"
+                                    >
+                                        <p
+                                            class="font-bold italic text-gray-500"
+                                            :class="{ 'text-gray-700': slideIndex === index }"
+                                        >
+                                            EN
+                                        </p>
+                                        <p
+                                            class="text-left line-clamp-2"
+                                            :class="{
+                                                italic: !element.en?.title
+                                            }"
+                                        >
+                                            {{
+                                                element.en?.title ||
+                                                (element.en?.title === ''
+                                                    ? $t('editor.slides.toc.newENGSlideText')
+                                                    : $t('editor.slides.toc.noENGslide'))
+                                            }}
+                                        </p>
+                                        <!-- Options for EN items with missing configs (e.g. one language has config, other doesn't) -->
+                                        <div v-if="!element.en" class="ml-auto flex my-auto">
+                                            <!-- Create a new blank config -->
+                                            <button
+                                                class="slide-toc-button"
+                                                :class="{
+                                                    'cursor-not-allowed opacity-50':
+                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                }"
+                                                v-tippy="{
+                                                    delay: '200',
+                                                    placement: 'top-start',
+                                                    content:
+                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                            ? $t('editor.slides.toc.prevEngDNE')
+                                                            : $t('editor.slides.toc.newBlankConfig'),
+                                                    animateFill: false
+                                                }"
+                                                @click="
+                                                    index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                        ? ''
+                                                        : createNewConfig(element, 'en')
+                                                "
+                                            >
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    shape-rendering="geometricPrecision"
+                                                    text-rendering="geometricPrecision"
+                                                    image-rendering="optimizeQuality"
+                                                    fill-rule="evenodd"
+                                                    clip-rule="evenodd"
+                                                    viewBox="0 0 399 511.66"
+                                                    width="14"
+                                                    height="14"
+                                                    class="mx-1"
+                                                >
+                                                    <path
+                                                        fill-rule="nonzero"
+                                                        d="M71.1 0h190.92c5.22 0 9.85 2.5 12.77 6.38L394.7 136.11c2.81 3.05 4.21 6.92 4.21 10.78l.09 293.67c0 19.47-8.02 37.23-20.9 50.14l-.09.08c-12.9 12.87-30.66 20.88-50.11 20.88H71.1c-19.54 0-37.33-8.01-50.22-20.9C8.01 477.89 0 460.1 0 440.56V71.1c0-19.56 8-37.35 20.87-50.23C33.75 8 51.54 0 71.1 0zm45.78 254.04c-8.81 0-15.96-7.15-15.96-15.95 0-8.81 7.15-15.96 15.96-15.96h165.23c8.81 0 15.96 7.15 15.96 15.96 0 8.8-7.15 15.95-15.96 15.95H116.88zm0 79.38c-8.81 0-15.96-7.15-15.96-15.96 0-8.8 7.15-15.95 15.96-15.95h156.47c8.81 0 15.96 7.15 15.96 15.95 0 8.81-7.15 15.96-15.96 15.96H116.88zm0 79.39c-8.81 0-15.96-7.15-15.96-15.96s7.15-15.95 15.96-15.95h132.7c8.81 0 15.95 7.14 15.95 15.95 0 8.81-7.14 15.96-15.95 15.96h-132.7zm154.2-363.67v54.21c1.07 13.59 5.77 24.22 13.99 31.24 8.63 7.37 21.65 11.52 38.95 11.83l36.93-.05-89.87-97.23zm96.01 129.11-43.31-.05c-25.2-.4-45.08-7.2-59.39-19.43-14.91-12.76-23.34-30.81-25.07-53.11l-.15-2.22V31.91H71.1c-10.77 0-20.58 4.42-27.68 11.51-7.09 7.1-11.51 16.91-11.51 27.68v369.46c0 10.76 4.43 20.56 11.52 27.65 7.11 7.12 16.92 11.53 27.67 11.53h256.8c10.78 0 20.58-4.4 27.65-11.48 7.13-7.12 11.54-16.93 11.54-27.7V178.25z"
+                                                    />
+                                                </svg>
+                                            </button>
+                                            <!-- Copy FR config over here -->
+                                            <button
+                                                v-if="element.fr"
+                                                class="slide-toc-button"
+                                                :class="{
+                                                    'cursor-not-allowed opacity-50':
+                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                }"
+                                                v-tippy="{
+                                                    delay: '200',
+                                                    placement: 'top-start',
+                                                    content:
+                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                            ? $t('editor.slides.toc.prevEngDNE')
+                                                            : $t('editor.slides.toc.newConfigFromFR'),
+                                                    animateFill: false
+                                                }"
+                                                @click="
+                                                    index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                        ? ''
+                                                        : copyConfigFromOtherLang(element, 'en')
+                                                "
+                                            >
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    height="16"
+                                                    width="16"
+                                                    viewBox="0 0 24 24"
+                                                    class="mx-1"
+                                                >
+                                                    <path
+                                                        d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
+                                                    />
+                                                </svg>
+                                            </button>
+                                            <!-- Warning indicator for isolated undefined configs: Defined configs below it WILL be moved up! -->
+                                            <button
+                                                class="slide-toc-button cursor-default"
+                                                v-if="
+                                                    bothLanguageSlides.slice(0, index).some((slide) => slide.en) &&
+                                                    bothLanguageSlides.slice(index + 1).some((slide) => slide.en)
+                                                "
+                                                v-tippy="{
+                                                    delay: '200',
+                                                    placement: 'top-start',
+                                                    content: $t('editor.slides.toc.isolatedUndefinedENGconfig'),
+                                                    animateFill: false
+                                                }"
+                                            >
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    shape-rendering="geometricPrecision"
+                                                    text-rendering="geometricPrecision"
+                                                    image-rendering="optimizeQuality"
+                                                    fill-rule="evenodd"
+                                                    clip-rule="evenodd"
+                                                    viewBox="0 0 512 463.43"
+                                                    height="16"
+                                                    width="16"
+                                                    style="fill: rgb(248, 113, 113)"
+                                                >
+                                                    <path
+                                                        d="M189.46 44.02c34.26-58.66 99.16-58.77 133.24.12l.97 1.81 175.27 304.4c33.71 56.4-1.2 113.76-66.17 112.96v.12H73.53c-.9 0-1.78-.04-2.66-.11-58.34-.79-86.64-54.22-61.9-106.84.39-.85.82-1.67 1.28-2.46l-.04-.03 179.3-309.94-.05-.03zm50.32 302.4c4.26-4.13 9.35-6.19 14.45-6.56 3.4-.24 6.8.29 9.94 1.48 3.13 1.19 6.01 3.03 8.39 5.41 6.92 6.91 8.72 17.38 4.64 26.16-2.69 5.8-7.08 9.7-12.11 11.78-3.03 1.27-6.3 1.84-9.56 1.76-3.27-.08-6.49-.82-9.41-2.18-5.02-2.33-9.3-6.43-11.7-12.2-2.65-6.36-2.27-12.96.63-19.15 1.15-2.46 2.75-4.81 4.73-6.5zm33.86-47.07c-.8 19.91-34.51 19.93-35.28-.01-3.41-34.1-12.13-110.53-11.85-142.58.28-9.87 8.47-15.72 18.94-17.95 3.23-.69 6.78-1.03 10.35-1.02 3.6.01 7.16.36 10.39 1.05 10.82 2.3 19.31 8.39 19.31 18.45l-.05 1-11.81 141.06z"
+                                                    />
+                                                </svg>
+                                            </button>
+                                        </div>
+                                        <div v-else class="ml-auto flex my-auto">
+                                            <!-- Allow deleting the final slide -->
+                                            <button
+                                                class="slide-toc-button"
+                                                v-if="!bothLanguageSlides.slice(index + 1).some((slide) => slide.en)"
+                                                v-tippy="{
+                                                    delay: '200',
+                                                    placement: 'top-start',
+                                                    content: $t('editor.slides.toc.deleteConfig'),
+                                                    animateFill: false
+                                                }"
+                                                @click="deleteConfig(element, 'en')"
+                                            >
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    viewBox="0 0 110.61 122.88"
+                                                    width="14"
+                                                    height="14"
+                                                    class="mx-1 my-0.5"
+                                                >
+                                                    <path
+                                                        d="M39.27,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Zm63.6-19.86L98,103a22.29,22.29,0,0,1-6.33,14.1,19.41,19.41,0,0,1-13.88,5.78h-45a19.4,19.4,0,0,1-13.86-5.78l0,0A22.31,22.31,0,0,1,12.59,103L7.74,38.78H0V25c0-3.32,1.63-4.58,4.84-4.58H27.58V10.79A10.82,10.82,0,0,1,38.37,0H72.24A10.82,10.82,0,0,1,83,10.79v9.62h23.35a6.19,6.19,0,0,1,1,.06A3.86,3.86,0,0,1,110.59,24c0,.2,0,.38,0,.57V38.78Zm-9.5.17H17.24L22,102.3a12.82,12.82,0,0,0,3.57,8.1l0,0a10,10,0,0,0,7.19,3h45a10.06,10.06,0,0,0,7.19-3,12.8,12.8,0,0,0,3.59-8.1L93.37,39ZM71,20.41V12.05H39.64v8.36ZM61.87,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Z"
+                                                    />
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </button>
+                                    <!-- FR config for slide -->
+                                    <button
+                                        class="flex gap-2 px-2 py-1 rounded-md bg-transparent hover:bg-gray-200"
+                                        :class="{
+                                            'selected-toc-config-item': element.fr === currentSlide,
+                                            'cursor-not-allowed border-2 border-red-400': !element.fr
+                                        }"
+                                        v-tippy="{
+                                            delay: '200',
+                                            placement: 'right',
+                                            content:
+                                                element.fr?.title ||
+                                                (element.fr?.title === ''
+                                                    ? $t('editor.slides.toc.newFRSlideText')
+                                                    : $t('editor.slide.toc.noFRSlide')),
+                                            animateFill: true,
+                                            offset: [0, 50]
+                                        }"
+                                        @click.stop="element.fr ? selectSlide(index, 'fr') : ''"
+                                    >
+                                        <p
+                                            class="font-bold italic text-gray-500"
+                                            :class="{ 'text-gray-700': slideIndex === index }"
+                                        >
+                                            FR
+                                        </p>
+                                        <p
+                                            class="text-left line-clamp-2"
+                                            :class="{
+                                                italic: !element.fr?.title
+                                            }"
+                                        >
+                                            {{
+                                                element.fr?.title ||
+                                                (element.fr?.title === ''
+                                                    ? $t('editor.slides.toc.newFRSlideText')
+                                                    : $t('editor.slide.toc.noFRSlide'))
+                                            }}
+                                        </p>
+                                        <!-- Options for FR items with missing configs (e.g. one language has config, other doesn't) -->
+                                        <div v-if="!element.fr" class="ml-auto flex my-auto">
+                                            <!-- Create a new blank config -->
+                                            <button
+                                                class="slide-toc-button"
+                                                :class="{
+                                                    'cursor-not-allowed opacity-50':
+                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                }"
+                                                v-tippy="{
+                                                    delay: '200',
+                                                    placement: 'bottom-start',
+                                                    content:
+                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                            ? $t('editor.slide.toc.prevFrDNE')
+                                                            : $t('editor.slides.toc.newBlankConfig'),
+                                                    animateFill: false
+                                                }"
+                                                @click="
+                                                    index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                        ? ''
+                                                        : createNewConfig(element, 'fr')
+                                                "
+                                            >
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    shape-rendering="geometricPrecision"
+                                                    text-rendering="geometricPrecision"
+                                                    image-rendering="optimizeQuality"
+                                                    fill-rule="evenodd"
+                                                    clip-rule="evenodd"
+                                                    viewBox="0 0 399 511.66"
+                                                    width="14"
+                                                    height="14"
+                                                    class="mx-1"
+                                                >
+                                                    <path
+                                                        fill-rule="nonzero"
+                                                        d="M71.1 0h190.92c5.22 0 9.85 2.5 12.77 6.38L394.7 136.11c2.81 3.05 4.21 6.92 4.21 10.78l.09 293.67c0 19.47-8.02 37.23-20.9 50.14l-.09.08c-12.9 12.87-30.66 20.88-50.11 20.88H71.1c-19.54 0-37.33-8.01-50.22-20.9C8.01 477.89 0 460.1 0 440.56V71.1c0-19.56 8-37.35 20.87-50.23C33.75 8 51.54 0 71.1 0zm45.78 254.04c-8.81 0-15.96-7.15-15.96-15.95 0-8.81 7.15-15.96 15.96-15.96h165.23c8.81 0 15.96 7.15 15.96 15.96 0 8.8-7.15 15.95-15.96 15.95H116.88zm0 79.38c-8.81 0-15.96-7.15-15.96-15.96 0-8.8 7.15-15.95 15.96-15.95h156.47c8.81 0 15.96 7.15 15.96 15.95 0 8.81-7.15 15.96-15.96 15.96H116.88zm0 79.39c-8.81 0-15.96-7.15-15.96-15.96s7.15-15.95 15.96-15.95h132.7c8.81 0 15.95 7.14 15.95 15.95 0 8.81-7.14 15.96-15.95 15.96h-132.7zm154.2-363.67v54.21c1.07 13.59 5.77 24.22 13.99 31.24 8.63 7.37 21.65 11.52 38.95 11.83l36.93-.05-89.87-97.23zm96.01 129.11-43.31-.05c-25.2-.4-45.08-7.2-59.39-19.43-14.91-12.76-23.34-30.81-25.07-53.11l-.15-2.22V31.91H71.1c-10.77 0-20.58 4.42-27.68 11.51-7.09 7.1-11.51 16.91-11.51 27.68v369.46c0 10.76 4.43 20.56 11.52 27.65 7.11 7.12 16.92 11.53 27.67 11.53h256.8c10.78 0 20.58-4.4 27.65-11.48 7.13-7.12 11.54-16.93 11.54-27.7V178.25z"
+                                                    />
+                                                </svg>
+                                            </button>
+                                            <!-- Copy ENG config over here -->
+                                            <button
+                                                v-if="element.en"
+                                                class="slide-toc-button"
+                                                :class="{
+                                                    'cursor-not-allowed opacity-50':
+                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                }"
+                                                v-tippy="{
+                                                    delay: '200',
+                                                    placement: 'bottom-start',
+                                                    content:
+                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                            ? $t('editor.slide.toc.prevFrDNE')
+                                                            : $t('editor.slides.toc.newConfigFromEng'),
+                                                    animateFill: false
+                                                }"
+                                                @click="
+                                                    index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                        ? ''
+                                                        : copyConfigFromOtherLang(element, 'fr')
+                                                "
+                                            >
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    height="16"
+                                                    width="16"
+                                                    viewBox="0 0 24 24"
+                                                    class="mx-1"
+                                                >
+                                                    <path
+                                                        d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
+                                                    />
+                                                </svg>
+                                            </button>
+                                            <!-- Warning indicator for isolated undefined configs: Defined configs below it WILL be moved up! -->
+                                            <button
+                                                class="slide-toc-button cursor-default"
+                                                v-if="
+                                                    bothLanguageSlides.slice(0, index).some((slide) => slide.fr) &&
+                                                    bothLanguageSlides.slice(index + 1).some((slide) => slide.fr)
+                                                "
+                                                v-tippy="{
+                                                    delay: '200',
+                                                    placement: 'bottom-start',
+                                                    content: $t('editor.slides.toc.isolatedUndefinedFRconfig'),
+                                                    animateFill: false
+                                                }"
+                                            >
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    shape-rendering="geometricPrecision"
+                                                    text-rendering="geometricPrecision"
+                                                    image-rendering="optimizeQuality"
+                                                    fill-rule="evenodd"
+                                                    clip-rule="evenodd"
+                                                    viewBox="0 0 512 463.43"
+                                                    height="16"
+                                                    width="16"
+                                                    style="fill: rgb(248, 113, 113)"
+                                                >
+                                                    <path
+                                                        d="M189.46 44.02c34.26-58.66 99.16-58.77 133.24.12l.97 1.81 175.27 304.4c33.71 56.4-1.2 113.76-66.17 112.96v.12H73.53c-.9 0-1.78-.04-2.66-.11-58.34-.79-86.64-54.22-61.9-106.84.39-.85.82-1.67 1.28-2.46l-.04-.03 179.3-309.94-.05-.03zm50.32 302.4c4.26-4.13 9.35-6.19 14.45-6.56 3.4-.24 6.8.29 9.94 1.48 3.13 1.19 6.01 3.03 8.39 5.41 6.92 6.91 8.72 17.38 4.64 26.16-2.69 5.8-7.08 9.7-12.11 11.78-3.03 1.27-6.3 1.84-9.56 1.76-3.27-.08-6.49-.82-9.41-2.18-5.02-2.33-9.3-6.43-11.7-12.2-2.65-6.36-2.27-12.96.63-19.15 1.15-2.46 2.75-4.81 4.73-6.5zm33.86-47.07c-.8 19.91-34.51 19.93-35.28-.01-3.41-34.1-12.13-110.53-11.85-142.58.28-9.87 8.47-15.72 18.94-17.95 3.23-.69 6.78-1.03 10.35-1.02 3.6.01 7.16.36 10.39 1.05 10.82 2.3 19.31 8.39 19.31 18.45l-.05 1-11.81 141.06z"
+                                                    />
+                                                </svg>
+                                            </button>
+                                        </div>
+                                        <div v-else class="ml-auto flex my-auto">
+                                            <!-- Allow deleting the final slide -->
+                                            <button
+                                                class="slide-toc-button"
+                                                v-if="!bothLanguageSlides.slice(index + 1).some((slide) => slide.fr)"
+                                                v-tippy="{
+                                                    delay: '200',
+                                                    placement: 'bottom-start',
+                                                    content: $t('editor.slides.toc.deleteConfig'),
+                                                    animateFill: false
+                                                }"
+                                                @click="deleteConfig(element, 'fr')"
+                                            >
+                                                <svg
+                                                    xmlns="http://www.w3.org/2000/svg"
+                                                    viewBox="0 0 110.61 122.88"
+                                                    width="14"
+                                                    height="14"
+                                                    class="mx-1 my-0.5"
+                                                >
+                                                    <path
+                                                        d="M39.27,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Zm63.6-19.86L98,103a22.29,22.29,0,0,1-6.33,14.1,19.41,19.41,0,0,1-13.88,5.78h-45a19.4,19.4,0,0,1-13.86-5.78l0,0A22.31,22.31,0,0,1,12.59,103L7.74,38.78H0V25c0-3.32,1.63-4.58,4.84-4.58H27.58V10.79A10.82,10.82,0,0,1,38.37,0H72.24A10.82,10.82,0,0,1,83,10.79v9.62h23.35a6.19,6.19,0,0,1,1,.06A3.86,3.86,0,0,1,110.59,24c0,.2,0,.38,0,.57V38.78Zm-9.5.17H17.24L22,102.3a12.82,12.82,0,0,0,3.57,8.1l0,0a10,10,0,0,0,7.19,3h45a10.06,10.06,0,0,0,7.19-3,12.8,12.8,0,0,0,3.59-8.1L93.37,39ZM71,20.41V12.05H39.64v8.36ZM61.87,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Z"
+                                                    />
+                                                </svg>
+                                            </button>
+                                        </div>
+                                    </button>
+                                </section>
                             </div>
-                            <div class="flex flex-col mr-2 ml-1 my-1">
+
+                            <div class="flex ml-0.5 flex-col space-between">
                                 <button
-                                    class="slide-toc-button"
-                                    :class="index == 0 ? 'text-gray-500 cursor-not-allowed' : ''"
+                                    class="slide-toc-button h-auto grow-0"
+                                    :class="index == 0 ? 'text-gray-400 cursor-not-allowed' : ''"
                                     @click.stop="moveUp(index)"
                                     :disabled="index == 0"
+                                    v-tippy="{
+                                        delay: '200',
+                                        placement: 'right',
+                                        content: $t('editor.slides.toc.moveSlideUp')
+                                    }"
                                 >
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="fill-current" height="20" width="20">
-                                        <path d="m2 16 8-12 8 12Z" />
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        x="0px"
+                                        y="0px"
+                                        viewBox="0 0 122.88 66.91"
+                                        style="enable-background: new 0 0 122.88 66.91"
+                                        xml:space="preserve"
+                                        height="14"
+                                        width="14"
+                                        class="m-1 fill-current"
+                                    >
+                                        <g>
+                                            <path
+                                                d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95 c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73 c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"
+                                            />
+                                        </g>
                                     </svg>
                                 </button>
                                 <button
-                                    class="slide-toc-button rotate-180 transform"
-                                    :class="index == slides.length - 1 ? 'text-gray-500 cursor-not-allowed' : ''"
+                                    class="slide-toc-button rotate-180 transform h-auto grow-0 mt-auto"
+                                    :class="
+                                        index == bothLanguageSlides.length - 1 ? 'text-gray-400 cursor-not-allowed' : ''
+                                    "
                                     @click.stop="moveDown(index)"
-                                    :disabled="index == slides.length - 1"
+                                    :disabled="index == bothLanguageSlides.length - 1"
+                                    v-tippy="{
+                                        delay: '200',
+                                        placement: 'right',
+                                        content: $t('editor.slides.toc.moveSlideDown')
+                                    }"
                                 >
-                                    <svg xmlns="http://www.w3.org/2000/svg" class="fill-current" height="20" width="20">
-                                        <path d="m2 16 8-12 8 12Z" />
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        x="0px"
+                                        y="0px"
+                                        viewBox="0 0 122.88 66.91"
+                                        style="enable-background: new 0 0 122.88 66.91"
+                                        xml:space="preserve"
+                                        height="14"
+                                        width="14"
+                                        class="m-1 fill-current"
+                                    >
+                                        <g>
+                                            <path
+                                                d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95 c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73 c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"
+                                            />
+                                        </g>
                                     </svg>
                                 </button>
                             </div>
                         </div>
                         <confirmation-modal
                             :name="`delete-slide-${index}`"
-                            :message="$t('editor.slides.deleteSlide.confirm', { title: element.title })"
+                            :message="
+                                $t('editor.slides.deleteSlide.confirm', {
+                                    title: element['en']?.title + ' AND ' + element['fr']?.title
+                                })
+                            "
                             @ok="removeSlide(index)"
                         />
                     </li>
@@ -155,6 +528,7 @@ import {
     ImagePanel,
     MapPanel,
     Slide,
+    SlideForBothLanguages,
     SlideshowPanel,
     SourceCounts,
     TextPanel,
@@ -178,7 +552,7 @@ import ConfirmationModalV from './helpers/confirmation-modal.vue';
     }
 })
 export default class SlideTocV extends Vue {
-    @Prop() slides!: Slide[];
+    @Prop() bothLanguageSlides!: SlideForBothLanguages[];
     @Prop() currentSlide!: Slide | string;
     @Prop() slideIndex!: number;
     @Prop() configFileStructure!: ConfigFileStructure;
@@ -187,12 +561,91 @@ export default class SlideTocV extends Vue {
 
     selectedForCopying = 0;
 
-    selectSlide(index: number): void {
-        this.$emit('slide-change', index);
+    selectSlide(index: number, lang: string): void {
+        this.$emit('slide-change', index, lang);
     }
 
+    // Assumes you're adding slide at end
     addNewSlide(): void {
-        this.slides.push({
+        const lastSlide = this.bothLanguageSlides[this.bothLanguageSlides.length - 1];
+        this.bothLanguageSlides.push({
+            en:
+                !lastSlide?.en && this.bothLanguageSlides.length !== 0
+                    ? undefined
+                    : {
+                          title: '',
+                          panel: [
+                              {
+                                  type: 'text',
+                                  title: '',
+                                  content: ''
+                              } as TextPanel,
+                              {
+                                  type: 'text',
+                                  title: '',
+                                  content: ''
+                              } as TextPanel
+                          ]
+                      },
+            fr:
+                !lastSlide?.fr && this.bothLanguageSlides.length !== 0
+                    ? undefined
+                    : {
+                          title: '',
+                          panel: [
+                              {
+                                  type: 'text',
+                                  title: '',
+                                  content: ''
+                              } as TextPanel,
+                              {
+                                  type: 'text',
+                                  title: '',
+                                  content: ''
+                              } as TextPanel
+                          ]
+                      }
+        });
+        this.selectSlide(this.bothLanguageSlides.length - 1, this.lang);
+        this.$emit('slides-updated', this.bothLanguageSlides);
+        this.scrollToElement(this.bothLanguageSlides.length - 1);
+    }
+
+    /**
+     * Deletes one of the language configs for a single slide. That config will be undefined after, and the slide will say "(No English/French Config)" or similar.
+     * @param slides A slide, containing an English and French config.
+     * @param currLang The config to delete, either 'en' for English of 'fr' for French.
+     */
+    deleteConfig(slides: SlideForBothLanguages, currLang: 'en' | 'fr'): void {
+        slides[currLang] = undefined;
+        this.$emit('slides-updated', this.bothLanguageSlides);
+    }
+
+    /**
+     * Smooth scroll to an element on the table of contents. Will end scroll in the middle of the ToC vertical area, if able.
+     * @param index The index of the slide to scroll to.
+     */
+    scrollToElement(index: number): void {
+        setTimeout(() => {
+            document.getElementById('slide' + index)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }, 10);
+    }
+
+    // Assumes that you've already checked that the other lang DOES have a config.
+    copyConfigFromOtherLang(slides: SlideForBothLanguages, currLang: string): void {
+        slides[currLang as keyof SlideForBothLanguages] = JSON.parse(
+            JSON.stringify(slides[currLang === 'en' ? 'fr' : 'en'])
+        );
+        this.$emit('slides-updated', this.bothLanguageSlides);
+    }
+
+    /**
+     * Creates a new blank config for a single language on a particular slide.
+     * @param slides A slide, containing an English and French config (either/both can be undefined).
+     * @param currLang The language to create a blank config for.
+     */
+    createNewConfig(slides: SlideForBothLanguages, currLang: 'en' | 'fr'): void {
+        slides[currLang] = {
             title: '',
             panel: [
                 {
@@ -206,31 +659,20 @@ export default class SlideTocV extends Vue {
                     content: ''
                 } as TextPanel
             ]
-        });
-        this.selectSlide(this.slides.length - 1);
-        this.$emit('slides-updated', this.slides);
+        };
+        this.$emit('slides-updated', this.bothLanguageSlides);
     }
 
-    copyFromOtherLang(slide: Slide | undefined): void {
-        if (slide) {
-            this.slides.splice(this.slides.length, 0, cloneDeep(slide));
-            this.$emit('slides-updated', this.slides);
-            Message.success(this.$t('editor.slide.copy.success'));
-        }
-    }
-
-    copyAllFromOtherLang(slides: Slide[] | undefined): void {
-        if (slides) {
-            this.slides.splice(this.slides.length, 0, ...slides.map((slide) => cloneDeep(slide)));
-            this.$emit('slides-updated', this.slides);
-            Message.success(this.$t('editor.slide.copy.success'));
-        }
-    }
-
+    /**
+     * Copies an entire slide, creating a new identical slide at the next index.
+     * @param index Index of the slide to copy.
+     */
     copySlide(index: number): void {
-        this.slides.splice(index + 1, 0, cloneDeep(this.slides[index]));
-        this.$emit('slides-updated', this.slides);
+        this.bothLanguageSlides.splice(index + 1, 0, cloneDeep(this.bothLanguageSlides[index]));
+        this.$emit('slides-updated', this.bothLanguageSlides);
+        this.selectSlide(index + 1, this.lang);
         Message.success(this.$t('editor.slide.copy.success'));
+        this.scrollToElement(index + 1);
     }
 
     removeSlide(index: number): void {
@@ -241,13 +683,18 @@ export default class SlideTocV extends Vue {
         // Before removing the slide, updated the sources for the panels.
         this.removeSourceCounts(index);
 
-        this.slides.splice(index, 1);
-        this.$emit('slides-updated', this.slides);
+        this.bothLanguageSlides.splice(index, 1);
+        this.$emit('slides-updated', this.bothLanguageSlides);
     }
 
     removeSourceCounts(deletedIndex: number): void {
-        const panel = this.slides.find((slide: Slide, idx: number) => idx === deletedIndex)?.panel;
-        panel?.forEach((p: BasePanel) => this.removeSourceHelper(p));
+        let panelEn = this.bothLanguageSlides.find((slide: SlideForBothLanguages, idx: number) => idx === deletedIndex)
+            ?.en?.panel;
+        let panelFr = this.bothLanguageSlides.find((slide: SlideForBothLanguages, idx: number) => idx === deletedIndex)
+            ?.fr?.panel;
+
+        panelEn?.forEach((p: BasePanel) => this.removeSourceHelper(p));
+        panelFr?.forEach((p: BasePanel) => this.removeSourceHelper(p));
     }
 
     removeSourceHelper(panel: BasePanel): void {
@@ -324,12 +771,12 @@ export default class SlideTocV extends Vue {
     }
 
     moveDown(index: number): void {
-        this.slides.splice(index + 1, 0, this.slides.splice(index, 1)[0]);
-        this.$emit('slides-updated', this.slides);
+        this.bothLanguageSlides.splice(index + 1, 0, this.bothLanguageSlides.splice(index, 1)[0]);
+        this.$emit('slides-updated', this.bothLanguageSlides);
     }
 
-    getSlideId(slide: Slide): string {
-        return slide.title + this.slides.indexOf(slide);
+    getSlideId(slide: SlideForBothLanguages): string {
+        return 'slide' + this.bothLanguageSlides.indexOf(slide);
     }
 }
 </script>
@@ -356,5 +803,31 @@ export default class SlideTocV extends Vue {
 
 .editor-toc-button {
     margin: 10px 0px 0px 0px !important;
+}
+
+.slide-toc-button {
+    border-radius: 3px;
+    padding: 2px;
+}
+.slide-toc-button:hover {
+    background-color: rgb(209, 213, 219);
+}
+
+.line-clamp-2 {
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+// Hard coded height :(
+// TODO: Change positioning of app components so we don't need to hardcode
+.toc-list {
+    height: calc(100vh - 177px);
+    overflow-y: auto;
+}
+
+.selected-toc-config-item {
+    background-color: rgb(225, 225, 225);
 }
 </style>

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -100,6 +100,8 @@
                                     </div>
                                 </section>
                                 <!-- ENG and FR configs for slide -->
+                                <!-- TODO: Modularize an individual config button and just reuse it twice here.
+                                           There's a lot of repeated code with just "EN" and "FR" swapped. -->
                                 <section class="flex flex-col gap-0.5 text-sm">
                                     <!-- ENG config for slide -->
                                     <button
@@ -155,25 +157,14 @@
                                             <!-- Create a new blank config -->
                                             <button
                                                 class="slide-toc-button"
-                                                :class="{
-                                                    'cursor-not-allowed opacity-50':
-                                                        index - 1 !== -1 && !slides[index - 1]?.en
-                                                }"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'top-start',
-                                                    content:
-                                                        index - 1 !== -1 && !slides[index - 1]?.en
-                                                            ? $t('editor.slides.toc.prevEngDNE')
-                                                            : $t('editor.slides.toc.newBlankConfig'),
+                                                    content: $t('editor.slides.toc.newBlankConfig'),
                                                     animateFill: false,
                                                     touch: ['hold', 500]
                                                 }"
-                                                @click="
-                                                    index - 1 !== -1 && !slides[index - 1]?.en
-                                                        ? ''
-                                                        : createNewConfig(element, 'en')
-                                                "
+                                                @click="createNewConfig(index, 'en')"
                                             >
                                                 <svg
                                                     xmlns="http://www.w3.org/2000/svg"
@@ -198,25 +189,14 @@
                                             <button
                                                 v-if="element.fr"
                                                 class="slide-toc-button"
-                                                :class="{
-                                                    'cursor-not-allowed opacity-50':
-                                                        index - 1 !== -1 && !slides[index - 1]?.en
-                                                }"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'top-start',
-                                                    content:
-                                                        index - 1 !== -1 && !slides[index - 1]?.en
-                                                            ? $t('editor.slides.toc.prevEngDNE')
-                                                            : $t('editor.slides.toc.newConfigFromFR'),
+                                                    content: $t('editor.slides.toc.newConfigFromFR'),
                                                     animateFill: false,
                                                     touch: ['hold', 500]
                                                 }"
-                                                @click="
-                                                    index - 1 !== -1 && !slides[index - 1]?.en
-                                                        ? ''
-                                                        : copyConfigFromOtherLang(element, 'en')
-                                                "
+                                                @click="copyConfigFromOtherLang(index, 'en')"
                                             >
                                                 <svg
                                                     xmlns="http://www.w3.org/2000/svg"
@@ -230,77 +210,50 @@
                                                     />
                                                 </svg>
                                             </button>
-                                            <!-- Warning indicator for isolated undefined configs: Defined configs below it WILL be moved up! -->
-                                            <button
-                                                class="slide-toc-button cursor-default"
-                                                v-if="
-                                                    slides.slice(0, index).some((slide) => slide.en) &&
-                                                    slides.slice(index + 1).some((slide) => slide.en)
-                                                "
-                                                v-tippy="{
-                                                    delay: '200',
-                                                    placement: 'top-start',
-                                                    content: $t('editor.slides.toc.isolatedUndefinedENGconfig'),
-                                                    animateFill: false,
-                                                    touch: ['hold', 500]
-                                                }"
-                                            >
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    shape-rendering="geometricPrecision"
-                                                    text-rendering="geometricPrecision"
-                                                    image-rendering="optimizeQuality"
-                                                    fill-rule="evenodd"
-                                                    clip-rule="evenodd"
-                                                    viewBox="0 0 512 463.43"
-                                                    height="16"
-                                                    width="16"
-                                                    style="fill: rgb(248, 113, 113)"
-                                                >
-                                                    <path
-                                                        d="M189.46 44.02c34.26-58.66 99.16-58.77 133.24.12l.97 1.81 175.27 304.4c33.71 56.4-1.2 113.76-66.17 112.96v.12H73.53c-.9 0-1.78-.04-2.66-.11-58.34-.79-86.64-54.22-61.9-106.84.39-.85.82-1.67 1.28-2.46l-.04-.03 179.3-309.94-.05-.03zm50.32 302.4c4.26-4.13 9.35-6.19 14.45-6.56 3.4-.24 6.8.29 9.94 1.48 3.13 1.19 6.01 3.03 8.39 5.41 6.92 6.91 8.72 17.38 4.64 26.16-2.69 5.8-7.08 9.7-12.11 11.78-3.03 1.27-6.3 1.84-9.56 1.76-3.27-.08-6.49-.82-9.41-2.18-5.02-2.33-9.3-6.43-11.7-12.2-2.65-6.36-2.27-12.96.63-19.15 1.15-2.46 2.75-4.81 4.73-6.5zm33.86-47.07c-.8 19.91-34.51 19.93-35.28-.01-3.41-34.1-12.13-110.53-11.85-142.58.28-9.87 8.47-15.72 18.94-17.95 3.23-.69 6.78-1.03 10.35-1.02 3.6.01 7.16.36 10.39 1.05 10.82 2.3 19.31 8.39 19.31 18.45l-.05 1-11.81 141.06z"
-                                                    />
-                                                </svg>
-                                            </button>
                                         </div>
                                         <div v-else class="ml-auto flex my-auto">
-                                            <!-- Allow deleting the final slide -->
-                                            <!-- TODO: Do we want a warning for deleting individual configs in a slide? -->
-                                            <button
-                                                class="slide-toc-button"
-                                                v-if="!slides.slice(index + 1).some((slide) => slide.en)"
-                                                v-tippy="{
-                                                    delay: '200',
-                                                    placement: 'top-start',
-                                                    content: $t('editor.slides.toc.deleteConfig'),
-                                                    animateFill: false,
-                                                    touch: ['hold', 500]
-                                                }"
-                                                @click.stop="$vfm.open(`delete-slide-${index}-en-config`)"
-                                            >
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    viewBox="0 0 110.61 122.88"
-                                                    width="14"
-                                                    height="14"
-                                                    class="mx-1 my-0.5"
-                                                >
-                                                    <path
-                                                        d="M39.27,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Zm63.6-19.86L98,103a22.29,22.29,0,0,1-6.33,14.1,19.41,19.41,0,0,1-13.88,5.78h-45a19.4,19.4,0,0,1-13.86-5.78l0,0A22.31,22.31,0,0,1,12.59,103L7.74,38.78H0V25c0-3.32,1.63-4.58,4.84-4.58H27.58V10.79A10.82,10.82,0,0,1,38.37,0H72.24A10.82,10.82,0,0,1,83,10.79v9.62h23.35a6.19,6.19,0,0,1,1,.06A3.86,3.86,0,0,1,110.59,24c0,.2,0,.38,0,.57V38.78Zm-9.5.17H17.24L22,102.3a12.82,12.82,0,0,0,3.57,8.1l0,0a10,10,0,0,0,7.19,3h45a10.06,10.06,0,0,0,7.19-3,12.8,12.8,0,0,0,3.59-8.1L93.37,39ZM71,20.41V12.05H39.64v8.36ZM61.87,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Z"
-                                                    />
-                                                </svg>
-                                            </button>
+                                            <!-- ENG options dropdown menu -->
+                                            <toc-options
+                                                :copy-allowed="!!element.fr"
+                                                @copy="
+                                                    configEmpty(element, 'en')
+                                                        ? copyConfigFromOtherLang(index, 'en')
+                                                        : $vfm.open(`copy-other-slide-${index}-en-config`)
+                                                "
+                                                @clear="$vfm.open(`delete-slide-${index}-en-config`)"
+                                            />
                                         </div>
                                     </button>
                                     <!-- Delete ENG confirmation modal -->
-                                    <confirmation-modal
+                                    <action-modal
                                         :name="`delete-slide-${index}-en-config`"
-                                        :message="
-                                            $t('editor.slides.deleteConfig.confirm', {
-                                                title: element['en']?.title
+                                        :title="
+                                            $t('editor.slides.deleteConfig.title', {
+                                                lang: $t('editor.lang.en'),
+                                                num: index + 1
                                             })
                                         "
-                                        @ok="deleteConfig(element, 'en')"
+                                        :message="
+                                            $t('editor.slides.deleteConfig.confirm', {
+                                                title: element['en']?.title || ''
+                                            })
+                                        "
+                                        @ok="createNewConfig(index, 'en')"
+                                    />
+                                    <!-- ENG copy other slide confirmation modal -->
+                                    <action-modal
+                                        :name="`copy-other-slide-${index}-en-config`"
+                                        :title="$t('editor.slides.toc.copySlide.warning.title')"
+                                        :message="
+                                            $t('editor.slides.toc.copySlide.warning.message', {
+                                                num: index + 1,
+                                                oldLang: $t('editor.lang.en'),
+                                                newLang: $t('editor.lang.fr'),
+                                                oldTitle: element['en']?.title || '',
+                                                newTitle: element['fr']?.title || ''
+                                            })
+                                        "
+                                        @ok="copyConfigFromOtherLang(index, 'en')"
                                     />
                                     <hr v-if="isMobileSidebar" />
                                     <!-- FR config for slide -->
@@ -357,25 +310,14 @@
                                             <!-- Create a new blank config -->
                                             <button
                                                 class="slide-toc-button"
-                                                :class="{
-                                                    'cursor-not-allowed opacity-50':
-                                                        index - 1 !== -1 && !slides[index - 1]?.fr
-                                                }"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'bottom-start',
-                                                    content:
-                                                        index - 1 !== -1 && !slides[index - 1]?.fr
-                                                            ? $t('editor.slide.toc.prevFrDNE')
-                                                            : $t('editor.slides.toc.newBlankConfig'),
+                                                    content: $t('editor.slides.toc.newBlankConfig'),
                                                     animateFill: false,
                                                     touch: ['hold', 500]
                                                 }"
-                                                @click="
-                                                    index - 1 !== -1 && !slides[index - 1]?.fr
-                                                        ? ''
-                                                        : createNewConfig(element, 'fr')
-                                                "
+                                                @click="createNewConfig(index, 'fr')"
                                             >
                                                 <svg
                                                     xmlns="http://www.w3.org/2000/svg"
@@ -400,25 +342,14 @@
                                             <button
                                                 v-if="element.en"
                                                 class="slide-toc-button"
-                                                :class="{
-                                                    'cursor-not-allowed opacity-50':
-                                                        index - 1 !== -1 && !slides[index - 1]?.fr
-                                                }"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'bottom-start',
-                                                    content:
-                                                        index - 1 !== -1 && !slides[index - 1]?.fr
-                                                            ? $t('editor.slide.toc.prevFrDNE')
-                                                            : $t('editor.slides.toc.newConfigFromEng'),
+                                                    content: $t('editor.slides.toc.newConfigFromEng'),
                                                     animateFill: false,
                                                     touch: ['hold', 500]
                                                 }"
-                                                @click="
-                                                    index - 1 !== -1 && !slides[index - 1]?.fr
-                                                        ? ''
-                                                        : copyConfigFromOtherLang(element, 'fr')
-                                                "
+                                                @click="copyConfigFromOtherLang(index, 'fr')"
                                             >
                                                 <svg
                                                     xmlns="http://www.w3.org/2000/svg"
@@ -432,76 +363,50 @@
                                                     />
                                                 </svg>
                                             </button>
-                                            <!-- Warning indicator for isolated undefined configs: Defined configs below it WILL be moved up! -->
-                                            <button
-                                                class="slide-toc-button cursor-default"
-                                                v-if="
-                                                    slides.slice(0, index).some((slide) => slide.fr) &&
-                                                    slides.slice(index + 1).some((slide) => slide.fr)
-                                                "
-                                                v-tippy="{
-                                                    delay: '200',
-                                                    placement: 'bottom-start',
-                                                    content: $t('editor.slides.toc.isolatedUndefinedFRconfig'),
-                                                    animateFill: false,
-                                                    touch: ['hold', 500]
-                                                }"
-                                            >
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    shape-rendering="geometricPrecision"
-                                                    text-rendering="geometricPrecision"
-                                                    image-rendering="optimizeQuality"
-                                                    fill-rule="evenodd"
-                                                    clip-rule="evenodd"
-                                                    viewBox="0 0 512 463.43"
-                                                    height="16"
-                                                    width="16"
-                                                    style="fill: rgb(248, 113, 113)"
-                                                >
-                                                    <path
-                                                        d="M189.46 44.02c34.26-58.66 99.16-58.77 133.24.12l.97 1.81 175.27 304.4c33.71 56.4-1.2 113.76-66.17 112.96v.12H73.53c-.9 0-1.78-.04-2.66-.11-58.34-.79-86.64-54.22-61.9-106.84.39-.85.82-1.67 1.28-2.46l-.04-.03 179.3-309.94-.05-.03zm50.32 302.4c4.26-4.13 9.35-6.19 14.45-6.56 3.4-.24 6.8.29 9.94 1.48 3.13 1.19 6.01 3.03 8.39 5.41 6.92 6.91 8.72 17.38 4.64 26.16-2.69 5.8-7.08 9.7-12.11 11.78-3.03 1.27-6.3 1.84-9.56 1.76-3.27-.08-6.49-.82-9.41-2.18-5.02-2.33-9.3-6.43-11.7-12.2-2.65-6.36-2.27-12.96.63-19.15 1.15-2.46 2.75-4.81 4.73-6.5zm33.86-47.07c-.8 19.91-34.51 19.93-35.28-.01-3.41-34.1-12.13-110.53-11.85-142.58.28-9.87 8.47-15.72 18.94-17.95 3.23-.69 6.78-1.03 10.35-1.02 3.6.01 7.16.36 10.39 1.05 10.82 2.3 19.31 8.39 19.31 18.45l-.05 1-11.81 141.06z"
-                                                    />
-                                                </svg>
-                                            </button>
                                         </div>
                                         <div v-else class="ml-auto flex my-auto">
-                                            <!-- Allow deleting the final slide -->
-                                            <button
-                                                class="slide-toc-button"
-                                                v-if="!slides.slice(index + 1).some((slide) => slide.fr)"
-                                                v-tippy="{
-                                                    delay: '200',
-                                                    placement: 'bottom-start',
-                                                    content: $t('editor.slides.toc.deleteConfig'),
-                                                    animateFill: false,
-                                                    touch: ['hold', 500]
-                                                }"
-                                                @click.stop="$vfm.open(`delete-slide-${index}-fr-config`)"
-                                            >
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    viewBox="0 0 110.61 122.88"
-                                                    width="14"
-                                                    height="14"
-                                                    class="mx-1 my-0.5"
-                                                >
-                                                    <path
-                                                        d="M39.27,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Zm63.6-19.86L98,103a22.29,22.29,0,0,1-6.33,14.1,19.41,19.41,0,0,1-13.88,5.78h-45a19.4,19.4,0,0,1-13.86-5.78l0,0A22.31,22.31,0,0,1,12.59,103L7.74,38.78H0V25c0-3.32,1.63-4.58,4.84-4.58H27.58V10.79A10.82,10.82,0,0,1,38.37,0H72.24A10.82,10.82,0,0,1,83,10.79v9.62h23.35a6.19,6.19,0,0,1,1,.06A3.86,3.86,0,0,1,110.59,24c0,.2,0,.38,0,.57V38.78Zm-9.5.17H17.24L22,102.3a12.82,12.82,0,0,0,3.57,8.1l0,0a10,10,0,0,0,7.19,3h45a10.06,10.06,0,0,0,7.19-3,12.8,12.8,0,0,0,3.59-8.1L93.37,39ZM71,20.41V12.05H39.64v8.36ZM61.87,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Z"
-                                                    />
-                                                </svg>
-                                            </button>
+                                            <!-- FR options dropdown menu -->
+                                            <toc-options
+                                                :copy-allowed="!!element.en"
+                                                @copy="
+                                                    configEmpty(element, 'fr')
+                                                        ? copyConfigFromOtherLang(index, 'fr')
+                                                        : $vfm.open(`copy-other-slide-${index}-fr-config`)
+                                                "
+                                                @clear="$vfm.open(`delete-slide-${index}-fr-config`)"
+                                            />
                                         </div>
                                     </button>
                                     <!-- Delete FR confirmation modal -->
-                                    <confirmation-modal
+                                    <action-modal
                                         :name="`delete-slide-${index}-fr-config`"
-                                        :message="
-                                            $t('editor.slides.deleteConfig.confirm', {
-                                                title: element['fr']?.title
+                                        :title="
+                                            $t('editor.slides.deleteConfig.title', {
+                                                lang: $t('editor.lang.fr'),
+                                                num: index + 1
                                             })
                                         "
-                                        @ok="deleteConfig(element, 'fr')"
+                                        :message="
+                                            $t('editor.slides.deleteConfig.confirm', {
+                                                title: element['fr']?.title || ''
+                                            })
+                                        "
+                                        @ok="createNewConfig(index, 'fr')"
+                                    />
+                                    <!-- FR copy other slide confirmation modal -->
+                                    <action-modal
+                                        :name="`copy-other-slide-${index}-fr-config`"
+                                        :title="$t('editor.slides.toc.copySlide.warning.title')"
+                                        :message="
+                                            $t('editor.slides.toc.copySlide.warning.message', {
+                                                num: index + 1,
+                                                oldLang: $t('editor.lang.fr'),
+                                                newLang: $t('editor.lang.en'),
+                                                oldTitle: element['fr']?.title || '',
+                                                newTitle: element['en']?.title || ''
+                                            })
+                                        "
+                                        @ok="copyConfigFromOtherLang(index, 'fr')"
                                     />
                                 </section>
                             </div>
@@ -609,6 +514,7 @@
 
 <script lang="ts">
 import ActionModal from '@/components/helpers/action-modal.vue';
+import TocOptions from '@/components/helpers/toc-options.vue';
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import {
     BasePanel,
@@ -619,7 +525,7 @@ import {
     ImagePanel,
     MapPanel,
     Slide,
-    SlideForBothLanguages,
+    MultiLanguageSlide,
     SlideshowPanel,
     SourceCounts,
     TextPanel,
@@ -636,6 +542,7 @@ import ConfirmationModalV from './helpers/confirmation-modal.vue';
 
 @Options({
     components: {
+        TocOptions,
         ActionModal,
         'slide-editor': SlideEditorV,
         'confirmation-modal': ConfirmationModalV,
@@ -644,7 +551,7 @@ import ConfirmationModalV from './helpers/confirmation-modal.vue';
     }
 })
 export default class SlideTocV extends Vue {
-    @Prop() slides!: SlideForBothLanguages[];
+    @Prop() slides!: MultiLanguageSlide[];
     @Prop() currentSlide!: Slide | string;
     @Prop() slideIndex!: number;
     @Prop() configFileStructure!: ConfigFileStructure;
@@ -652,8 +559,6 @@ export default class SlideTocV extends Vue {
     @Prop() sourceCounts!: SourceCounts;
     @Prop() closeSidebar!: Function;
     @Prop({ default: false }) isMobileSidebar!: boolean;
-
-    selectedForCopying = 0;
 
     defaultBlankSlide: Slide = {
         title: '',
@@ -672,6 +577,15 @@ export default class SlideTocV extends Vue {
     };
 
     /**
+     * Determines if a particular config is empty.
+     * @param slide Slide object to check.
+     * @param lang Specific config in slide to check ('en' or 'fr')
+     */
+    configEmpty(slide: MultiLanguageSlide, lang: keyof MultiLanguageSlide): boolean {
+        return JSON.stringify(slide[lang]) === JSON.stringify(this.defaultBlankSlide);
+    }
+
+    /**
      * Selects a config (english or french) of a particular slide, and opens its editor.
      * @param index Index of slide to select (usually slide number [in UI] - 1)
      * @param lang Specific config in slide to select ('en' or 'fr')
@@ -686,14 +600,8 @@ export default class SlideTocV extends Vue {
     addNewSlide(): void {
         const lastSlide = this.slides[this.slides.length - 1];
         this.slides.push({
-            en:
-                !lastSlide?.en && this.slides.length !== 0
-                    ? undefined
-                    : JSON.parse(JSON.stringify(this.defaultBlankSlide)),
-            fr:
-                !lastSlide?.fr && this.slides.length !== 0
-                    ? undefined
-                    : JSON.parse(JSON.stringify(this.defaultBlankSlide))
+            en: JSON.parse(JSON.stringify(this.defaultBlankSlide)),
+            fr: JSON.parse(JSON.stringify(this.defaultBlankSlide))
         });
         this.selectSlide(this.slides.length - 1, this.lang);
         this.$emit('slides-updated', this.slides);
@@ -705,7 +613,7 @@ export default class SlideTocV extends Vue {
      * @param slides A slide, containing an English and French config.
      * @param currLang The config to delete, either 'en' for English of 'fr' for French.
      */
-    deleteConfig(slides: SlideForBothLanguages, currLang: 'en' | 'fr'): void {
+    deleteConfig(slides: MultiLanguageSlide, currLang: 'en' | 'fr'): void {
         slides[currLang] = undefined;
         this.$emit('slides-updated', this.slides);
     }
@@ -723,21 +631,21 @@ export default class SlideTocV extends Vue {
     }
 
     // Assumes that you've already checked that the other lang DOES have a config.
-    copyConfigFromOtherLang(slides: SlideForBothLanguages, currLang: string): void {
-        slides[currLang as keyof SlideForBothLanguages] = JSON.parse(
-            JSON.stringify(slides[currLang === 'en' ? 'fr' : 'en'])
-        );
+    copyConfigFromOtherLang(index: number, currLang: keyof MultiLanguageSlide): void {
+        this.slides[index][currLang] = JSON.parse(JSON.stringify(this.slides[index][currLang === 'en' ? 'fr' : 'en']));
         this.$emit('slides-updated', this.slides);
+        this.$emit('slide-change', index, currLang);
     }
 
     /**
      * Creates a new blank config for a single language on a particular slide.
-     * @param slides A slide, containing an English and French config (either/both can be undefined).
+     * @param index The index of the slide to be changed into a blank slide.
      * @param currLang The language to create a blank config for.
      */
-    createNewConfig(slides: SlideForBothLanguages, currLang: 'en' | 'fr'): void {
-        slides[currLang] = JSON.parse(JSON.stringify(this.defaultBlankSlide));
+    createNewConfig(index: number, currLang: 'en' | 'fr'): void {
+        this.slides[index][currLang] = JSON.parse(JSON.stringify(this.defaultBlankSlide));
         this.$emit('slides-updated', this.slides);
+        this.$emit('slide-change', index, currLang);
     }
 
     /**
@@ -765,8 +673,8 @@ export default class SlideTocV extends Vue {
     }
 
     removeSourceCounts(deletedIndex: number): void {
-        let panelEn = this.slides.find((slide: SlideForBothLanguages, idx: number) => idx === deletedIndex)?.en?.panel;
-        let panelFr = this.slides.find((slide: SlideForBothLanguages, idx: number) => idx === deletedIndex)?.fr?.panel;
+        let panelEn = this.slides.find((slide: MultiLanguageSlide, idx: number) => idx === deletedIndex)?.en?.panel;
+        let panelFr = this.slides.find((slide: MultiLanguageSlide, idx: number) => idx === deletedIndex)?.fr?.panel;
 
         panelEn?.forEach((p: BasePanel) => this.removeSourceHelper(p));
         panelFr?.forEach((p: BasePanel) => this.removeSourceHelper(p));
@@ -847,10 +755,11 @@ export default class SlideTocV extends Vue {
 
     moveDown(index: number): void {
         this.slides.splice(index + 1, 0, this.slides.splice(index, 1)[0]);
+        this.scrollToElement(index + 1);
         this.$emit('slides-updated', this.slides);
     }
 
-    getSlideId(slide: SlideForBothLanguages): string {
+    getSlideId(slide: MultiLanguageSlide): string {
         return 'slide' + this.slides.indexOf(slide);
     }
 }

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -1,9 +1,13 @@
 <template>
     <div>
+        <!-- Sidebar header -->
         <div class="flex toc-header px-3 pt-2 mt-5 pb-2 border-b align-bottom items-end">
+            <!-- Header title ("SLIDES" or equivalent) -->
             <p class="flex items-center justify-center font-bold">{{ $t('editor.slides.slideHeader') }}</p>
             <p class="flex-1"></p>
             <p class="ml-auto"></p>
+            <!-- Add new slide button -->
+            <!-- New slide will have a blank ENG and FR config, with some exceptions -->
             <button class="mx-auto toc-popup-button py-0 px-2" @click="addNewSlide">
                 <span class="inline-block pr-1"
                     ><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24">
@@ -15,35 +19,46 @@
             <br />
         </div>
 
-        <ul class="toc-list">
+        <!-- Slide list -->
+        <ul :class="[isMobileSidebar ? 'toc-list-mobile' : 'toc-list']">
+            <!-- Slide -->
+            <!-- Dragging is turned off on mobile version as you can't scroll otherwise (component would think a scroll === a drag) -->
             <draggable
-                :list="bothLanguageSlides"
-                @update="$emit('slides-updated', bothLanguageSlides)"
+                :disabled="isMobileSidebar"
+                :list="slides"
+                @update="$emit('slides-updated', slides)"
                 :item-key="getSlideId"
                 v-focus-list
             >
                 <template #item="{ element, index }">
                     <li
-                        class="toc-slide border-t flex px-3 py-2 cursor-pointer hover:bg-gray-50"
+                        class="toc-slide select-none border-t flex px-3 py-2 cursor-pointer hover:bg-gray-50"
                         :class="slideIndex === index ? 'bg-gray-100 border-gray-300' : ''"
-                        :id="'slide' + index"
+                        :id="(isMobileSidebar ? 'mobile' : '') + 'slide' + index"
                         :key="'slide' + index"
                         v-focus-item
                     >
                         <div class="flex space-between w-full align-center text-base">
                             <div class="flex flex-col flex-1">
                                 <section class="flex space-between mb-1">
-                                    <p class="font-semibold overflow-ellipsis whitespace-nowrap overflow-hidden flex-1">
+                                    <!-- Slide number -->
+                                    <p
+                                        class="font-semibold select-none overflow-ellipsis whitespace-nowrap self-center overflow-hidden flex-1"
+                                    >
                                         {{ $t('editor.slides.slide') }} {{ index + 1 }}
                                     </p>
-                                    <div class="flex align-center mr-4">
+                                    <!-- Whole-slide options -->
+                                    <div class="flex align-center mr-4 space-x-1">
+                                        <!-- Copy slide button -->
                                         <button
-                                            class="slide-toc-button px-5"
+                                            class="slide-toc-button"
+                                            :class="{ 'toc-popup-button': isMobileSidebar }"
                                             @click.stop="copySlide(index)"
                                             v-tippy="{
                                                 delay: '200',
                                                 placement: 'top-start',
-                                                content: $t('editor.slides.toc.copySlide')
+                                                content: $t('editor.slides.toc.copySlide'),
+                                                touch: ['hold', 500]
                                             }"
                                         >
                                             <svg
@@ -51,20 +66,23 @@
                                                 height="17"
                                                 width="17"
                                                 viewBox="0 0 24 24"
-                                                class="mx-1"
+                                                :class="[isMobileSidebar ? 'mx-2 my-1' : 'mx-1']"
                                             >
                                                 <path
                                                     d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
                                                 />
                                             </svg>
                                         </button>
+                                        <!-- Delete slide button -->
                                         <button
                                             class="slide-toc-button"
+                                            :class="{ 'toc-popup-button': isMobileSidebar }"
                                             @click.stop="$vfm.open(`delete-slide-${index}`)"
                                             v-tippy="{
                                                 delay: '200',
                                                 placement: 'top-start',
-                                                content: $t('editor.slides.toc.deleteSlide')
+                                                content: $t('editor.slides.toc.deleteSlide'),
+                                                touch: ['hold', 500]
                                             }"
                                         >
                                             <svg
@@ -72,7 +90,7 @@
                                                 viewBox="0 0 110.61 122.88"
                                                 width="15"
                                                 height="15"
-                                                class="mx-1"
+                                                :class="[isMobileSidebar ? 'mx-2 my-1' : 'mx-1']"
                                             >
                                                 <path
                                                     d="M39.27,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Zm63.6-19.86L98,103a22.29,22.29,0,0,1-6.33,14.1,19.41,19.41,0,0,1-13.88,5.78h-45a19.4,19.4,0,0,1-13.86-5.78l0,0A22.31,22.31,0,0,1,12.59,103L7.74,38.78H0V25c0-3.32,1.63-4.58,4.84-4.58H27.58V10.79A10.82,10.82,0,0,1,38.37,0H72.24A10.82,10.82,0,0,1,83,10.79v9.62h23.35a6.19,6.19,0,0,1,1,.06A3.86,3.86,0,0,1,110.59,24c0,.2,0,.38,0,.57V38.78Zm-9.5.17H17.24L22,102.3a12.82,12.82,0,0,0,3.57,8.1l0,0a10,10,0,0,0,7.19,3h45a10.06,10.06,0,0,0,7.19-3,12.8,12.8,0,0,0,3.59-8.1L93.37,39ZM71,20.41V12.05H39.64v8.36ZM61.87,58.64a4.74,4.74,0,1,1,9.47,0V93.72a4.74,4.74,0,1,1-9.47,0V58.64Z"
@@ -81,36 +99,46 @@
                                         </button>
                                     </div>
                                 </section>
-
+                                <!-- ENG and FR configs for slide -->
                                 <section class="flex flex-col gap-0.5 text-sm">
                                     <!-- ENG config for slide -->
                                     <button
-                                        class="flex gap-2 px-2 py-1 rounded-md bg-transparent hover:bg-gray-200"
+                                        class="flex gap-2 px-2 rounded-md bg-transparent hover:bg-gray-200"
+                                        :disabled="!element.en"
                                         :class="{
                                             'selected-toc-config-item': element.en === currentSlide,
+                                            'py-1': !isMobileSidebar,
+                                            'py-2': isMobileSidebar,
+                                            'border-2 border-blue-500': isMobileSidebar && element.en === currentSlide,
                                             'cursor-not-allowed border-2 border-red-400': !element.en
                                         }"
                                         v-tippy="{
                                             delay: '200',
-                                            placement: 'right',
+                                            placement: isMobileSidebar ? 'top' : 'right',
                                             content:
                                                 element.en?.title ||
                                                 (element.en?.title === ''
                                                     ? $t('editor.slides.toc.newENGSlideText')
                                                     : $t('editor.slides.toc.noENGslide')),
                                             animateFill: true,
-                                            offset: [0, 50]
+                                            offset: [0, isMobileSidebar ? 0 : 50],
+                                            touch: ['hold', 500]
                                         }"
-                                        @click.stop="selectSlide(index, 'en')"
+                                        @click.stop="
+                                            selectSlide(index, 'en');
+                                            isMobileSidebar && closeSidebar();
+                                        "
                                     >
+                                        <!-- "EN" text -->
                                         <p
-                                            class="font-bold italic text-gray-500"
+                                            class="font-bold italic text-gray-500 select-none"
                                             :class="{ 'text-gray-700': slideIndex === index }"
                                         >
                                             EN
                                         </p>
+                                        <!-- Config title -->
                                         <p
-                                            class="text-left line-clamp-2"
+                                            class="text-left line-clamp-2 select-none"
                                             :class="{
                                                 italic: !element.en?.title
                                             }"
@@ -129,19 +157,20 @@
                                                 class="slide-toc-button"
                                                 :class="{
                                                     'cursor-not-allowed opacity-50':
-                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                        index - 1 !== -1 && !slides[index - 1]?.en
                                                 }"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'top-start',
                                                     content:
-                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                        index - 1 !== -1 && !slides[index - 1]?.en
                                                             ? $t('editor.slides.toc.prevEngDNE')
                                                             : $t('editor.slides.toc.newBlankConfig'),
-                                                    animateFill: false
+                                                    animateFill: false,
+                                                    touch: ['hold', 500]
                                                 }"
                                                 @click="
-                                                    index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                    index - 1 !== -1 && !slides[index - 1]?.en
                                                         ? ''
                                                         : createNewConfig(element, 'en')
                                                 "
@@ -164,25 +193,27 @@
                                                     />
                                                 </svg>
                                             </button>
-                                            <!-- Copy FR config over here -->
+                                            <!-- Button: Copy the FR config in the same slide, if it exists -->
+                                            <!-- Only available if the slide's ENG config is undefined -->
                                             <button
                                                 v-if="element.fr"
                                                 class="slide-toc-button"
                                                 :class="{
                                                     'cursor-not-allowed opacity-50':
-                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                        index - 1 !== -1 && !slides[index - 1]?.en
                                                 }"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'top-start',
                                                     content:
-                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                        index - 1 !== -1 && !slides[index - 1]?.en
                                                             ? $t('editor.slides.toc.prevEngDNE')
                                                             : $t('editor.slides.toc.newConfigFromFR'),
-                                                    animateFill: false
+                                                    animateFill: false,
+                                                    touch: ['hold', 500]
                                                 }"
                                                 @click="
-                                                    index - 1 !== -1 && !bothLanguageSlides[index - 1]?.en
+                                                    index - 1 !== -1 && !slides[index - 1]?.en
                                                         ? ''
                                                         : copyConfigFromOtherLang(element, 'en')
                                                 "
@@ -203,14 +234,15 @@
                                             <button
                                                 class="slide-toc-button cursor-default"
                                                 v-if="
-                                                    bothLanguageSlides.slice(0, index).some((slide) => slide.en) &&
-                                                    bothLanguageSlides.slice(index + 1).some((slide) => slide.en)
+                                                    slides.slice(0, index).some((slide) => slide.en) &&
+                                                    slides.slice(index + 1).some((slide) => slide.en)
                                                 "
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'top-start',
                                                     content: $t('editor.slides.toc.isolatedUndefinedENGconfig'),
-                                                    animateFill: false
+                                                    animateFill: false,
+                                                    touch: ['hold', 500]
                                                 }"
                                             >
                                                 <svg
@@ -233,16 +265,18 @@
                                         </div>
                                         <div v-else class="ml-auto flex my-auto">
                                             <!-- Allow deleting the final slide -->
+                                            <!-- TODO: Do we want a warning for deleting individual configs in a slide? -->
                                             <button
                                                 class="slide-toc-button"
-                                                v-if="!bothLanguageSlides.slice(index + 1).some((slide) => slide.en)"
+                                                v-if="!slides.slice(index + 1).some((slide) => slide.en)"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'top-start',
                                                     content: $t('editor.slides.toc.deleteConfig'),
-                                                    animateFill: false
+                                                    animateFill: false,
+                                                    touch: ['hold', 500]
                                                 }"
-                                                @click="deleteConfig(element, 'en')"
+                                                @click.stop="$vfm.open(`delete-slide-${index}-en-config`)"
                                             >
                                                 <svg
                                                     xmlns="http://www.w3.org/2000/svg"
@@ -258,34 +292,55 @@
                                             </button>
                                         </div>
                                     </button>
+                                    <!-- Delete ENG confirmation modal -->
+                                    <confirmation-modal
+                                        :name="`delete-slide-${index}-en-config`"
+                                        :message="
+                                            $t('editor.slides.deleteConfig.confirm', {
+                                                title: element['en']?.title
+                                            })
+                                        "
+                                        @ok="deleteConfig(element, 'en')"
+                                    />
+                                    <hr v-if="isMobileSidebar" />
                                     <!-- FR config for slide -->
                                     <button
                                         class="flex gap-2 px-2 py-1 rounded-md bg-transparent hover:bg-gray-200"
+                                        :disabled="!element.fr"
                                         :class="{
                                             'selected-toc-config-item': element.fr === currentSlide,
+                                            'py-1': !isMobileSidebar,
+                                            'py-2': isMobileSidebar,
+                                            'border-2 border-blue-500': isMobileSidebar && element.fr === currentSlide,
                                             'cursor-not-allowed border-2 border-red-400': !element.fr
                                         }"
                                         v-tippy="{
                                             delay: '200',
-                                            placement: 'right',
+                                            placement: isMobileSidebar ? 'bottom' : 'right',
                                             content:
                                                 element.fr?.title ||
                                                 (element.fr?.title === ''
                                                     ? $t('editor.slides.toc.newFRSlideText')
                                                     : $t('editor.slide.toc.noFRSlide')),
                                             animateFill: true,
-                                            offset: [0, 50]
+                                            offset: [0, isMobileSidebar ? 0 : 50],
+                                            touch: ['hold', 500]
                                         }"
-                                        @click.stop="element.fr ? selectSlide(index, 'fr') : ''"
+                                        @click.stop="
+                                            selectSlide(index, 'fr');
+                                            isMobileSidebar && closeSidebar();
+                                        "
                                     >
+                                        <!-- "FR" text -->
                                         <p
-                                            class="font-bold italic text-gray-500"
+                                            class="font-bold italic text-gray-500 select-none"
                                             :class="{ 'text-gray-700': slideIndex === index }"
                                         >
                                             FR
                                         </p>
+                                        <!-- Config title -->
                                         <p
-                                            class="text-left line-clamp-2"
+                                            class="text-left line-clamp-2 select-none"
                                             :class="{
                                                 italic: !element.fr?.title
                                             }"
@@ -304,19 +359,20 @@
                                                 class="slide-toc-button"
                                                 :class="{
                                                     'cursor-not-allowed opacity-50':
-                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                        index - 1 !== -1 && !slides[index - 1]?.fr
                                                 }"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'bottom-start',
                                                     content:
-                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                        index - 1 !== -1 && !slides[index - 1]?.fr
                                                             ? $t('editor.slide.toc.prevFrDNE')
                                                             : $t('editor.slides.toc.newBlankConfig'),
-                                                    animateFill: false
+                                                    animateFill: false,
+                                                    touch: ['hold', 500]
                                                 }"
                                                 @click="
-                                                    index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                    index - 1 !== -1 && !slides[index - 1]?.fr
                                                         ? ''
                                                         : createNewConfig(element, 'fr')
                                                 "
@@ -339,25 +395,27 @@
                                                     />
                                                 </svg>
                                             </button>
-                                            <!-- Copy ENG config over here -->
+                                            <!-- Button: Copy the ENG config in the same slide, if it exists -->
+                                            <!-- Only available if the slide's FR config is undefined -->
                                             <button
                                                 v-if="element.en"
                                                 class="slide-toc-button"
                                                 :class="{
                                                     'cursor-not-allowed opacity-50':
-                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                        index - 1 !== -1 && !slides[index - 1]?.fr
                                                 }"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'bottom-start',
                                                     content:
-                                                        index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                        index - 1 !== -1 && !slides[index - 1]?.fr
                                                             ? $t('editor.slide.toc.prevFrDNE')
                                                             : $t('editor.slides.toc.newConfigFromEng'),
-                                                    animateFill: false
+                                                    animateFill: false,
+                                                    touch: ['hold', 500]
                                                 }"
                                                 @click="
-                                                    index - 1 !== -1 && !bothLanguageSlides[index - 1]?.fr
+                                                    index - 1 !== -1 && !slides[index - 1]?.fr
                                                         ? ''
                                                         : copyConfigFromOtherLang(element, 'fr')
                                                 "
@@ -378,14 +436,15 @@
                                             <button
                                                 class="slide-toc-button cursor-default"
                                                 v-if="
-                                                    bothLanguageSlides.slice(0, index).some((slide) => slide.fr) &&
-                                                    bothLanguageSlides.slice(index + 1).some((slide) => slide.fr)
+                                                    slides.slice(0, index).some((slide) => slide.fr) &&
+                                                    slides.slice(index + 1).some((slide) => slide.fr)
                                                 "
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'bottom-start',
                                                     content: $t('editor.slides.toc.isolatedUndefinedFRconfig'),
-                                                    animateFill: false
+                                                    animateFill: false,
+                                                    touch: ['hold', 500]
                                                 }"
                                             >
                                                 <svg
@@ -410,14 +469,15 @@
                                             <!-- Allow deleting the final slide -->
                                             <button
                                                 class="slide-toc-button"
-                                                v-if="!bothLanguageSlides.slice(index + 1).some((slide) => slide.fr)"
+                                                v-if="!slides.slice(index + 1).some((slide) => slide.fr)"
                                                 v-tippy="{
                                                     delay: '200',
                                                     placement: 'bottom-start',
                                                     content: $t('editor.slides.toc.deleteConfig'),
-                                                    animateFill: false
+                                                    animateFill: false,
+                                                    touch: ['hold', 500]
                                                 }"
-                                                @click="deleteConfig(element, 'fr')"
+                                                @click.stop="$vfm.open(`delete-slide-${index}-fr-config`)"
                                             >
                                                 <svg
                                                     xmlns="http://www.w3.org/2000/svg"
@@ -433,19 +493,35 @@
                                             </button>
                                         </div>
                                     </button>
+                                    <!-- Delete FR confirmation modal -->
+                                    <confirmation-modal
+                                        :name="`delete-slide-${index}-fr-config`"
+                                        :message="
+                                            $t('editor.slides.deleteConfig.confirm', {
+                                                title: element['fr']?.title
+                                            })
+                                        "
+                                        @ok="deleteConfig(element, 'fr')"
+                                    />
                                 </section>
                             </div>
 
+                            <!-- Move slide buttons -->
                             <div class="flex ml-0.5 flex-col space-between">
+                                <!-- Move slide up button -->
                                 <button
                                     class="slide-toc-button h-auto grow-0"
-                                    :class="index == 0 ? 'text-gray-400 cursor-not-allowed' : ''"
+                                    :class="{
+                                        'toc-popup-button border-none bg-transparent': isMobileSidebar,
+                                        'text-gray-400 cursor-not-allowed': index === 0
+                                    }"
                                     @click.stop="moveUp(index)"
                                     :disabled="index == 0"
                                     v-tippy="{
                                         delay: '200',
                                         placement: 'right',
-                                        content: $t('editor.slides.toc.moveSlideUp')
+                                        content: $t('editor.slides.toc.moveSlideUp'),
+                                        touch: ['hold', 500]
                                     }"
                                 >
                                     <svg
@@ -458,7 +534,8 @@
                                         xml:space="preserve"
                                         height="14"
                                         width="14"
-                                        class="m-1 fill-current"
+                                        class="fill-current"
+                                        :class="[isMobileSidebar ? 'm-2' : 'm-1']"
                                     >
                                         <g>
                                             <path
@@ -467,17 +544,20 @@
                                         </g>
                                     </svg>
                                 </button>
+                                <!-- Move slide down button -->
                                 <button
                                     class="slide-toc-button rotate-180 transform h-auto grow-0 mt-auto"
-                                    :class="
-                                        index == bothLanguageSlides.length - 1 ? 'text-gray-400 cursor-not-allowed' : ''
-                                    "
+                                    :class="{
+                                        'toc-popup-button border-none bg-transparent': isMobileSidebar,
+                                        'text-gray-400 cursor-not-allowed': index == slides.length - 1
+                                    }"
                                     @click.stop="moveDown(index)"
-                                    :disabled="index == bothLanguageSlides.length - 1"
+                                    :disabled="index == slides.length - 1"
                                     v-tippy="{
                                         delay: '200',
                                         placement: 'right',
-                                        content: $t('editor.slides.toc.moveSlideDown')
+                                        content: $t('editor.slides.toc.moveSlideDown'),
+                                        touch: ['hold', 500]
                                     }"
                                 >
                                     <svg
@@ -490,7 +570,8 @@
                                         xml:space="preserve"
                                         height="14"
                                         width="14"
-                                        class="m-1 fill-current"
+                                        class="fill-current"
+                                        :class="[isMobileSidebar ? 'm-2' : 'm-1']"
                                     >
                                         <g>
                                             <path
@@ -501,11 +582,20 @@
                                 </button>
                             </div>
                         </div>
-                        <confirmation-modal
+                        <!-- Delete slide confirmation modal -->
+                        <action-modal
                             :name="`delete-slide-${index}`"
+                            :title="$t('editor.slides.deleteSlide.title', { num: index + 1 })"
                             :message="
                                 $t('editor.slides.deleteSlide.confirm', {
-                                    title: element['en']?.title + ' AND ' + element['fr']?.title
+                                    title:
+                                        element['en']?.title !== undefined || element['fr']?.title !== undefined
+                                            ? ': &quot;' +
+                                              (element['en']?.title || $t('editor.slide.toc.untitledENG')) +
+                                              '&quot;, &quot;' +
+                                              (element['fr']?.title || $t('editor.slide.toc.untitledFR')) +
+                                              '&quot;'
+                                            : ''
                                 })
                             "
                             @ok="removeSlide(index)"
@@ -518,6 +608,7 @@
 </template>
 
 <script lang="ts">
+import ActionModal from '@/components/helpers/action-modal.vue';
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import {
     BasePanel,
@@ -545,6 +636,7 @@ import ConfirmationModalV from './helpers/confirmation-modal.vue';
 
 @Options({
     components: {
+        ActionModal,
         'slide-editor': SlideEditorV,
         'confirmation-modal': ConfirmationModalV,
         'vue-final-modal': VueFinalModal,
@@ -552,63 +644,60 @@ import ConfirmationModalV from './helpers/confirmation-modal.vue';
     }
 })
 export default class SlideTocV extends Vue {
-    @Prop() bothLanguageSlides!: SlideForBothLanguages[];
+    @Prop() slides!: SlideForBothLanguages[];
     @Prop() currentSlide!: Slide | string;
     @Prop() slideIndex!: number;
     @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
     @Prop() sourceCounts!: SourceCounts;
+    @Prop() closeSidebar!: Function;
+    @Prop({ default: false }) isMobileSidebar!: boolean;
 
     selectedForCopying = 0;
 
+    defaultBlankSlide: Slide = {
+        title: '',
+        panel: [
+            {
+                type: 'text',
+                title: '',
+                content: ''
+            } as TextPanel,
+            {
+                type: 'text',
+                title: '',
+                content: ''
+            } as TextPanel
+        ]
+    };
+
+    /**
+     * Selects a config (english or french) of a particular slide, and opens its editor.
+     * @param index Index of slide to select (usually slide number [in UI] - 1)
+     * @param lang Specific config in slide to select ('en' or 'fr')
+     */
     selectSlide(index: number, lang: string): void {
         this.$emit('slide-change', index, lang);
     }
 
-    // Assumes you're adding slide at end
+    /**
+     * Adds a new slide at the end of the current list.
+     */
     addNewSlide(): void {
-        const lastSlide = this.bothLanguageSlides[this.bothLanguageSlides.length - 1];
-        this.bothLanguageSlides.push({
+        const lastSlide = this.slides[this.slides.length - 1];
+        this.slides.push({
             en:
-                !lastSlide?.en && this.bothLanguageSlides.length !== 0
+                !lastSlide?.en && this.slides.length !== 0
                     ? undefined
-                    : {
-                          title: '',
-                          panel: [
-                              {
-                                  type: 'text',
-                                  title: '',
-                                  content: ''
-                              } as TextPanel,
-                              {
-                                  type: 'text',
-                                  title: '',
-                                  content: ''
-                              } as TextPanel
-                          ]
-                      },
+                    : JSON.parse(JSON.stringify(this.defaultBlankSlide)),
             fr:
-                !lastSlide?.fr && this.bothLanguageSlides.length !== 0
+                !lastSlide?.fr && this.slides.length !== 0
                     ? undefined
-                    : {
-                          title: '',
-                          panel: [
-                              {
-                                  type: 'text',
-                                  title: '',
-                                  content: ''
-                              } as TextPanel,
-                              {
-                                  type: 'text',
-                                  title: '',
-                                  content: ''
-                              } as TextPanel
-                          ]
-                      }
+                    : JSON.parse(JSON.stringify(this.defaultBlankSlide))
         });
-        this.selectSlide(this.bothLanguageSlides.length - 1, this.lang);
-        this.$emit('slides-updated', this.bothLanguageSlides);
-        this.scrollToElement(this.bothLanguageSlides.length - 1);
+        this.selectSlide(this.slides.length - 1, this.lang);
+        this.$emit('slides-updated', this.slides);
+        this.scrollToElement(this.slides.length - 1);
     }
 
     /**
@@ -618,7 +707,7 @@ export default class SlideTocV extends Vue {
      */
     deleteConfig(slides: SlideForBothLanguages, currLang: 'en' | 'fr'): void {
         slides[currLang] = undefined;
-        this.$emit('slides-updated', this.bothLanguageSlides);
+        this.$emit('slides-updated', this.slides);
     }
 
     /**
@@ -627,7 +716,9 @@ export default class SlideTocV extends Vue {
      */
     scrollToElement(index: number): void {
         setTimeout(() => {
-            document.getElementById('slide' + index)?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            document
+                .getElementById((this.isMobileSidebar ? 'mobile' : '') + 'slide' + index)
+                ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }, 10);
     }
 
@@ -636,7 +727,7 @@ export default class SlideTocV extends Vue {
         slides[currLang as keyof SlideForBothLanguages] = JSON.parse(
             JSON.stringify(slides[currLang === 'en' ? 'fr' : 'en'])
         );
-        this.$emit('slides-updated', this.bothLanguageSlides);
+        this.$emit('slides-updated', this.slides);
     }
 
     /**
@@ -645,22 +736,8 @@ export default class SlideTocV extends Vue {
      * @param currLang The language to create a blank config for.
      */
     createNewConfig(slides: SlideForBothLanguages, currLang: 'en' | 'fr'): void {
-        slides[currLang] = {
-            title: '',
-            panel: [
-                {
-                    type: 'text',
-                    title: '',
-                    content: ''
-                } as TextPanel,
-                {
-                    type: 'text',
-                    title: '',
-                    content: ''
-                } as TextPanel
-            ]
-        };
-        this.$emit('slides-updated', this.bothLanguageSlides);
+        slides[currLang] = JSON.parse(JSON.stringify(this.defaultBlankSlide));
+        this.$emit('slides-updated', this.slides);
     }
 
     /**
@@ -668,8 +745,8 @@ export default class SlideTocV extends Vue {
      * @param index Index of the slide to copy.
      */
     copySlide(index: number): void {
-        this.bothLanguageSlides.splice(index + 1, 0, cloneDeep(this.bothLanguageSlides[index]));
-        this.$emit('slides-updated', this.bothLanguageSlides);
+        this.slides.splice(index + 1, 0, cloneDeep(this.slides[index]));
+        this.$emit('slides-updated', this.slides);
         this.selectSlide(index + 1, this.lang);
         Message.success(this.$t('editor.slide.copy.success'));
         this.scrollToElement(index + 1);
@@ -683,15 +760,13 @@ export default class SlideTocV extends Vue {
         // Before removing the slide, updated the sources for the panels.
         this.removeSourceCounts(index);
 
-        this.bothLanguageSlides.splice(index, 1);
-        this.$emit('slides-updated', this.bothLanguageSlides);
+        this.slides.splice(index, 1);
+        this.$emit('slides-updated', this.slides);
     }
 
     removeSourceCounts(deletedIndex: number): void {
-        let panelEn = this.bothLanguageSlides.find((slide: SlideForBothLanguages, idx: number) => idx === deletedIndex)
-            ?.en?.panel;
-        let panelFr = this.bothLanguageSlides.find((slide: SlideForBothLanguages, idx: number) => idx === deletedIndex)
-            ?.fr?.panel;
+        let panelEn = this.slides.find((slide: SlideForBothLanguages, idx: number) => idx === deletedIndex)?.en?.panel;
+        let panelFr = this.slides.find((slide: SlideForBothLanguages, idx: number) => idx === deletedIndex)?.fr?.panel;
 
         panelEn?.forEach((p: BasePanel) => this.removeSourceHelper(p));
         panelFr?.forEach((p: BasePanel) => this.removeSourceHelper(p));
@@ -771,14 +846,26 @@ export default class SlideTocV extends Vue {
     }
 
     moveDown(index: number): void {
-        this.bothLanguageSlides.splice(index + 1, 0, this.bothLanguageSlides.splice(index, 1)[0]);
-        this.$emit('slides-updated', this.bothLanguageSlides);
+        this.slides.splice(index + 1, 0, this.slides.splice(index, 1)[0]);
+        this.$emit('slides-updated', this.slides);
     }
 
     getSlideId(slide: SlideForBothLanguages): string {
-        return 'slide' + this.bothLanguageSlides.indexOf(slide);
+        return 'slide' + this.slides.indexOf(slide);
     }
 }
+
+// More accurate page height for mobile
+// Counts the URL bar for mobile browsers (e.g. iOS Safari) so the content doesn't vertically overshoot
+// and get covered by the URL bar when it's opened
+
+let vh = window.innerHeight * 0.01;
+document.documentElement.style.setProperty('--vh', `${vh}px`);
+
+window.addEventListener('resize', () => {
+    let vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
+});
 </script>
 
 <style lang="scss" scoped>
@@ -820,10 +907,20 @@ export default class SlideTocV extends Vue {
     -webkit-line-clamp: 2;
 }
 
-// Hard coded height :(
-// TODO: Change positioning of app components so we don't need to hardcode
+/* Hard coded height :(
+   TODO: Change positioning of app components so we don't need to hardcode
+   TODO: Change height here when any new changes cause overshoot
+ */
 .toc-list {
     height: calc(100vh - 177px);
+    height: calc(calc(var(--vh, 1vh) * 100) - 177px);
+    overflow-y: auto;
+}
+
+/* TODO: Change height here when any new changes cause overshoot */
+.toc-list-mobile {
+    height: calc(100vh - 123px);
+    height: calc(calc(var(--vh, 1vh) * 100) - 123px);
     overflow-y: auto;
 }
 

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -4,7 +4,7 @@ export interface StoryRampConfig {
     title: string;
     lang: string;
     introSlide: Intro;
-    slides: Slide[];
+    slides: (Slide | {})[];
     contextLink: string;
     contextLabel: string;
     tocOrientation: string;
@@ -143,7 +143,7 @@ export interface Slide {
     includeInToc?: boolean;
 }
 
-export interface SlideForBothLanguages {
+export interface MultiLanguageSlide {
     en: Slide | undefined;
     fr: Slide | undefined;
 }

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -143,6 +143,11 @@ export interface Slide {
     includeInToc?: boolean;
 }
 
+export interface SlideForBothLanguages {
+    en: Slide | undefined;
+    fr: Slide | undefined;
+}
+
 export enum PanelType {
     Text = 'text',
     Image = 'image',

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -32,6 +32,7 @@ editor.window.title,RAMP Storylines Editor,1,Éditeur de scénarios de la PCAR,1
 editor.configOverwrite,Are you sure you want to overwrite product '{uuid}'?,1,Êtes-vous sûr de vouloir remplacer le produit « {uuid} » ?,0
 editor.createProduct,Create New Storylines Product,1,Créer un nouveau produit de scénarios,1
 editor.loadProduct,Load Existing Storylines Product,1,Charger un produit Storylines existant,0
+editor.editMetadata,Edit Project Metadata,1,Modifier les métadonnées,1
 editor.chooseOption,What would you like to do?,1,Qu'aimeriez-vous faire?, 0
 editor.dashboard,Dashboard,1,Tableau de bord,0
 editor.previousProducts,Previously Edited Products,1,Produits précédemment édités,0
@@ -66,6 +67,8 @@ editor.editMetadata.versionHistory.actions,Actions,1,Actes,0
 editor.editMetadata.versionHistory.saveDate,Save Date,1,Enregistrer la date,0
 editor.editMetadata.retrievalAborted,Product retrieval manually aborted.,1,Récupération du produit interrompue manuellement.,0
 editor.done,Done,1,Fini,0
+editor.editProduct,Edit Existing Storylines Product,1,Modifier un produit de scénarios,1
+editor.editMetadata,Edit Project Metadata,1,Modifier les métadonnées,1
 editor.productDetails,Storylines product details,1,Détails du produit de scénarios,1
 editor.metadata.instructions,Fill in metadata details about your new Storylines product. Use the "Preview" button to see what your slides will look like.,1,Inscrivez les métadonnées de votre nouveau produit de scénario. Utilisez la fonction « Afficher l’aperçu » pour voir à quoi ressemblent vos diapositives.,1
 editor.uuid,UUID,1,UUID,0
@@ -163,8 +166,9 @@ editor.slideshow.label.edit,Edit existing item,1,Modifier un élément existant,
 editor.slideshow.label.type,Type,1,Type,0
 editor.slideshow.label.add,Add,1,Ajouter,1
 editor.slideshow.label.slideNumber,Slide Number,1,Numéro de diapositive,0
-editor.slides.title,SLIDES,1,DIAPOSITIVES,1
-editor.slides.addSlide,"New Slide",1,Nouvelle diapositive,1
+editor.slides.title,Intro title,1,Titre de l’introduction,1
+editor.slides.addSlide,"New blank slide",1,Nouvelle diapositive,0
+editor.slides.currentLangLabel,({lang} slide),1,(Diapositive en {lang}),0
 editor.slides.copyFromLang,"Copy slides from the other language",1,"Copier les diapositives de l’autre langue",1
 editor.slides.deleteSlide.confirm,"Are you sure you want to delete the slide {title}?",1,"Voulez-vous vraiment supprimer la diapositive {titre}?",1
 editor.slides.changeSlide.confirm,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",1,"Voulez-vous vraiment modifier la diapositive {titre}? Toute modification non enregistrée sera perdue.",1
@@ -175,6 +179,22 @@ editor.slides.copyAll,Copy all,1,Copier tout,1
 editor.slides.copyAll.confirm,Are you sure you want to copy all slides?,1,Êtes-vous sûr de vouloir copier toutes les diapositives ?,0
 editor.slides.copy,Copy,1,Copier,1
 editor.slides.slide,Slide,1,Diapositive,1
+editor.slides.toc.copySlide,Copy Slide,1,Copier la diapositive,0
+editor.slides.toc.deleteSlide,Delete Slide,1,Supprimer la diapositive,0
+editor.slides.toc.newENGSlideText,New ENG Slide *,1,Nouvelle diapositive ANG *,0
+editor.slides.toc.newFRSlideText,New FR Slide *,1,Novelle diapositive FR *,0
+editor.slides.toc.noENGslide,(No English Config),1,(Pas de configuration Anglais),0
+editor.slide.toc.noFRSlide,(No French Config),1,(Pas de configuration française),0
+editor.slides.toc.prevEngDNE,Cannot create this config if previous slide EN config does not exist.,1,Impossible de créer cette configuration si la configuration EN de la diapositive précédente n'existe pas.,0
+editor.slide.toc.prevFrDNE,Cannot create this config if previous slide FR config does not exist.,1,Impossible de créer cette configuration si la configuration FR de la diapositive précédente n'existe pas.,0
+editor.slides.toc.newBlankConfig,Create new blank config,1,Créer une nouvelle configuration vierge,0
+editor.slides.toc.newConfigFromFR,Copy config from French slide,1,Copier la configuration à partir de la diapositive française,0
+editor.slides.toc.newConfigFromEng,Copy config from English slide,1,Copier la configuration à partir de la diapositive anglais,0
+editor.slides.toc.moveSlideUp,Move slide up,1,Déplacer la diapositive vers le haut,0
+editor.slides.toc.moveSlideDown,Move slide down,1,Déplacer la diapositive vers le bas,0
+editor.slides.toc.isolatedUndefinedFRconfig,This is an isolated undefined config; ALL existing FR configs in below slides will be automatically moved up upon save & reload! Configs MUST be defined continuously without undefined breaks.,1,Il s'agit d'une configuration non définie isolée ; TOUTES les configurations FR existantes dans les diapositives ci-dessous seront automatiquement déplacées vers le haut lors de l'enregistrement et du rechargement ! Les configurations DOIVENT être définies en continu sans interruptions indéfinies.,0
+editor.slides.toc.isolatedUndefinedENGconfig,This is an isolated undefined config; ALL existing EN configs in below slides will be automatically moved up upon save & reload! Configs MUST be defined continuously without undefined breaks.,1,Il s'agit d'une configuration non définie isolée ; TOUTES les configurations EN existantes dans les diapositives ci-dessous seront automatiquement déplacées vers le haut lors de l'enregistrement et du rechargement ! Les configurations DOIVENT être définies en continu sans interruptions indéfinies.,0
+editor.slides.toc.deleteConfig,Delete Config (You can delete the last configs for each lang),1,Supprimer la configuration (vous pouvez supprimer les dernières configurations pour chaque langue),0
 editor.slides.previousSlide,Previous slide,1,Diapositive précédente,1
 editor.slides.nextSlide,Next slide,1,Diapositive suivante,1
 editor.slides.leftPanel,Left panel,1,Panneau de gauche,1
@@ -194,6 +214,7 @@ editor.slides.panel.body,Panel body,1,Corps du panneau,1
 editor.slides.panel.title,Panel title,1,Titre du panneau,1
 editor.slides.intro,Intro subtitle,1,Sous-titre de l’introduction,1
 editor.slides.title,Intro title,1,Titre de l’introduction,1
+editor.slides.slideHeader,SLIDES,1,DIAPOSITIVES,0
 editor.slides.includeInToc,Include in table of contents,1,Inclure dans la table des matières,0
 editor.slide.untitled,Untitled slide,1,Diapositive sans titre,0
 editor.slide.copy.success,Slide copied successfully!,1,Diapositive copiée avec succès !,0

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -166,11 +166,17 @@ editor.slideshow.label.edit,Edit existing item,1,Modifier un élément existant,
 editor.slideshow.label.type,Type,1,Type,0
 editor.slideshow.label.add,Add,1,Ajouter,1
 editor.slideshow.label.slideNumber,Slide Number,1,Numéro de diapositive,0
+editor.slides.overwrite.title,Save will overwrite undefined configs,1,L'enregistrement écrasera les configurations non définies,0
+editor.slides.overwrite.text,Saving will replace all undefined configs with blank configs. Are you sure you want to continue?,1,L'enregistrement remplacera toutes les configurations non définies par des diapositives vides. Êtes-vous sûr de vouloir continuer ?,0
+editor.slides.continue,Continue,1,Continuer,0
 editor.slides.title,Intro title,1,Titre de l’introduction,1
 editor.slides.addSlide,"New blank slide",1,Nouvelle diapositive,0
 editor.slides.currentLangLabel,({lang} slide),1,(Diapositive en {lang}),0
 editor.slides.copyFromLang,"Copy slides from the other language",1,"Copier les diapositives de l’autre langue",1
-editor.slides.deleteSlide.confirm,"Are you sure you want to delete the slide {title}?",1,"Voulez-vous vraiment supprimer la diapositive {titre}?",1
+editor.slides.deleteSlide.title,Delete slide {num}?,1,Supprimer la diapositive {num} ?,0
+editor.slides.deleteSlide.confirm,"Both English and French configurations will be deleted{title}.",1,"Les configurations anglaise et française seront supprimées{title}.",0
+editor.slides.deleteConfig.title,Delete {lang} config?,1,Supprimer la configuration {lang} ?,0
+editor.slides.deleteConfig.confirm,"Are you sure you want to delete this config {title}?",1,Êtes-vous sûr de vouloir supprimer cette configuration {title} ?,0
 editor.slides.changeSlide.confirm,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",1,"Voulez-vous vraiment modifier la diapositive {titre}? Toute modification non enregistrée sera perdue.",1
 editor.slides.makeFull,Make the right panel the full slide,1,Mettre la diapositive complète dans le panneau de droite,1
 editor.slides.centerPanel,Center panel content,1,Contenu de la diapositive centrale,0
@@ -185,6 +191,8 @@ editor.slides.toc.newENGSlideText,New ENG Slide *,1,Nouvelle diapositive ANG *,0
 editor.slides.toc.newFRSlideText,New FR Slide *,1,Novelle diapositive FR *,0
 editor.slides.toc.noENGslide,(No English Config),1,(Pas de configuration Anglais),0
 editor.slide.toc.noFRSlide,(No French Config),1,(Pas de configuration française),0
+editor.slide.toc.untitledENG,(Untitled English slide),1,(Diapositive anglaise sans titre),0
+editor.slide.toc.untitledFR,(Untitled French slide),1,(Diapositive française sans titre),0
 editor.slides.toc.prevEngDNE,Cannot create this config if previous slide EN config does not exist.,1,Impossible de créer cette configuration si la configuration EN de la diapositive précédente n'existe pas.,0
 editor.slide.toc.prevFrDNE,Cannot create this config if previous slide FR config does not exist.,1,Impossible de créer cette configuration si la configuration FR de la diapositive précédente n'existe pas.,0
 editor.slides.toc.newBlankConfig,Create new blank config,1,Créer une nouvelle configuration vierge,0

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -68,7 +68,7 @@ editor.editMetadata.versionHistory.saveDate,Save Date,1,Enregistrer la date,0
 editor.editMetadata.retrievalAborted,Product retrieval manually aborted.,1,Récupération du produit interrompue manuellement.,0
 editor.done,Done,1,Fini,0
 editor.editProduct,Edit Existing Storylines Product,1,Modifier un produit de scénarios,1
-editor.editMetadata,Edit Project Metadata,1,Modifier les métadonnées,1
+editor.editMetadata,Edit Project Metadata,1,Mod. les métadonnées,1
 editor.productDetails,Storylines product details,1,Détails du produit de scénarios,1
 editor.metadata.instructions,Fill in metadata details about your new Storylines product. Use the "Preview" button to see what your slides will look like.,1,Inscrivez les métadonnées de votre nouveau produit de scénario. Utilisez la fonction « Afficher l’aperçu » pour voir à quoi ressemblent vos diapositives.,1
 editor.uuid,UUID,1,UUID,0
@@ -166,8 +166,6 @@ editor.slideshow.label.edit,Edit existing item,1,Modifier un élément existant,
 editor.slideshow.label.type,Type,1,Type,0
 editor.slideshow.label.add,Add,1,Ajouter,1
 editor.slideshow.label.slideNumber,Slide Number,1,Numéro de diapositive,0
-editor.slides.overwrite.title,Save will overwrite undefined configs,1,L'enregistrement écrasera les configurations non définies,0
-editor.slides.overwrite.text,Saving will replace all undefined configs with blank configs. Are you sure you want to continue?,1,L'enregistrement remplacera toutes les configurations non définies par des diapositives vides. Êtes-vous sûr de vouloir continuer ?,0
 editor.slides.continue,Continue,1,Continuer,0
 editor.slides.title,Intro title,1,Titre de l’introduction,1
 editor.slides.addSlide,"New blank slide",1,Nouvelle diapositive,0
@@ -175,8 +173,8 @@ editor.slides.currentLangLabel,({lang} slide),1,(Diapositive en {lang}),0
 editor.slides.copyFromLang,"Copy slides from the other language",1,"Copier les diapositives de l’autre langue",1
 editor.slides.deleteSlide.title,Delete slide {num}?,1,Supprimer la diapositive {num} ?,0
 editor.slides.deleteSlide.confirm,"Both English and French configurations will be deleted{title}.",1,"Les configurations anglaise et française seront supprimées{title}.",0
-editor.slides.deleteConfig.title,Delete {lang} config?,1,Supprimer la configuration {lang} ?,0
-editor.slides.deleteConfig.confirm,"Are you sure you want to delete this config {title}?",1,Êtes-vous sûr de vouloir supprimer cette configuration {title} ?,0
+editor.slides.deleteConfig.title,Slide {num} {lang} config will be cleared,1,La configuration de la diapositive {num} {lang} sera effacée,0
+editor.slides.deleteConfig.confirm,"This will replace the config '{title}' with a blank config.",1,Cela remplacera la configuration '{title}' par une configuration vide.,0
 editor.slides.changeSlide.confirm,"Are you sure you want to change the slide {title}? All unsaved progress will be lost.",1,"Voulez-vous vraiment modifier la diapositive {titre}? Toute modification non enregistrée sera perdue.",1
 editor.slides.makeFull,Make the right panel the full slide,1,Mettre la diapositive complète dans le panneau de droite,1
 editor.slides.centerPanel,Center panel content,1,Contenu de la diapositive centrale,0
@@ -185,10 +183,15 @@ editor.slides.copyAll,Copy all,1,Copier tout,1
 editor.slides.copyAll.confirm,Are you sure you want to copy all slides?,1,Êtes-vous sûr de vouloir copier toutes les diapositives ?,0
 editor.slides.copy,Copy,1,Copier,1
 editor.slides.slide,Slide,1,Diapositive,1
+editor.slides.toc.dropdownTooltip,Options,1,Options,0
+editor.slides.toc.dropdown.copy,Copy from other config,1,Copier à partir d'une autre config.,0
+editor.slides.toc.dropdown.clear,Clear content,1,Contenu clair,0
+editor.slides.toc.copySlide.warning.title,Copy will delete existing contents,1,La copie supprimera le contenu existant,0
+editor.slides.toc.copySlide.warning.message,Slide {num}'s {oldLang} config ('{oldTitle}') will be replaced with the {newLang} config ('{newTitle}'). All existing contents will be lost.,1,La configuration {oldLang} de la diapositive {num} ('{oldTitle}') sera remplacée par la configuration {newLang} ('{newTitle}'). Tout le contenu existant sera perdu.,0
 editor.slides.toc.copySlide,Copy Slide,1,Copier la diapositive,0
 editor.slides.toc.deleteSlide,Delete Slide,1,Supprimer la diapositive,0
-editor.slides.toc.newENGSlideText,New ENG Slide *,1,Nouvelle diapositive ANG *,0
-editor.slides.toc.newFRSlideText,New FR Slide *,1,Novelle diapositive FR *,0
+editor.slides.toc.newENGSlideText,New EN Slide*,1,Nouvelle diapositive AN*,0
+editor.slides.toc.newFRSlideText,New FR Slide*,1,Nouvelle diapositive FR*,0
 editor.slides.toc.noENGslide,(No English Config),1,(Pas de configuration Anglais),0
 editor.slide.toc.noFRSlide,(No French Config),1,(Pas de configuration française),0
 editor.slide.toc.untitledENG,(Untitled English slide),1,(Diapositive anglaise sans titre),0


### PR DESCRIPTION
### Related Item(s)
Issues:
#401 
#402 

### Changes
- [FEATURE] Implements complete redesign and refactor of ToC, based on designs given by UX team.
    - Both language configs are displayed simultaneously, removing the need to swap configs. Creating a new slide creates two new configs, in English and French. 
    - New slide item design, reducing clutter. Each title can take up to two lines now, meaning most titles are fully visible immediately, without tooltips.
    - ToC will now smooth-scroll automatically to the new slide when you create one. It will also smooth scroll to a copied slide until it's in the middle of the ToC, to give a little indicator that something happened.
    - UI element redesign (e.g. buttons)
    - Indicators for slides with a missing config (e.g. a slide doesn't have a FR config). Code handles all edge cases (that I could think of) involving a slide missing one of its language configs. Slides without a config can copy the config of its slide neighbour (e.g. FR version of Slide 12, if it has no config, can copy ENG config of slide 12 if it exists) OR create a new blank config.
    - Slides allow for deleting an individual lang config, as long as its the last of its lang configs in the list (e.g. you can delete an ENG config if its the last ENG config, i.e. there are no ENG configs in any slide below it).
    - ToC should no longer overflow the viewport height, requiring two scrollbars to be used (main page + ToC-specific) to scroll it.
    - A separate ToC is created for mobile sizes. When the viewport is small enough, the ToC will be auto-hidden. Clicking the new hamburger menu up top will open a new mobile ToC drawer, featuring larger buttons and more visual dividers to make it better for touch devices. To access an item's tooltips, you simply long-press it to simulate a hover. Dragging slides to reorder is disabled so users can scroll properly.
- [FEATURE] Implements new preview button, allowing user to select which language config they want to preview.
- [REFACTOR] Complete refactor of code involving slides/configs, to handle new ToC.

### Notes
Implementing the new ToC required a change in how the `slides` object worked. It's now called `bothLanguageSlides`, and each contains two Slide objects, one for each config, as so:
```
export interface SlideForBothLanguages {
    en: Slide | undefined;
    fr: Slide | undefined;
}
```

**App layout**: I've modified the layout so the whole app no longer overshoots the page height (and requires a scrollbar); scrolling is now done only for individual panes (sidebar or slide editor+feedback), when they independently overflow. However, my current solution hardcodes the page height based on the existing elements; it works for different viewport sizes, but will break if there's ANY added/removed page elements in the future that increases/decreases the size given for the ToC or the slide editor half of the page. A future app layout refactor should probably find a better way to do this. 

### TODO
- [x] <del>Mobile ToC (this one doesn't shrink)</del>
- [x] <del>Comment main code</del>

### Testing
Steps:
1. Open the product `00000000-0000-0000-0000-000000000000`.
2. View the new ToC. Test each of the new ToC features listed above, in both the English and French versions of the page.
3. Use the new Preview dropdown to preview both the English and French configs. They should both still show even unsaved changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/409)
<!-- Reviewable:end -->
