### PR TITLE
Limit video upload size

### DIFF
--- a/src/components/video-editor.vue
+++ b/src/components/video-editor.vue
@@ -31,11 +31,12 @@
                 </span>
                 <span class="align-middle inline-block">
                     <span>
-                        <div>{{ $t('editor.video.label.drag') }}</div>
+                        <div class="text-center">{{ $t('editor.video.label.drag') }}</div>
                         <div>
                             {{ $t('editor.label.or') }}
                             <span class="text-blue-700 font-bold">{{ $t('editor.label.browse') }}</span>
                             {{ $t('editor.label.upload') }}
+                            {{ ' ' + $t('editor.video.label.sizeLimit', { size: fileSizeLimit }) }}
                         </div>
                     </span>
                     <input ref="videoFileInput" type="file" class="cursor-pointer" @change="onFileChange" />
@@ -116,6 +117,7 @@
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import { ConfigFileStructure, SourceCounts, VideoFile, VideoPanel } from '@/definitions';
 
+import Message from 'vue-m-message';
 import draggable from 'vuedraggable';
 import VideoPreviewV from './helpers/video-preview.vue';
 
@@ -137,6 +139,7 @@ export default class VideoEditorV extends Vue {
     edited = false;
 
     fileType = '';
+    fileSizeLimit = 75; // File size limit in MB
     videoPreviewLoading = false;
     videoPreviewPromise = undefined as Promise<VideoFile> | undefined;
     videoPreview = {} as VideoFile | Record<string, never>;
@@ -218,6 +221,17 @@ export default class VideoEditorV extends Vue {
 
     onFileChange(e: Event): void {
         const file = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
+
+        // Block files which are too big
+        if (file.size > this.fileSizeLimit * 1024 * 1024) {
+            Message.error(
+                this.$t('editor.video.sizeExceeded') +
+                    ' ' +
+                    this.$t('editor.video.label.sizeLimit', { size: this.fileSizeLimit })
+            );
+            return;
+        }
+
         this.addUploadedFile(file, 'src');
         this.onVideoEdited();
     }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -145,9 +145,11 @@ editor.image.slideshowCaption,Slideshow Caption,1,Légende du diaporama,1
 editor.image.loadingError,An error occurred when trying to load image,1,Une erreur est survenue lors du chargement de l’image.,1
 editor.video.title,Video Title,1,Titre de la vidéo,1
 editor.video.label.drag,Drag your video file here,1,Glissez votre fichier vidéo ici,1
+editor.video.label.sizeLimit,({size}MB limit),1,(limite {size}MB),0
 editor.video.label.captions,Video Captions,1,Sous-titres,1
 editor.video.label.transcript,Video Transcript,1,Transcription,1
 editor.video.label.upload,Upload,1,Télécharger,1
+editor.video.sizeExceeded,File too big!,1,Fichier trop gros !,0
 editor.video.label.linkSupport,Supports YouTube links (regular and shortened) as well as direct links to mp4 videos.,1,Prend en charge les liens YouTube (réguliers et raccourcis) ainsi que les liens directs vers des vidéos mp4.,0
 editor.video.delete,Delete Video,1,Supprimer la vidéo,1
 editor.video.pasteUrl,Paste the URL to a video,1,Collez l'url d'une vidéo,0


### PR DESCRIPTION
### Related Item(s)
Issue #417 

### Changes
- [FEATURE] Prevents videos larger than 75MB from being uploaded in video panels, and shows an error when attempting to upload them.

### Testing
Steps:
1. Go to any product (e.g. `00000000-0000-0000-0000-000000000000`).
2. Go to any video panel.
3. Try to upload a video greater than 75MB. It will fail and show a warning.
4. Try to upload a video less than 75MB. It will upload as expected.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/430)
<!-- Reviewable:end -->
