### PR TITLE
Set max width for md editor tooltip, Add untitled key, Add logo alt text to metadata

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -923,6 +923,7 @@ export default class MetadataEditorV extends Vue {
         // Generate a new configuration file and populate required fields.
         this.configs[this.configLang] = this.configHelper();
         const config = this.configs[this.configLang] as StoryRampConfig;
+        config.introSlide.logo.altText = this.metadata.logoAltText ?? '';
 
         // Set the source of the product logo
         if (!this.metadata.logoName) {

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -1,5 +1,5 @@
 <template>
-    <div class="p-5">
+    <div id="slideEditor" class="p-5">
         <div v-if="!!currentSlide">
             <div class="flex">
                 <div class="flex flex-col w-full">

--- a/src/components/text-editor.vue
+++ b/src/components/text-editor.vue
@@ -158,12 +158,51 @@ export default class TextEditorV extends Vue {
         }
     };
 
+    toolbarTooltipAdjust(toggle): void {
+        const slideEditor = document.querySelector('#slideEditor');
+        const scrollbarVisible =
+            slideEditor.scrollHeight > slideEditor.clientHeight ||
+            document.documentElement.scrollHeight > document.documentElement.clientHeight;
+        const toggleToRightBorder = slideEditor.getBoundingClientRect().right - toggle.getBoundingClientRect().right;
+        const scrollbarOffset = document.documentElement.clientWidth * 1.3 * 0.01;
+        // limit the right position of the toggle's tooltip if the toggle is sufficiently close to the right
+        // border of the screen (only when scrollbar is visible)
+        if (scrollbarVisible && toggleToRightBorder <= 90) {
+            toggle.children[0].style.right = `${Math.max(
+                Math.min(-40, -toggleToRightBorder + scrollbarOffset),
+                -65
+            )}px`;
+        } else {
+            toggle.children[0].style.right = `${-toggleToRightBorder}px`;
+        }
+    }
+
     mounted(): void {
         if (this.centerSlide && this.dynamicSelected) {
             this.panel.customStyles += 'text-align: left !important;';
         } else if (!this.centerSlide && this.dynamicSelected) {
             this.panel.customStyles = (this.panel.customStyles || '').replace('text-align: left !important;', '');
         }
+
+        const rightToolbarToggles = Array.from(
+            document.querySelectorAll('.v-md-editor__toolbar-right > .v-md-editor__toolbar-item')
+        );
+        rightToolbarToggles.forEach((toggle) => {
+            toggle.addEventListener('mouseover', () => {
+                this.toolbarTooltipAdjust(toggle);
+            });
+        });
+    }
+
+    unmounted(): void {
+        const rightToolbarToggles = Array.from(
+            document.querySelectorAll('.v-md-editor__toolbar-right > .v-md-editor__toolbar-item')
+        );
+        rightToolbarToggles.forEach((toggle) => {
+            toggle.removeEventListener('mouseover', () => {
+                this.toolbarTooltipAdjust(toggle);
+            });
+        });
     }
 }
 </script>
@@ -174,5 +213,21 @@ label {
 }
 :deep(.v-md-icon-link::before) {
     content: '\1F517';
+}
+:deep(.v-md-editor__tooltip) {
+    text-wrap: wrap;
+    overflow-wrap: break-word;
+}
+
+:deep(.v-md-editor__toolbar-right > .v-md-editor__toolbar-item > .v-md-editor__tooltip) {
+    max-width: 80px;
+}
+
+:deep(.v-md-editor__toolbar-right) {
+    padding-right: 20px;
+}
+
+:deep(.v-md-icon-preview) {
+    margin-left: 4px;
 }
 </style>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -2,6 +2,7 @@ key,enValue,enValid,frValue,frValid
 chapters.title,Chapters,1,Chapitres,1
 chapters.return,Return to top,1,Retournez en haut,1
 chapters.menu,Toggle menu,1,Menu à bascule,1
+chapters.untitled,Untitled Slide,1,Diapositive sans titre,0
 scrollguard.desc,Use ctrl + scroll to zoom the map,1,Utilisez les touches Ctrl et + pour faire un zoom de la carte,1
 story.window.title,RAMP Storylines,1,Scénarios de la PCAR,1
 story.date,Date modified:,1,Date de modification:,1


### PR DESCRIPTION
### Related Item(s)
#452 
#443 
#438

### Changes
- Set a max width of `90px` for tooltips within the `v-md-editor` component, so that a horizontal scrollbar doesn't appear when the tooltip exits the screen
- Add the `chapters.untitled` key into `lang.csv`, so that the appropriate text appears in the ToC for slides without a title
- Include the logo alt text within the metadata upon creating a new object

### Testing

Steps (#452):
1. Open a text panel
2. Decrease the screen width
3. Hover over the buttons on the right side of the editor
4. Observe that the horizontal bar doesn't appear

Steps (#443):
1. Remove the titles from one/more slide
2. Switch the ToC to horizontal
3. Open the preview
4. Observe that the title of each slide without a title (within the ToC) is 'Untitled Slide'
5. Switch to French and observe the corresponding French text in the ToC

Steps (#438):
1. Create a new product
2. Upload a logo and set the alt text
3. Click Next to proceed to the main editor page
4. Click Edit Product Metadata
6. The alt text should be visible

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/485)
<!-- Reviewable:end -->
