### PR TITLE
Add translations for panel types

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -1424,7 +1424,7 @@ export default class MetadataEditorV extends Vue {
                             })
                             .catch((error: any) => console.log(error.response || error));
                     } else {
-                        Message.success('Successfully saved changes!');
+                        Message.success(this.$t('editor.editMetadata.message.successfulSave'));
                         // padding to prevent save button from being clicked rapidly
                         setTimeout(() => {
                             this.saving = false;

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -286,7 +286,7 @@
                                 :key="thing"
                                 :value="thing"
                             >
-                                {{ thing }}
+                                {{ $t(`editor.slide.panel.type.${thing}`) }}
                             </option>
                         </select>
                     </div>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -240,6 +240,13 @@ editor.slides.content,Content,1,Contenu,1
 editor.slides.select,Please select a slide to edit,1,Veuillez sélectionner une diapositive à modifier,1
 editor.slides.panel.body,Panel body,1,Corps du panneau,1
 editor.slides.panel.title,Panel title,1,Titre du panneau,1
+editor.slide.panel.type.text,Text,1,Texte,0
+editor.slide.panel.type.image,Image,1,Image,0
+editor.slide.panel.type.slideshow,Slideshow,1,Diaporama,0
+editor.slide.panel.type.chart,Chart,1,Graphique,0
+editor.slide.panel.type.map,Map,1,Carte,0
+editor.slide.panel.type.video,Video,1,Vidéo,0
+editor.slide.panel.type.dynamic,Dynamic,1,Dynamique,0
 editor.slides.intro,Intro subtitle,1,Sous-titre de l’introduction,1
 editor.slides.title,Intro title,1,Titre de l’introduction,1
 editor.slides.slideHeader,SLIDES,1,DIAPOSITIVES,0
@@ -248,8 +255,8 @@ editor.slide.untitled,Untitled slide,1,Diapositive sans titre,0
 editor.slide.copy.success,Slide copied successfully!,1,Diapositive copiée avec succès !,0
 editor.tocOrientation,Table of Contents Orientation,1,Orientation de la table des matières,0
 editor.tocOrientation.info,The table of contents orientation will be set to vertical in mobile view.,1,L'orientation de la table des matières sera définie sur verticale en vue mobile.,0
-editor.tocOrientation.vertical,Vertical,1,Vertical,0
-editor.tocOrientation.horizontal,Horizontal,1,Horizontal,0
+editor.tocOrientation.vertical,Vertical,1,Verticale,0
+editor.tocOrientation.horizontal,Horizontal,1,Horizontale,0
 editor.returnTop,Include return to top navigation,1,Inclure le retour en haut de la navigation,0
 editor.landing.greeting,Hello,1,Bonjour,1
 editor.month.january,January,1,Janvier,0


### PR DESCRIPTION
### Related Item(s)
#440

### Changes
- Add translations for panel types, used for the panel type dropdown
- Add correct translations for 'Vertical' and 'Horizontal'
- Use appropriate translated text for successful save message

### Testing
Steps:
1. Open `editor-metadata` in French
2. Load an existing product
3. Click the `Mod. les métadonnées` button to edit metadata
4. Click the `Orientation de la table des matières` dropdown, and observe the correct translations for 'Vertical' and 'Horizontal' 
5. Load the product into `editor-main`
6. Go to a slide and open the panel type dropdown for one of its panels
7. Observe that the panel types are listed in French
8. Switch to English and repeat.
9. Observe that the panel types are listed in English

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/469)
<!-- Reviewable:end -->
