### PR TITLE
re-implement rename feature

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -59,12 +59,12 @@
                             <button
                                 class="ml-10 sub-link inline-block select-none text-sm"
                                 @click="
-                                    renaming = !renaming;
+                                    renameMode = !renameMode;
                                     changeUuid = '';
                                     warning = warning === 'rename' ? 'none' : warning;
                                 "
                             >
-                                {{ renaming ? $t('editor.cancel') : $t('editor.changeUuid') }}
+                                {{ renameMode ? $t('editor.cancel') : $t('editor.changeUuid') }}
                             </button>
                         </span>
 
@@ -76,8 +76,8 @@
                         <div class="pb-5 pt-1">
                             <!-- UUID rename inputs -->
                             <!-- Shows up after you load a UUID and click the 'rename uuid' button (not exact text) -->
-                            <div v-if="renaming" class="flex flex-row items-center w-full md:w-3/4">
-                                <label for="rename-input" class="mr-6 ml-3"> {{ $t('editor.uuid.new') }}: </label>
+                            <div v-if="renameMode" class="flex flex-row items-center w-full md:w-3/4">
+                                <label for="rename-input" class="mr-6"> {{ $t('editor.uuid.new') }}: </label>
                                 <input
                                     id="rename-input"
                                     class="editor-input mt-0 flex-2"
@@ -102,13 +102,18 @@
                                     @click="renameProduct"
                                     class="editor-button editor-forms-button bg-black text-white ml-3 mr-0"
                                     :class="{ 'input-error': error }"
-                                    :disabled="changeUuid.length === 0 || checkingUuid || warning === 'rename'"
+                                    :disabled="
+                                        changeUuid.length === 0 ||
+                                        checkingUuid ||
+                                        processingRename ||
+                                        warning === 'rename'
+                                    "
                                 >
                                     {{ $t('editor.rename') }}
                                 </button>
 
                                 <!-- If config is loading, display a small spinner. -->
-                                <div class="inline-flex align-middle mb-1" v-if="checkingUuid">
+                                <div class="inline-flex align-middle mb-1" v-if="checkingUuid || processingRename">
                                     <spinner size="24px" color="#009cd1" class="mx-2 my-auto"></spinner>
                                 </div>
                             </div>
@@ -144,7 +149,7 @@
                                             :class="{
                                                 'input-error': error || !reqFields.uuid,
                                                 'input-success': loadStatus === 'loaded',
-                                                'input-warning': warning !== 'none' || (!renaming && renamed)
+                                                'input-warning': warning !== 'none'
                                             }"
                                             v-tippy="{
                                                 content: $t('editor.editMetadata.input.tooltip'),
@@ -245,41 +250,6 @@
                                         <span class="inline-block select-none text-sm">{{
                                             $t(`editor.warning.${warning}`)
                                         }}</span>
-                                    </div>
-                                    <br />
-                                </span>
-
-                                <!-- Warning displayed if product is being renamed. -->
-                                <span
-                                    v-if="!renaming && renamed"
-                                    class="flex flex-row items-center text-accent-dark-orange rounded p-1"
-                                >
-                                    <!-- <div class="editor-label"></div> -->
-                                    <span class="align-middle inline-block mr-1 fill-current">
-                                        <svg
-                                            clip-rule="evenodd"
-                                            fill-rule="evenodd"
-                                            stroke-linejoin="round"
-                                            stroke-miterlimit="2"
-                                            viewBox="0 0 24 24"
-                                            width="18"
-                                            height="18"
-                                            xmlns="http://www.w3.org/2000/svg"
-                                        >
-                                            <path
-                                                d="m2.095 19.886 9.248-16.5c.133-.237.384-.384.657-.384.272 0 .524.147.656.384l9.248 16.5c.064.115.096.241.096.367 0 .385-.309.749-.752.749h-18.496c-.44 0-.752-.36-.752-.749 0-.126.031-.252.095-.367zm9.907-6.881c-.414 0-.75.336-.75.75v3.5c0 .414.336.75.75.75s.75-.336.75-.75v-3.5c0-.414-.336-.75-.75-.75zm-.002-3c-.552 0-1 .448-1 1s.448 1 1 1 1-.448 1-1-.448-1-1-1z"
-                                                fill-rule="nonzero"
-                                            />
-                                        </svg>
-                                    </span>
-                                    <div>
-                                        <span class="inline-block select-none text-sm"
-                                            >{{
-                                                $t('editor.changingUuid', {
-                                                    changeUuid: renamed
-                                                })
-                                            }}
-                                        </span>
                                     </div>
                                     <br />
                                 </span>
@@ -671,9 +641,9 @@ export default class MetadataEditorV extends Vue {
     // Form properties.
     uuid = '';
     baseUuid = ''; // to save the original UUID
-    changeUuid = '';
-    renaming = false;
-    renamed = '';
+    changeUuid = ''; // the model for the rename input
+    renameMode = false; // if currently in rename mode
+    processingRename = false; // only true while we're waiting for the server to process a rename
     logoImage: undefined | File = undefined;
     metadata: MetadataContent = {
         title: '',
@@ -1010,7 +980,6 @@ export default class MetadataEditorV extends Vue {
 
         // Reset fields
         this.baseUuid = this.uuid;
-        this.renamed = '';
         this.changeUuid = '';
 
         // Attempt to fetch the project from the server.
@@ -1072,50 +1041,89 @@ export default class MetadataEditorV extends Vue {
             return;
         }
 
+        const prevUuid = this.configFileStructure.uuid;
+        const userStore = useUserStore();
+
         // Fetch the two existing configuration files.
-        const enFile = this.configFileStructure?.zip.file(`${this.uuid}_en.json`);
-        const frFile = this.configFileStructure?.zip.file(`${this.uuid}_fr.json`);
+        const enFile = this.configFileStructure?.zip.file(`${prevUuid}_en.json`);
+        const frFile = this.configFileStructure?.zip.file(`${prevUuid}_fr.json`);
 
         if (enFile && frFile) {
-            axios
-                .post(process.env.VUE_APP_NET_API_URL + '/api/version/update', {
-                    uuid: this.uuid,
-                    changeUuid: this.changeUuid
+            this.processingRename = true;
+
+            // Fetch the contents of the two configuration files, and perform a find/replace on the UUID for each source.
+            const englishConfig = await enFile?.async('string').then((res: string) => JSON.parse(res));
+            const frenchConfig = await frFile?.async('string').then((res: string) => JSON.parse(res));
+            [englishConfig, frenchConfig].forEach((config) => this.renameSources(config, prevUuid));
+            // Convert the two configuration files into string format.
+            const convertedEnglish = JSON.stringify(englishConfig, null, 4);
+            const convertedFrench = JSON.stringify(frenchConfig, null, 4);
+
+            // First, hit the Express server `rename` endpoint to perform the `rename` syscall on the file system.
+            await axios
+                .post(this.apiUrl + `/rename`, {
+                    user: userStore.userProfile.userName || 'Guest',
+                    previousUuid: prevUuid,
+                    newUuid: this.changeUuid,
+                    configs: { en: convertedEnglish, fr: convertedFrench }
                 })
-                .then(async (response: any) => {
-                    // Remove the files from the ZIP folder.
-                    this.configFileStructure?.zip.remove(enFile.name);
-                    this.configFileStructure?.zip.remove(frFile.name);
+                .then(async (res: AxiosResponse) => {
+                    // Once the server has processed the renaming, update the UUID in the database if not in dev mode.
+                    if (process.env.VUE_APP_NET_API_URL !== undefined) {
+                        await axios.post(process.env.VUE_APP_NET_API_URL + '/api/version/update', {
+                            uuid: prevUuid,
+                            changeUuid: this.changeUuid
+                        });
+                    }
 
-                    // Fetch the contents of the two files, and perform a find/replace on the UUID for each source.
-                    const englishConfig = await enFile?.async('string').then((res: string) => JSON.parse(res));
-                    const frenchConfig = await frFile?.async('string').then((res: string) => JSON.parse(res));
-                    [englishConfig, frenchConfig].forEach((config) => this.renameSources(config));
+                    // After the server and database have been updated, re-build configFileStructure,
+                    // save the new config files to the server and fetch the new Git history.
+                    if (this.configFileStructure?.zip) {
+                        // Remove the current configuration files from the ZIP folder.
+                        this.configFileStructure?.zip.remove(enFile.name);
+                        this.configFileStructure?.zip.remove(frFile.name);
 
-                    // Convert the configs back into a string and re-add them to the ZIP with the new UUID.
-                    this.configFileStructure?.zip.file(
-                        `${this.changeUuid}_en.json`,
-                        JSON.stringify(englishConfig, null, 4)
-                    );
-                    this.configFileStructure?.zip.file(
-                        `${this.changeUuid}_fr.json`,
-                        JSON.stringify(frenchConfig, null, 4)
-                    );
+                        // Re-add the configuration files to the ZIP with the new UUID.
+                        this.configFileStructure?.zip.file(`${this.changeUuid}_en.json`, convertedEnglish);
+                        this.configFileStructure?.zip.file(`${this.changeUuid}_fr.json`, convertedFrench);
 
-                    this.uuid = this.changeUuid;
+                        // Iterate through the RAMP configuration files and rename them using the new UUID.
+                        const configPromises: Promise<void>[] = [];
+                        this.configFileStructure?.zip.folder('ramp-config/')?.forEach((relativePath, file) => {
+                            configPromises.push(this.renameMapConfig(file.name, prevUuid));
+                        });
 
-                    // Reset source counts and re-generate the config file structure.
-                    this.sourceCounts = {};
+                        // Wait for map configuration files to be renamed.
+                        await Promise.all(configPromises);
 
-                    if (this.configFileStructure?.zip) this.configFileStructureHelper(this.configFileStructure.zip);
+                        this.uuid = this.changeUuid;
+
+                        // Reset source counts.
+                        this.sourceCounts = {};
+
+                        this.configFileStructureHelper(this.configFileStructure.zip).then(() => {
+                            this.fetchHistory();
+                            this.renameMode = this.processingRename = false;
+                        });
+                    }
+                })
+                .catch((err) => {
+                    /** If the server returns a 500 error for whatever reason (most likely due to file in use),
+                     * roll back the UUID to the previous value and display an error message.
+                     */
+                    if (err.status === 500) {
+                        Message.error(this.$t('editor.warning.renameFailed'));
+                        this.uuid = prevUuid;
+                        this.processingRename = false;
+                        console.log(this.configFileStructure);
+                        return;
+                    }
                 });
         }
-        this.renaming = false;
-        this.renamed = this.uuid;
     }
 
     // Given a Storylines config, replace instances of the current UUID with a new UUID.
-    renameSources(config: StoryRampConfig): void {
+    renameSources(config: StoryRampConfig, prevUuid: string): void {
         const _renameHelper = (panel: any): any => {
             switch (panel.type) {
                 case PanelType.Dynamic:
@@ -1128,29 +1136,71 @@ export default class MetadataEditorV extends Vue {
                         _renameHelper(child);
                     });
                     break;
+                case PanelType.Map:
+                    if (panel.config && typeof panel.config === 'string') {
+                        // Update the path to the RAMP config in the product config file.
+                        panel.config = panel.config.replace(`/${prevUuid}-map-`, `/${this.changeUuid}-map-`);
+                    }
                 default:
                     // Base case. This is a panel that doesn't have any children (i.e., not dynamic, slideshow).
                     // Rename the source.
                     if (panel.src) {
-                        panel.src = panel.src.replace(`${this.uuid}/`, `${this.changeUuid}/`);
+                        panel.src = panel.src.replace(`${prevUuid}/`, `${this.changeUuid}/`);
                     }
                     if (panel.config && typeof panel.config === 'string') {
-                        panel.config = panel.config.replace(`${this.uuid}/`, `${this.changeUuid}/`);
+                        panel.config = panel.config.replace(`${prevUuid}/`, `${this.changeUuid}/`);
                     }
             }
         };
 
+        // Rename logo and introduction slide background image, if applicable.
         if (config?.introSlide.logo?.src) {
             config.introSlide.logo.src = config.introSlide.logo.src.replace(
-                `${this.uuid}/assets/`,
+                `${prevUuid}/assets/`,
+                `${this.changeUuid}/assets/`
+            );
+        }
+
+        if (config?.introSlide.backgroundImage) {
+            config.introSlide.backgroundImage = config.introSlide.backgroundImage.replace(
+                `${prevUuid}/assets/`,
                 `${this.changeUuid}/assets/`
             );
         }
 
         config.slides.forEach((slide) => {
-            slide.panel.forEach((panel) => {
-                _renameHelper(panel);
-            });
+            if (Object.keys(slide).length !== 0) {
+                if ((slide as Slide).backgroundImage) {
+                    (slide as Slide).backgroundImage = (slide as Slide).backgroundImage.replace(
+                        `${prevUuid}/assets/`,
+                        `${this.changeUuid}/assets/`
+                    );
+                }
+
+                (slide as Slide).panel.forEach((panel) => {
+                    _renameHelper(panel);
+                });
+            }
+        });
+    }
+
+    // Provided with the path of a RAMP configuration file, rename it in the JSZip object using the new UUID.
+    renameMapConfig(oldPath: string, prevUuid: string): Promise<void> {
+        return new Promise((resolve) => {
+            this.configFileStructure?.zip
+                .file(oldPath)
+                ?.async('string')
+                .then((res: string) => {
+                    // Remove the old config file.
+                    this.configFileStructure?.zip.remove(oldPath);
+
+                    // Get the new config name.
+                    const newFile = oldPath.replace(`/${prevUuid}-map-`, `/${this.changeUuid}-map-`);
+
+                    // Re-add the config to the ZIP with the new name.
+                    this.configFileStructure?.zip.file(newFile, res);
+                    resolve();
+                });
         });
     }
 
@@ -1161,9 +1211,11 @@ export default class MetadataEditorV extends Vue {
             }
 
             configs[lang]?.slides.forEach((slide) => {
-                slide.panel.forEach((panel) => {
-                    this.panelSourceHelper(panel);
-                });
+                if (Object.keys(slide).length !== 0) {
+                    (slide as Slide).panel.forEach((panel) => {
+                        this.panelSourceHelper(panel);
+                    });
+                }
             });
         });
     }
@@ -1216,7 +1268,7 @@ export default class MetadataEditorV extends Vue {
      * Generates or loads a ZIP file and creates required project folders if needed.
      * Returns an object that makes it easy to access any specific folder.
      */
-    configFileStructureHelper(configZip: typeof JSZip, uploadLogo?: File | undefined): void {
+    configFileStructureHelper(configZip: typeof JSZip, uploadLogo?: File | undefined): Promise<void> {
         const assetsFolder = configZip.folder('assets');
         const chartsFolder = configZip.folder('charts');
         const rampConfigFolder = configZip.folder('ramp-config');
@@ -1241,12 +1293,13 @@ export default class MetadataEditorV extends Vue {
             this.configFileStructure.assets[this.configLang].file(uploadLogo?.name, uploadLogo);
         }
 
-        this.loadConfig();
+        return this.loadConfig();
     }
 
     /**
      * Loads a configuration file from the product folder, and sets application data
      * as needed.
+     * @param config the configuration object to load.
      */
     async loadConfig(config?: StoryRampConfig): Promise<void> {
         if (config) {
@@ -1270,7 +1323,7 @@ export default class MetadataEditorV extends Vue {
             return;
         }
 
-        if (this.loadExisting && !this.renamed) {
+        if (this.loadExisting) {
             this.loadStatus = 'waiting';
             Message.success(this.$t('editor.editMetadata.message.successfulLoad'));
         } else {
@@ -1619,28 +1672,26 @@ export default class MetadataEditorV extends Vue {
         if (!this.loadExisting || rename) {
             const user = useUserStore().userProfile.userName || 'Guest';
             // If renaming, show the loading spinner while we check whether the UUID is taken.
-            fetch(this.apiUrl + `/retrieve/${rename ? this.changeUuid : this.uuid}/latest`, { headers: { user } }).then(
-                (res: Response) => {
-                    if (res.status !== 404) {
-                        this.warning = rename ? 'rename' : 'uuid';
-                    }
-
-                    if (rename) this.checkingUuid = false;
-
-                    fetch(this.apiUrl + `/retrieveMessages`)
-                        .then((res: any) => {
-                            if (res.ok) return res.json();
-                        })
-                        .then((data) => {
-                            axios
-                                .post(import.meta.env.VITE_APP_NET_API_URL + '/api/log/create', {
-                                    messages: data.messages
-                                })
-                                .catch((error: any) => console.log(error.response || error));
-                        })
-                        .catch((error: any) => console.log(error.response || error));
+            fetch(this.apiUrl + `/check/${rename ? this.changeUuid : this.uuid}`).then((res: Response) => {
+                if (res.status !== 404) {
+                    this.warning = rename ? 'rename' : 'uuid';
                 }
-            );
+
+                if (rename) this.checkingUuid = false;
+
+                fetch(this.apiUrl + `/retrieveMessages`)
+                    .then((res: any) => {
+                        if (res.ok) return res.json();
+                    })
+                    .then((data) => {
+                        axios
+                            .post(import.meta.env.VITE_APP_NET_API_URL + '/api/log/create', {
+                                messages: data.messages
+                            })
+                            .catch((error: any) => console.log(error.response || error));
+                    })
+                    .catch((error: any) => console.log(error.response || error));
+            });
         }
         this.warning = 'none';
         this.highlightedIndex = -1;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -133,6 +133,7 @@ export interface Intro {
     title: string;
     subtitle: string;
     blurb?: string;
+    backgroundImage: string;
 }
 
 export interface Slide {
@@ -141,6 +142,7 @@ export interface Slide {
     // panel: [BasePanel, BasePanel | undefined];
     panel: BasePanel[];
     includeInToc?: boolean;
+    backgroundImage: string;
 }
 
 export interface MultiLanguageSlide {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -95,8 +95,8 @@ editor.warning.uuidNotFound,The requested UUID '{uuid}' does not exist.,1,L'UUID
 editor.metadata.uuidInstructions,"Please enter the UUID of an existing storylines product, then click the 'Load' button.",1,"Veuillez saisir l'UUID d'un produit de scénario existant, puis cliquez sur le bouton « Charger ».",0
 editor.metadata.newUuidInstructions,"Enter a unique ID for your new storyline. One has been auto-generated for you, but you can also enter your own.",1,"Entrez un identifiant unique pour votre nouveau scénario. Un a été généré automatiquement pour vous, mais vous pouvez également saisir le vôtre.",0
 editor.warning.rename,UUID already in use. Please choose a different ID.,1,UUID déjà utilisé. Veuillez choisir un autre identifiant.,0
+editor.warning.renameFailed,Failed to rename product.,1,Échec du renommage du produit.,0
 editor.changeUuid,Click here to change UUID,1,Cliquez ici pour changer,0
-editor.changingUuid,You are changing this product UUID to '{changeUuid}'. Save changes required.,1,Vous modifiez l'UUID de ce produit en '{changeUuid}'. Enregistrez les modifications requises.,0
 editor.title,Title,1,Titre,1
 editor.respectTitle,RAMP Storylines Editor & Creation Tool,1,Éditeur et outil de création de scénarios RAMP,0
 editor.logo,Logo,1,Logo,1


### PR DESCRIPTION
### Related Item(s)
#253 
#418 
#419

### Changes
- Added the `/rename` server endpoint: this is a re-implementation of the rename feature. Instead of relying on the `/upload` endpoint that simply created a new product folder, the `/rename` endpoint calls the `rename` syscall on the existing product folder. It will also delete and re-instantiate the Git repo.
- Added a new `/check` endpoint to the server to see if a product already exists. This way, we don't need to call the `/retrieve` endpoint and wait for the entire product to transfer every time the user enters a UUID. It should be much faster now.
- Moved the `responseMessages.push()` calls in to the `logger` function to reduce code duplication.

### Notes
![image](https://github.com/user-attachments/assets/6870b2a4-be1b-4dc7-ba46-016b74c2604f)

### Testing
This is a big one, so please test thoroughly! If my instructions below are confusing please reach out, or post a comment on this PR to help others if they also have trouble.

**:warning: IMPORTANT! :warning:** If testing locally, please move the `server` folder outside of the `storylines-editor` folder. `npm run dev` seems to lock the `server/public` folder and it will result in the `rename` system call hanging indefinitely otherwise. Alternatively, if you overwrite the `server/index.js` code with the new code in this PR, you should be able to test using the demo page associated with this PR.<br />
**:warning:** If you notice the rename endpoint is hanging at any point, then the product folder is being accessed from somewhere else at the same time. Try closing anything that could be using it (VS Code, File Explorer, notepad, etc.). As far as I understand this should (hopefully) not happen on prod as nothing should be accessing the file system. If anyone knows of something that can be added to the code to fix this, please let me know.


Steps:
1. Pull this PR locally and follow the important step above.
2. Try creating a new product with an existing UUID. Notice that the "UUID is already in use" error should appear much faster than before.
3. Create a new product that doesn't already exist. Save it so it gets uploaded to the server.
4. Return to the home page, and now load this new product.
5. Try to rename it, and ensure it works properly.
6. Now, try to load an existing product.
7. Try to rename it and ensure that everything works here as well. Also, check that the previous editing history has been wiped.
8. Try whatever you want to break this otherwise!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/487)
<!-- Reviewable:end -->
