### PR TITLE
Disable right only toggle for dynamic slide, Remove uuid spellcheck

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -97,6 +97,7 @@
                                         placement: 'top-end',
                                         touch: false
                                     }"
+                                    spellcheck="false"
                                 />
                                 <button
                                     @click="renameProduct"
@@ -157,6 +158,7 @@
                                                 placement: 'top-end',
                                                 touch: false
                                             }"
+                                            spellcheck="false"
                                         />
                                         <!-- Previous storylines (?) dropdown -->
                                         <div

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -44,13 +44,16 @@
                     <!-- Slide options -->
                     <div class="flex flex-col lg:flex-row mt-3 gap-y-3 gap-x-7 flex-wrap">
                         <!-- Make the current panel the full slide -->
-                        <div class="flex flex-row items-center">
+                        <div
+                            class="flex flex-row items-center"
+                            v-if="determineEditorType(currentSlide.panel[0]) !== 'dynamic'"
+                        >
                             <input
                                 type="checkbox"
                                 id="fullSlide"
                                 class="rounded-none cursor-pointer w-4 h-4"
                                 v-model="onePanelOnly"
-                                :disabled="determineEditorType(currentSlide.panel[panelIndex]) === 'dynamic'"
+                                :disabled="onePanelOnly && determineEditorType(currentSlide.panel[0]) === 'dynamic'"
                                 @change.stop="
                                     () => {
                                         // if statement doesn't work properly (?), so had to use ternary
@@ -489,13 +492,10 @@ export default class SlideEditorV extends Vue {
     @Watch('currentSlide', { deep: true })
     onSlideChange(): void {
         this.langTranslate = this.$t(`editor.lang.${this.lang}`);
-        this.currentSlide ? (this.onePanelOnly = this.currentSlide.panel.length === 1) : false;
         this.centerPanel = this.currentSlide.centerPanel ?? false;
         this.centerSlide = this.currentSlide.centerSlide ?? false;
         this.includeInToc = this.currentSlide.includeInToc ?? true;
-        this.onePanelOnly =
-            this.currentSlide.rightOnly ??
-            this.determineEditorType(this.currentSlide.panel[this.panelIndex]) === 'dynamic';
+        this.onePanelOnly = this.currentSlide?.rightOnly || this.currentSlide?.panel.length === 1;
     }
 
     /**
@@ -579,6 +579,8 @@ export default class SlideEditorV extends Vue {
             // Switching panel type when dynamic panels are not involved.
             this.currentSlide.panel[this.panelIndex] = startingConfig[newType as keyof DefaultConfigs];
         }
+
+        this.currentSlide.rightOnly = this.currentSlide.panel.length === 1;
     }
 
     removeSourceCounts(panel: BasePanel): void {
@@ -721,7 +723,7 @@ export default class SlideEditorV extends Vue {
                     ''
                 );
             }
-        } else if (this.onePanelOnly) {
+        } else if (this.onePanelOnly || this.currentSlide.panel.length === 1) {
             if (this.centerSlide) {
                 this.currentSlide.panel[0].customStyles = 'text-align: center;';
             } else {


### PR DESCRIPTION
### Related Item(s)
#441 
#433

### Changes
- Disable the `Make the right panel the full slide` toggle for dynamic slides (i.e. for slides with only one panel)
- Disable spellcheck for the uuid entry field

### Testing
Steps:
#433
1. From the dashboard click `Load Existing Storylines Product`
2. Enter random text into the uuid field
3. Notice there is no red underline
4. Load an existing product
5. Click the change uuid link
6. Enter random text into the uuid field
7. Notice there is no red underline

#441
1. Load a product into editor-main
2. Create a new slide
3. Create a dynamic panel within this slide
4. Observe that the  `Make the right panel the full slide` toggle is disabled
5. Change the panel type, and observe that the toggle is still disabled (since the slide only contains 1 panel)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/474)
<!-- Reviewable:end -->
