### PR TITLE
Slackbot: Escape special characters

### DIFF
--- a/.github/slack-bot.py
+++ b/.github/slack-bot.py
@@ -9,7 +9,8 @@ pr_labels = json.loads(pr_labels_json)
 
 # Summarization (example model, could be adjusted)
 summarizer = pipeline('summarization', model='tuner007/pegasus_summarizer')
-neutral_summary = summarizer(pr_body, max_length=200, min_length=25, do_sample=False)[0]['summary_text']
+# Escape double quotes and literal backslashes
+neutral_summary = summarizer(pr_body, max_length=200, min_length=25, do_sample=False)[0]['summary_text'].replace('"', '\\"')
 
 # PR label types with associated metadata
 pr_label_types = {


### PR DESCRIPTION
### Changes
- [FIX] Escapes double quotes (`"`) and literal backslash characters (`\`) within the slackbot summary to prevent the string and the bot from breaking.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/465)
<!-- Reviewable:end -->
