### PR TITLE
Prevent removal of source content on panel type swap

### DIFF
--- a/src/components/image-editor.vue
+++ b/src/components/image-editor.vue
@@ -154,7 +154,6 @@ export default class ImageEditorV extends Vue {
                 // Check if the config file exists in the ZIP folder first.
                 const assetSrc = `${image.src.substring(image.src.indexOf('/') + 1)}`;
                 const filename = image.src.replace(/^.*[\\/]/, '');
-
                 const assetFile = this.configFileStructure.zip.file(assetSrc);
                 if (assetFile) {
                     this.imagePreviewPromises.push(

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -489,15 +489,17 @@ export default class SlideEditorV extends Vue {
             }
         };
 
-        // Before swapping panel type, update sources from the to-be-deleted config.
-        this.currentSlide.panel.forEach((panel: BasePanel) => this.removeSourceCounts(panel));
-
         // When switching to a dynamic panel, remove the secondary panel.
         if (newType === 'dynamic') {
+            // Remove source content of both panels
+            this.currentSlide.panel.forEach((panel: BasePanel) => this.removeSourceCounts(panel));
             this.panelIndex = 0;
             this.currentSlide['panel'] = [startingConfig[newType as keyof DefaultConfigs]];
             this.dynamicSelected = true;
         } else {
+            // Remove source content of panel having its type swapped
+            this.removeSourceCounts(this.currentSlide.panel[this.panelIndex]);
+
             // Switching panel type when dynamic panels are not involved.
             this.currentSlide.panel[this.panelIndex] = startingConfig[newType as keyof DefaultConfigs];
         }

--- a/src/components/video-editor.vue
+++ b/src/components/video-editor.vue
@@ -280,10 +280,7 @@ export default class VideoEditorV extends Vue {
 
     onVideoEdited(): void {
         this.edited = true;
-        this.$emit(
-            'slide-edit',
-            (this.videoPreview?.videoType || this.videoPreview?.title?.length) ? true : false
-        );
+        this.$emit('slide-edit', this.videoPreview?.videoType || this.videoPreview?.title?.length ? true : false);
     }
 }
 </script>


### PR DESCRIPTION
### Related Item(s)
#390

### Changes
- Prevent the source content of a panel from being removed from the config when the type of the opposing panel (within the same slide) is swapped

### Notes
- This only applies for slides with both a left and right panel
- When a panel is switched to a dynamic panel, the source content of both panels will be removed from the config. This is the same behavior as before

### Testing
Steps:
1. Open any storylines product
2. Open a slide that has a panel with multimedia content
3. Go to the opposing panel and switch the panel type
4. Go back to the original panel, and observe that its multimedia content is still there

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/410)
<!-- Reviewable:end -->
