### PR TITLE
Add modified property to video panel schema

### DIFF
--- a/StorylinesSchema.json
+++ b/StorylinesSchema.json
@@ -281,6 +281,10 @@
                 "type": {
                     "type": "string",
                     "enum": ["video"]
+                }, 
+                "modified": {
+                    "type": "boolean",
+                    "description": "An optional tag that specifies whether the panel has been modified from its default configuration"
                 }
             },
             "required": ["src", "type"]

--- a/public/StorylinesSlideSchema.json
+++ b/public/StorylinesSlideSchema.json
@@ -358,6 +358,10 @@
                 "customStyles": {
                     "type": "string",
                     "description": "Additional CSS styles to apply to the panel."
+                }, 
+                "modified": {
+                    "type": "boolean",
+                    "description": "An optional tag that specifies whether the panel has been modified from its default configuration" 
                 }
             },
             "additionalProperties": false,


### PR DESCRIPTION
### Related Item(s)
#480

### Changes
- Added `modified` property to video panel schema in order to avoid a schema error

### Notes
The `modified` property is being added to video panels due to [this line](https://github.com/ramp4-pcar4/storylines-editor/blob/d8f60c909c80532e2a1a1cca30c195bfc10187bf/src/components/slide-editor.vue#L318)

### Testing
Steps:
1. Open a video panel
2. Upload a video
3. Go to the advanced editor
4. There should be no schema errors

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/483)
<!-- Reviewable:end -->
