### PR TITLE
Add truncate directive, Modularize slide toc buttons

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -26,8 +26,6 @@ export default class App extends Vue {
         }
     }
 }
-
-
 </script>
 
 <style lang="scss">

--- a/src/components/helpers/slide-toc-button.vue
+++ b/src/components/helpers/slide-toc-button.vue
@@ -1,0 +1,183 @@
+<template>
+    <button
+        class="flex gap-2 px-2 rounded-md bg-transparent hover:bg-gray-200"
+        :disabled="!element[lang]"
+        :class="{
+            'selected-toc-config-item': element.lang === currentSlide,
+            'py-1': !isMobileSidebar,
+            'py-2': isMobileSidebar,
+            'border-2 border-blue-500': isMobileSidebar && element[lang] === currentSlide,
+            'cursor-not-allowed border-2 border-red-400': !element[lang]
+        }"
+        @click.stop="
+            $emit('select-slide');
+            isMobileSidebar && $emit('close-sidebar');
+        "
+    >
+        <!-- ::lang:: text -->
+        <p class="font-bold italic text-gray-500 select-none" :class="{ 'text-gray-700': isActiveSlide }">
+            {{ lang === 'en' ? 'EN' : 'FR' }}
+        </p>
+        <!-- Config title -->
+        <p
+            class="text-left select-none truncate-multiline"
+            :class="{
+                italic: !element[lang]?.title
+            }"
+            v-truncate="{
+                options: {
+                    delay: '200',
+                    placement: isMobileSidebar ? 'top' : 'right',
+                    content: content,
+                    animateFill: true,
+                    offset: [0, isMobileSidebar ? 0 : 50],
+                    touch: ['hold', 500]
+                }
+            }"
+        >
+            {{ content }}
+        </p>
+        <!-- Options for ::lang:: items with missing configs (e.g. one language has config, other doesn't) -->
+        <div v-if="!element[lang]" class="ml-auto flex my-auto">
+            <!-- Create a new blank config -->
+            <button
+                class="slide-toc-button"
+                v-tippy="{
+                    delay: '200',
+                    placement: 'top-start',
+                    content: $t('editor.slides.toc.newBlankConfig'),
+                    animateFill: false,
+                    touch: ['hold', 500]
+                }"
+                @click="$emit('create-config')"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    shape-rendering="geometricPrecision"
+                    text-rendering="geometricPrecision"
+                    image-rendering="optimizeQuality"
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    viewBox="0 0 399 511.66"
+                    width="14"
+                    height="14"
+                    class="mx-1"
+                >
+                    <path
+                        fill-rule="nonzero"
+                        d="M71.1 0h190.92c5.22 0 9.85 2.5 12.77 6.38L394.7 136.11c2.81 3.05 4.21 6.92 4.21 10.78l.09 293.67c0 19.47-8.02 37.23-20.9 50.14l-.09.08c-12.9 12.87-30.66 20.88-50.11 20.88H71.1c-19.54 0-37.33-8.01-50.22-20.9C8.01 477.89 0 460.1 0 440.56V71.1c0-19.56 8-37.35 20.87-50.23C33.75 8 51.54 0 71.1 0zm45.78 254.04c-8.81 0-15.96-7.15-15.96-15.95 0-8.81 7.15-15.96 15.96-15.96h165.23c8.81 0 15.96 7.15 15.96 15.96 0 8.8-7.15 15.95-15.96 15.95H116.88zm0 79.38c-8.81 0-15.96-7.15-15.96-15.96 0-8.8 7.15-15.95 15.96-15.95h156.47c8.81 0 15.96 7.15 15.96 15.95 0 8.81-7.15 15.96-15.96 15.96H116.88zm0 79.39c-8.81 0-15.96-7.15-15.96-15.96s7.15-15.95 15.96-15.95h132.7c8.81 0 15.95 7.14 15.95 15.95 0 8.81-7.14 15.96-15.95 15.96h-132.7zm154.2-363.67v54.21c1.07 13.59 5.77 24.22 13.99 31.24 8.63 7.37 21.65 11.52 38.95 11.83l36.93-.05-89.87-97.23zm96.01 129.11-43.31-.05c-25.2-.4-45.08-7.2-59.39-19.43-14.91-12.76-23.34-30.81-25.07-53.11l-.15-2.22V31.91H71.1c-10.77 0-20.58 4.42-27.68 11.51-7.09 7.1-11.51 16.91-11.51 27.68v369.46c0 10.76 4.43 20.56 11.52 27.65 7.11 7.12 16.92 11.53 27.67 11.53h256.8c10.78 0 20.58-4.4 27.65-11.48 7.13-7.12 11.54-16.93 11.54-27.7V178.25z"
+                    />
+                </svg>
+            </button>
+            <!-- Button: Copy the ::oppositeLang:: config in the same slide, if it exists -->
+            <!-- Only available if the slide's ::lang:: config is undefined -->
+            <button
+                v-if="element[oppositeLang]"
+                class="slide-toc-button"
+                v-tippy="{
+                    delay: '200',
+                    placement: 'top-start',
+                    content:
+                        lang === 'en'
+                            ? $t('editor.slides.toc.newConfigFromFR')
+                            : $t('editor.slides.toc.newConfigFromEng'),
+                    animateFill: false,
+                    touch: ['hold', 500]
+                }"
+                @click="$emit('copy-config')"
+            >
+                <svg xmlns="http://www.w3.org/2000/svg" height="16" width="16" viewBox="0 0 24 24" class="mx-1">
+                    <path
+                        d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
+                    />
+                </svg>
+            </button>
+        </div>
+        <div v-else class="ml-auto flex my-auto">
+            <!-- ::lang:: options dropdown menu -->
+            <toc-options :copy-allowed="!!element[oppositeLang]" @copy="$emit('copy')" @clear="$emit('clear')" />
+        </div>
+    </button>
+</template>
+
+<script lang="ts">
+import { Slide } from '@/definitions';
+import { Options, Prop, Vue } from 'vue-property-decorator';
+import TocOptions from '@/components/helpers/toc-options.vue';
+
+@Options({
+    components: {
+        TocOptions
+    }
+})
+export default class SlideTocV extends Vue {
+    @Prop() lang!: string;
+    @Prop() element: Slide;
+    @Prop() currentSlide!: Slide | string;
+    @Prop({ default: false }) isMobileSidebar!: boolean;
+    @Prop() isActiveSlide: boolean;
+
+    oppositeLang = '';
+    content = '';
+
+    mounted(): void {
+        this.oppositeLang = this.lang === 'en' ? 'fr' : 'en';
+
+        // assigning the content using a ternary expression prevents the 'editor.slide.toc.noFRSlide'
+        // from being detected
+        if (this.element[this.lang]?.title) {
+            this.content = this.element[this.lang]?.title;
+        } else if (this.element[this.lang]?.title === '') {
+            if (this.lang === 'en') {
+                this.content = this.$t('editor.slides.toc.newENGSlideText');
+            } else {
+                this.content = this.$t('editor.slides.toc.newFRSlideText');
+            }
+        } else {
+            if (this.lang === 'en') {
+                this.content = this.$t('editor.slide.toc.noENGslide');
+            } else {
+                this.content = this.$t('editor.slide.toc.noFRSlide');
+            }
+        }
+    }
+
+    updated(): void {
+        // assigning the content using a ternary expression prevents the 'editor.slide.toc.noFRSlide'
+        // from being detected
+        if (this.element[this.lang]?.title) {
+            this.content = this.element[this.lang]?.title;
+        } else if (this.element[this.lang]?.title === '') {
+            if (this.lang === 'en') {
+                this.content = this.$t('editor.slides.toc.newENGSlideText');
+            } else {
+                this.content = this.$t('editor.slides.toc.newFRSlideText');
+            }
+        } else {
+            if (this.lang === 'en') {
+                this.content = this.$t('editor.slide.toc.noENGslide');
+            } else {
+                this.content = this.$t('editor.slide.toc.noFRSlide');
+            }
+        }
+    }
+}
+</script>
+
+<style lang="scss" scoped>
+.truncate-multiline {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.slide-toc-button {
+    border-radius: 3px;
+    padding: 2px;
+}
+.slide-toc-button:hover {
+    background-color: rgb(209, 213, 219);
+}
+</style>

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -100,130 +100,26 @@
                                     </div>
                                 </section>
                                 <!-- ENG and FR configs for slide -->
-                                <!-- TODO: Modularize an individual config button and just reuse it twice here.
-                                           There's a lot of repeated code with just "EN" and "FR" swapped. -->
-                                <section class="flex flex-col gap-0.5 text-sm">
+                                <section class="flex flex-col gap-0.5 text-sm w-64">
                                     <!-- ENG config for slide -->
-                                    <button
-                                        class="flex gap-2 px-2 rounded-md bg-transparent hover:bg-gray-200"
-                                        :disabled="!element.en"
-                                        :class="{
-                                            'selected-toc-config-item': element.en === currentSlide,
-                                            'py-1': !isMobileSidebar,
-                                            'py-2': isMobileSidebar,
-                                            'border-2 border-blue-500': isMobileSidebar && element.en === currentSlide,
-                                            'cursor-not-allowed border-2 border-red-400': !element.en
-                                        }"
-                                        v-tippy="{
-                                            delay: '200',
-                                            placement: isMobileSidebar ? 'top' : 'right',
-                                            content:
-                                                element.en?.title ||
-                                                (element.en?.title === ''
-                                                    ? $t('editor.slides.toc.newENGSlideText')
-                                                    : $t('editor.slides.toc.noENGslide')),
-                                            animateFill: true,
-                                            offset: [0, isMobileSidebar ? 0 : 50],
-                                            touch: ['hold', 500]
-                                        }"
-                                        @click.stop="
-                                            selectSlide(index, 'en');
-                                            isMobileSidebar && closeSidebar();
+                                    <slide-toc-button
+                                        :element="element"
+                                        lang="en"
+                                        :currentSlide="currentSlide"
+                                        :isMobileSidebar="isMobileSidebar"
+                                        :activeSlide="slideIndex === index"
+                                        @selectSlide="selectSlide(index, 'en')"
+                                        @closeSidebar="closeSidebar()"
+                                        @copyConfig="copyConfigFromOtherLang(index, 'en')"
+                                        @copy="
+                                            {
+                                                configEmpty(element, 'en')
+                                                    ? copyConfigFromOtherLang(index, 'en')
+                                                    : $vfm.open(`copy-other-slide-${index}-en-config`);
+                                            }
                                         "
-                                    >
-                                        <!-- "EN" text -->
-                                        <p
-                                            class="font-bold italic text-gray-500 select-none"
-                                            :class="{ 'text-gray-700': slideIndex === index }"
-                                        >
-                                            EN
-                                        </p>
-                                        <!-- Config title -->
-                                        <p
-                                            class="text-left line-clamp-2 select-none"
-                                            :class="{
-                                                italic: !element.en?.title
-                                            }"
-                                        >
-                                            {{
-                                                element.en?.title ||
-                                                (element.en?.title === ''
-                                                    ? $t('editor.slides.toc.newENGSlideText')
-                                                    : $t('editor.slides.toc.noENGslide'))
-                                            }}
-                                        </p>
-                                        <!-- Options for EN items with missing configs (e.g. one language has config, other doesn't) -->
-                                        <div v-if="!element.en" class="ml-auto flex my-auto">
-                                            <!-- Create a new blank config -->
-                                            <button
-                                                class="slide-toc-button"
-                                                v-tippy="{
-                                                    delay: '200',
-                                                    placement: 'top-start',
-                                                    content: $t('editor.slides.toc.newBlankConfig'),
-                                                    animateFill: false,
-                                                    touch: ['hold', 500]
-                                                }"
-                                                @click="createNewConfig(index, 'en')"
-                                            >
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    shape-rendering="geometricPrecision"
-                                                    text-rendering="geometricPrecision"
-                                                    image-rendering="optimizeQuality"
-                                                    fill-rule="evenodd"
-                                                    clip-rule="evenodd"
-                                                    viewBox="0 0 399 511.66"
-                                                    width="14"
-                                                    height="14"
-                                                    class="mx-1"
-                                                >
-                                                    <path
-                                                        fill-rule="nonzero"
-                                                        d="M71.1 0h190.92c5.22 0 9.85 2.5 12.77 6.38L394.7 136.11c2.81 3.05 4.21 6.92 4.21 10.78l.09 293.67c0 19.47-8.02 37.23-20.9 50.14l-.09.08c-12.9 12.87-30.66 20.88-50.11 20.88H71.1c-19.54 0-37.33-8.01-50.22-20.9C8.01 477.89 0 460.1 0 440.56V71.1c0-19.56 8-37.35 20.87-50.23C33.75 8 51.54 0 71.1 0zm45.78 254.04c-8.81 0-15.96-7.15-15.96-15.95 0-8.81 7.15-15.96 15.96-15.96h165.23c8.81 0 15.96 7.15 15.96 15.96 0 8.8-7.15 15.95-15.96 15.95H116.88zm0 79.38c-8.81 0-15.96-7.15-15.96-15.96 0-8.8 7.15-15.95 15.96-15.95h156.47c8.81 0 15.96 7.15 15.96 15.95 0 8.81-7.15 15.96-15.96 15.96H116.88zm0 79.39c-8.81 0-15.96-7.15-15.96-15.96s7.15-15.95 15.96-15.95h132.7c8.81 0 15.95 7.14 15.95 15.95 0 8.81-7.14 15.96-15.95 15.96h-132.7zm154.2-363.67v54.21c1.07 13.59 5.77 24.22 13.99 31.24 8.63 7.37 21.65 11.52 38.95 11.83l36.93-.05-89.87-97.23zm96.01 129.11-43.31-.05c-25.2-.4-45.08-7.2-59.39-19.43-14.91-12.76-23.34-30.81-25.07-53.11l-.15-2.22V31.91H71.1c-10.77 0-20.58 4.42-27.68 11.51-7.09 7.1-11.51 16.91-11.51 27.68v369.46c0 10.76 4.43 20.56 11.52 27.65 7.11 7.12 16.92 11.53 27.67 11.53h256.8c10.78 0 20.58-4.4 27.65-11.48 7.13-7.12 11.54-16.93 11.54-27.7V178.25z"
-                                                    />
-                                                </svg>
-                                            </button>
-                                            <!-- Button: Copy the FR config in the same slide, if it exists -->
-                                            <!-- Only available if the slide's ENG config is undefined -->
-                                            <button
-                                                v-if="element.fr"
-                                                class="slide-toc-button"
-                                                v-tippy="{
-                                                    delay: '200',
-                                                    placement: 'top-start',
-                                                    content: $t('editor.slides.toc.newConfigFromFR'),
-                                                    animateFill: false,
-                                                    touch: ['hold', 500]
-                                                }"
-                                                @click="copyConfigFromOtherLang(index, 'en')"
-                                            >
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    height="16"
-                                                    width="16"
-                                                    viewBox="0 0 24 24"
-                                                    class="mx-1"
-                                                >
-                                                    <path
-                                                        d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
-                                                    />
-                                                </svg>
-                                            </button>
-                                        </div>
-                                        <div v-else class="ml-auto flex my-auto">
-                                            <!-- ENG options dropdown menu -->
-                                            <toc-options
-                                                :copy-allowed="!!element.fr"
-                                                @copy="
-                                                    configEmpty(element, 'en')
-                                                        ? copyConfigFromOtherLang(index, 'en')
-                                                        : $vfm.open(`copy-other-slide-${index}-en-config`)
-                                                "
-                                                @clear="$vfm.open(`delete-slide-${index}-en-config`)"
-                                            />
-                                        </div>
-                                    </button>
+                                        @clear="$vfm.open(`delete-slide-${index}-en-config`)"
+                                    />
                                     <!-- Delete ENG confirmation modal -->
                                     <action-modal
                                         :name="`delete-slide-${index}-en-config`"
@@ -257,126 +153,24 @@
                                     />
                                     <hr v-if="isMobileSidebar" />
                                     <!-- FR config for slide -->
-                                    <button
-                                        class="flex gap-2 px-2 py-1 rounded-md bg-transparent hover:bg-gray-200"
-                                        :disabled="!element.fr"
-                                        :class="{
-                                            'selected-toc-config-item': element.fr === currentSlide,
-                                            'py-1': !isMobileSidebar,
-                                            'py-2': isMobileSidebar,
-                                            'border-2 border-blue-500': isMobileSidebar && element.fr === currentSlide,
-                                            'cursor-not-allowed border-2 border-red-400': !element.fr
-                                        }"
-                                        v-tippy="{
-                                            delay: '200',
-                                            placement: isMobileSidebar ? 'bottom' : 'right',
-                                            content:
-                                                element.fr?.title ||
-                                                (element.fr?.title === ''
-                                                    ? $t('editor.slides.toc.newFRSlideText')
-                                                    : $t('editor.slide.toc.noFRSlide')),
-                                            animateFill: true,
-                                            offset: [0, isMobileSidebar ? 0 : 50],
-                                            touch: ['hold', 500]
-                                        }"
-                                        @click.stop="
-                                            selectSlide(index, 'fr');
-                                            isMobileSidebar && closeSidebar();
+                                    <slide-toc-button
+                                        :element="element"
+                                        lang="fr"
+                                        :currentSlide="currentSlide"
+                                        :isMobileSidebar="isMobileSidebar"
+                                        :activeSlide="slideIndex === index"
+                                        @selectSlide="selectSlide(index, 'fr')"
+                                        @closeSidebar="closeSidebar()"
+                                        @copyConfig="copyConfigFromOtherLang(index, 'fr')"
+                                        @copy="
+                                            {
+                                                configEmpty(element, 'fr')
+                                                    ? copyConfigFromOtherLang(index, 'fr')
+                                                    : $vfm.open(`copy-other-slide-${index}-fr-config`);
+                                            }
                                         "
-                                    >
-                                        <!-- "FR" text -->
-                                        <p
-                                            class="font-bold italic text-gray-500 select-none"
-                                            :class="{ 'text-gray-700': slideIndex === index }"
-                                        >
-                                            FR
-                                        </p>
-                                        <!-- Config title -->
-                                        <p
-                                            class="text-left line-clamp-2 select-none"
-                                            :class="{
-                                                italic: !element.fr?.title
-                                            }"
-                                        >
-                                            {{
-                                                element.fr?.title ||
-                                                (element.fr?.title === ''
-                                                    ? $t('editor.slides.toc.newFRSlideText')
-                                                    : $t('editor.slide.toc.noFRSlide'))
-                                            }}
-                                        </p>
-                                        <!-- Options for FR items with missing configs (e.g. one language has config, other doesn't) -->
-                                        <div v-if="!element.fr" class="ml-auto flex my-auto">
-                                            <!-- Create a new blank config -->
-                                            <button
-                                                class="slide-toc-button"
-                                                v-tippy="{
-                                                    delay: '200',
-                                                    placement: 'bottom-start',
-                                                    content: $t('editor.slides.toc.newBlankConfig'),
-                                                    animateFill: false,
-                                                    touch: ['hold', 500]
-                                                }"
-                                                @click="createNewConfig(index, 'fr')"
-                                            >
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    shape-rendering="geometricPrecision"
-                                                    text-rendering="geometricPrecision"
-                                                    image-rendering="optimizeQuality"
-                                                    fill-rule="evenodd"
-                                                    clip-rule="evenodd"
-                                                    viewBox="0 0 399 511.66"
-                                                    width="14"
-                                                    height="14"
-                                                    class="mx-1"
-                                                >
-                                                    <path
-                                                        fill-rule="nonzero"
-                                                        d="M71.1 0h190.92c5.22 0 9.85 2.5 12.77 6.38L394.7 136.11c2.81 3.05 4.21 6.92 4.21 10.78l.09 293.67c0 19.47-8.02 37.23-20.9 50.14l-.09.08c-12.9 12.87-30.66 20.88-50.11 20.88H71.1c-19.54 0-37.33-8.01-50.22-20.9C8.01 477.89 0 460.1 0 440.56V71.1c0-19.56 8-37.35 20.87-50.23C33.75 8 51.54 0 71.1 0zm45.78 254.04c-8.81 0-15.96-7.15-15.96-15.95 0-8.81 7.15-15.96 15.96-15.96h165.23c8.81 0 15.96 7.15 15.96 15.96 0 8.8-7.15 15.95-15.96 15.95H116.88zm0 79.38c-8.81 0-15.96-7.15-15.96-15.96 0-8.8 7.15-15.95 15.96-15.95h156.47c8.81 0 15.96 7.15 15.96 15.95 0 8.81-7.15 15.96-15.96 15.96H116.88zm0 79.39c-8.81 0-15.96-7.15-15.96-15.96s7.15-15.95 15.96-15.95h132.7c8.81 0 15.95 7.14 15.95 15.95 0 8.81-7.14 15.96-15.95 15.96h-132.7zm154.2-363.67v54.21c1.07 13.59 5.77 24.22 13.99 31.24 8.63 7.37 21.65 11.52 38.95 11.83l36.93-.05-89.87-97.23zm96.01 129.11-43.31-.05c-25.2-.4-45.08-7.2-59.39-19.43-14.91-12.76-23.34-30.81-25.07-53.11l-.15-2.22V31.91H71.1c-10.77 0-20.58 4.42-27.68 11.51-7.09 7.1-11.51 16.91-11.51 27.68v369.46c0 10.76 4.43 20.56 11.52 27.65 7.11 7.12 16.92 11.53 27.67 11.53h256.8c10.78 0 20.58-4.4 27.65-11.48 7.13-7.12 11.54-16.93 11.54-27.7V178.25z"
-                                                    />
-                                                </svg>
-                                            </button>
-                                            <!-- Button: Copy the ENG config in the same slide, if it exists -->
-                                            <!-- Only available if the slide's FR config is undefined -->
-                                            <button
-                                                v-if="element.en"
-                                                class="slide-toc-button"
-                                                v-tippy="{
-                                                    delay: '200',
-                                                    placement: 'bottom-start',
-                                                    content: $t('editor.slides.toc.newConfigFromEng'),
-                                                    animateFill: false,
-                                                    touch: ['hold', 500]
-                                                }"
-                                                @click="copyConfigFromOtherLang(index, 'fr')"
-                                            >
-                                                <svg
-                                                    xmlns="http://www.w3.org/2000/svg"
-                                                    height="16"
-                                                    width="16"
-                                                    viewBox="0 0 24 24"
-                                                    class="mx-1"
-                                                >
-                                                    <path
-                                                        d="M5 22q-.825 0-1.413-.587Q3 20.825 3 20V6h2v14h11v2Zm4-4q-.825 0-1.412-.587Q7 16.825 7 16V4q0-.825.588-1.413Q8.175 2 9 2h9q.825 0 1.413.587Q20 3.175 20 4v12q0 .825-.587 1.413Q18.825 18 18 18Zm0-2h9V4H9v12Zm0 0V4v12Z"
-                                                    />
-                                                </svg>
-                                            </button>
-                                        </div>
-                                        <div v-else class="ml-auto flex my-auto">
-                                            <!-- FR options dropdown menu -->
-                                            <toc-options
-                                                :copy-allowed="!!element.en"
-                                                @copy="
-                                                    configEmpty(element, 'fr')
-                                                        ? copyConfigFromOtherLang(index, 'fr')
-                                                        : $vfm.open(`copy-other-slide-${index}-fr-config`)
-                                                "
-                                                @clear="$vfm.open(`delete-slide-${index}-fr-config`)"
-                                            />
-                                        </div>
-                                    </button>
+                                        @clear="$vfm.open(`delete-slide-${index}-fr-config`)"
+                                    />
                                     <!-- Delete FR confirmation modal -->
                                     <action-modal
                                         :name="`delete-slide-${index}-fr-config`"
@@ -514,7 +308,7 @@
 
 <script lang="ts">
 import ActionModal from '@/components/helpers/action-modal.vue';
-import TocOptions from '@/components/helpers/toc-options.vue';
+import SlideTocButton from '@/components/helpers/slide-toc-button.vue';
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import {
     BasePanel,
@@ -542,12 +336,12 @@ import ConfirmationModalV from './helpers/confirmation-modal.vue';
 
 @Options({
     components: {
-        TocOptions,
         ActionModal,
         'slide-editor': SlideEditorV,
         'confirmation-modal': ConfirmationModalV,
         'vue-final-modal': VueFinalModal,
-        draggable
+        draggable,
+        SlideTocButton
     }
 })
 export default class SlideTocV extends Vue {
@@ -799,21 +593,6 @@ window.addEventListener('resize', () => {
 
 .editor-toc-button {
     margin: 10px 0px 0px 0px !important;
-}
-
-.slide-toc-button {
-    border-radius: 3px;
-    padding: 2px;
-}
-.slide-toc-button:hover {
-    background-color: rgb(209, 213, 219);
-}
-
-.line-clamp-2 {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
 }
 
 /* Hard coded height :(

--- a/src/directives/truncate/truncate.ts
+++ b/src/directives/truncate/truncate.ts
@@ -1,0 +1,108 @@
+import { useTippy } from 'vue-tippy';
+import type { TippyContent } from 'vue-tippy';
+import linkifyHtml from 'linkify-html';
+import type { Directive, DirectiveBinding } from 'vue';
+
+const TRUNCATE_ATTR = 'truncate-text';
+const TRIGGER_ATTR = 'truncate-trigger';
+
+/**
+ * The Truncate Directive
+ *
+ * It makes the text truncate as needed and adds a tooltip that shows IFF the text is actually truncated.
+ *
+ * The binding value looks like:
+ * ```
+ * {
+ *      externalTrigger: boolean,
+ *      options: tippyOptions
+ * }
+ * ```
+ * if externalTrigger is present you must put the attribute `truncate-trigger` on the element you wish to be the tooltip trigger (this element must be an ancestor of the element with v-truncate)
+ * if noTruncateClass is present it will prevent the 'truncate' class from being added (which can break some elements)
+ */
+export const Truncate: Directive = {
+    beforeMount(el: HTMLElement, binding: DirectiveBinding) {
+        if (!el.classList.contains('truncate-multiline') && !binding.value?.noTruncateClass) {
+            el.classList.add('truncate-multiline');
+        }
+
+        el.toggleAttribute(TRUNCATE_ATTR, true);
+    },
+    mounted(el: HTMLElement, binding: DirectiveBinding) {
+        let triggerElement;
+        if (binding.value && binding.value.externalTrigger) {
+            // el.closest gets closest ancestor that matches the selector (moves up the parent chain)
+            triggerElement = el.closest(`[${TRIGGER_ATTR}]`);
+        }
+
+        useTippy(el, {
+            content: linkifyContent(el.textContent),
+            onShow: onShow,
+            allowHTML: true,
+            placement: 'bottom-start',
+            flip: false, // can't find a replacement for Vue3
+            boundary: 'window',
+            triggerTarget: triggerElement,
+            size: 'large',
+            ...(binding.value?.options || {})
+        });
+    },
+    updated(el: HTMLElement, binding: DirectiveBinding) {
+        // update content and options
+        if ((el as any)._tippy) {
+            (el as any)._tippy.setContent(linkifyContent(el.textContent));
+            if (binding.value && binding.value.options) {
+                (el as any)._tippy.setProps(binding.value.options);
+            }
+        }
+    },
+    unmounted(el: HTMLElement) {
+        // destroy tippy instance
+        if ((el as any)._tippy) {
+            (el as any)._tippy.destroy();
+        }
+    }
+};
+
+/**
+ * The callback for the onShow lifecycle hook of tooltips
+ *
+ * @param instance tippy instance, automatically given to this on callback
+ * @returns false IFF the text is not being truncated and the tooltip should not be shown
+ */
+function onShow(instance: any) {
+    // cancel showing the tooltip if the text isn't truncated
+    // clientWidth is the visible width of the element, scrollWidth is the width of the content
+    // clientHeight is the visible height of the element, scrollHeight is the height of the content
+    const isTruncated =
+        instance.reference.clientWidth < instance.reference.scrollWidth ||
+        instance.reference.clientHeight < instance.reference.scrollHeight;
+
+    if (!isTruncated) {
+        // returning false tells tippy to cancel
+        return false;
+    }
+}
+
+/**
+ * Applies hyperlinks to any URLs in the provided content.
+ *
+ * @param the text content
+ * @returns a string with any URLs hyperlinked.
+ */
+function linkifyContent(content: string | null): TippyContent {
+    if (content === null) {
+        return '';
+    }
+
+    let res = linkifyHtml(content, {
+        target: '_blank',
+        validate: {
+            url: (value: string) => /^https?:\/\//.test(value) // only links that begin with a protocol will be hyperlinked
+        }
+    });
+    res = `<div style='word-break: break-all; text-wrap: wrap;'>${res}</div>`;
+
+    return <TippyContent>res;
+}

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -210,7 +210,7 @@ editor.slides.toc.copySlide,Copy Slide,1,Copier la diapositive,0
 editor.slides.toc.deleteSlide,Delete Slide,1,Supprimer la diapositive,0
 editor.slides.toc.newENGSlideText,New EN Slide*,1,Nouvelle diapositive AN*,0
 editor.slides.toc.newFRSlideText,New FR Slide*,1,Nouvelle diapositive FR*,0
-editor.slides.toc.noENGslide,(No English Config),1,(Pas de configuration Anglais),0
+editor.slide.toc.noENGslide,(No English Config),1,(Pas de configuration Anglais),0
 editor.slide.toc.noFRSlide,(No French Config),1,(Pas de configuration française),0
 editor.slide.toc.untitledENG,(Untitled English slide),1,(Diapositive anglaise sans titre),0
 editor.slide.toc.untitledFR,(Untitled French slide),1,(Diapositive française sans titre),0

--- a/src/main.ts
+++ b/src/main.ts
@@ -36,6 +36,7 @@ import StorylinesViewer from 'ramp-storylines_demo-scenarios-pcar';
 import 'ramp-storylines_demo-scenarios-pcar/dist/style.css';
 
 import { FocusContainer, FocusItem, FocusList } from '@/directives/focus-list';
+import { Truncate } from '@/directives/truncate/truncate';
 
 const app = createApp(App);
 const pinia = createPinia();
@@ -56,4 +57,5 @@ app.use(pinia)
 app.directive('focus-container', FocusContainer);
 app.directive('focus-list', FocusList);
 app.directive('focus-item', FocusItem);
+app.directive('truncate', Truncate);
 app.mount('#app');


### PR DESCRIPTION
### Related Item(s)
#416 
#488

### Changes
- Added the truncate directive, so that slide buttons in the ToC have a tooltip only if their text is truncated
- Created a new component for slide ToC buttons, due to lots of repetition between the en and fr buttons

### Testing
Steps:
1. Load any product into editor-main
2. Hover over the buttons in the slide ToC
3. Ensure that a tooltip for a button only appears if the text is truncated
4. Also ensure that the text is at most two lines for each button
5. Click on the options (`...`) button for a slide ToC button, and ensure that the `Clear content` and `Copy from other config` features still work correctly
6. Introduce a new slide in one of the configs (would have to edit the json) but not the other, and ensure that you can correctly copy the content of the opposite config or create a new config
7. Ensure that reordering slides doesn't have any issues
8. Ensure that when renaming a slide, the slides name is correctly updated in the corresponding slide ToC button
9. Ensure that the `Copy Slide` feature still works correctly
10. Ensure that the above steps also work for a mobile ToC
