### PR TITLE
Render style tags as plain text in md editor

### DIFF
--- a/src/components/text-editor.vue
+++ b/src/components/text-editor.vue
@@ -8,6 +8,8 @@
             height="400px"
             left-toolbar="undo redo clear | h bold italic strikethrough quote subsuper | ul ol table hr | addLink image code | save"
             :toolbar="toolbar"
+            @change="escapeStyleTags"
+            ref="textEditor"
         ></v-md-editor>
     </div>
 </template>
@@ -115,6 +117,19 @@ export default class TextEditorV extends Vue {
             this.panel.customStyles += 'text-align: left !important;';
         } else if (!this.centerSlide && this.dynamicSelected) {
             this.panel.customStyles = (this.panel.customStyles || '').replace('text-align: left !important;', '');
+        }
+    }
+
+    escapeStyleTags(text: string, html: string): void {
+        const styleRegex = /<\/?\s*style\s*\/?>/gi;
+        if (this.$refs.textEditor?.text){
+            const regexMatch = text.match(styleRegex);
+            if (regexMatch) {
+                const escapedText = text.replaceAll(styleRegex, (match) => {
+                    return match.split(' ').join('').replace('<', '‹').replace('>', '›').toLowerCase();
+                });
+                this.$refs.textEditor.text = escapedText;
+            }
         }
     }
 }


### PR DESCRIPTION
### Related Item(s)
#423

### Changes
- Render style tags as plain text within the `v-md-editor` component, by replacing < and > with ‹ and › (respectively)
- This was done so that any pair of opening and closing style tags don't get interpreted as a style sheet by the rendering function of the  `v-md-editor` component

### Testing
Steps:
1. Open any product
2. Open a slide containing a text panel
3. Within the editor of the text panel, try typing variations of a `<style>` tag (ex. with a forward slash at front/end, with whitespace in between, etc.)
4. Observe that all variations of a `<style>` tag now have  < and > replaced with ‹ and › (respectively)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/429)
<!-- Reviewable:end -->
