### PR TITLE
add intro background customization to metadata editor

### DIFF
--- a/StorylinesSchema.json
+++ b/StorylinesSchema.json
@@ -103,7 +103,7 @@
                 "type": {
                     "type": "string",
                     "enum": ["dynamic"]
-                }, 
+                },
                 "modified": {
                     "type": "boolean",
                     "description": "An optional tag that specifies whether the panel has been modified from its default configuration"
@@ -189,7 +189,7 @@
                 "title": {
                     "type": "string",
                     "description": "A title that is displayed centered above this map."
-                }, 
+                },
                 "caption": {
                     "type": "string",
                     "description": "Supporting text content for the map."
@@ -289,7 +289,7 @@
                 "type": {
                     "type": "string",
                     "enum": ["video"]
-                }, 
+                },
                 "modified": {
                     "type": "boolean",
                     "description": "An optional tag that specifies whether the panel has been modified from its default configuration"
@@ -361,7 +361,20 @@
                 "type": {
                     "type": "string",
                     "description": "The type of chart.",
-                    "enum": ["line", "spline", "area", "areaspline", "column", "bar", "pie", "scatter", "gauge", "arearange", "areasplinerange", "columnrange"]
+                    "enum": [
+                        "line",
+                        "spline",
+                        "area",
+                        "areaspline",
+                        "column",
+                        "bar",
+                        "pie",
+                        "scatter",
+                        "gauge",
+                        "arearange",
+                        "areasplinerange",
+                        "columnrange"
+                    ]
                 },
                 "width": {
                     "type": "number",
@@ -436,6 +449,10 @@
                 "blurb": {
                     "type": "string",
                     "description": "Any additional information to display on the introductory slide."
+                },
+                "backgroundImage": {
+                    "type": "string",
+                    "description": "A background image for the introduction slide."
                 }
             },
             "required": ["logo", "title"]

--- a/src/components/helpers/metadata-content.vue
+++ b/src/components/helpers/metadata-content.vue
@@ -115,14 +115,14 @@
                     <input
                         type="text"
                         id="metaLogo"
-                        @change="$emit('logo-source-changed', $event)"
+                        @change="$emit('image-source-changed', $event, 'logo')"
                         :value="metadata.logoName"
                         class="metadata-input editor-input w-full lg:w-1/2"
                     />
                     <!-- Upload button -->
                     <button
-                        @click.stop="openFileSelector"
-                        class="editor-button py-1.5 bg-black border border-black text-white hover:bg-gray-800"
+                        @click.stop="openFileSelector('logoUpload')"
+                        class="editor-button mb-0.5 bg-black border border-black text-white hover:bg-gray-800"
                     >
                         {{ $t('editor.browse') }}
                     </button>
@@ -155,7 +155,7 @@
             <input
                 type="file"
                 id="logoUpload"
-                @change="$emit('logo-changed', $event)"
+                @change="$emit('image-changed', $event, 'logo')"
                 class="editor-input w-1/4"
                 style="display: none"
             />
@@ -177,6 +177,66 @@
                 </div>
                 <p v-if="!editing">{{ metadata.logoAltText || $t('editor.metadataForm.na') }}</p>
             </div>
+        </section>
+        <!-- Subsection: Intro background stuff -->
+        <section>
+            <div class="metadata-item">
+                <label class="metadata-label" for="metaIntroBg">{{ $t('editor.introBackground') }}</label>
+                <div v-show="editing">
+                    <!-- Intro slide background URL -->
+                    <div class="flex flex-wrap gap-2 items-center">
+                        <input
+                            type="text"
+                            id="metaIntroBg"
+                            @change="$emit('image-source-changed', $event, 'introBg')"
+                            :value="metadata.introBgName"
+                            class="metadata-input editor-input w-full lg:w-1/2"
+                        />
+                        <!-- Upload button -->
+                        <button
+                            @click.stop="openFileSelector('backgroundUpload')"
+                            class="editor-button mb-0.5 bg-black border border-black text-white hover:bg-gray-800"
+                        >
+                            {{ $t('editor.browse') }}
+                        </button>
+                        <!-- Delete button -->
+                        <button
+                            v-if="metadata.introBgName || metadata.introBgPreview"
+                            @click.stop="removeIntroBackground"
+                            class="editor-button border mb-0.5 border-black"
+                        >
+                            {{ $t('editor.remove') }}
+                        </button>
+                    </div>
+                    <p class="metadata-subcaption">
+                        {{ $t('editor.metadataForm.caption.introBackground') }}
+                    </p>
+                </div>
+
+                <p class="break-all" v-if="!editing">{{ metadata.introBgName || $t('editor.metadataForm.na') }}</p>
+            </div>
+            <!-- Logo Preview -->
+            <div v-if="!!metadata.introBgPreview" class="metadata-item">
+                <div class="metadata-label">{{ $t('editor.introBackgroundPreview') }}:</div>
+                <img
+                    :src="metadata.introBgPreview"
+                    v-if="!!metadata.introBgPreview && metadata.introBgPreview != 'error'"
+                    class="image-preview"
+                    :alt="$t('editor.introBackgroundPreview')"
+                />
+                <p v-if="metadata.introBgPreview == 'error'" class="image-preview">
+                    {{ $t('editor.image.loadingError') }}
+                </p>
+            </div>
+            <!-- hide the actual file input. Label prevents a WAVE error -->
+            <label style="display: none" for="backgroundUpload">Intro background upload</label>
+            <input
+                type="file"
+                id="backgroundUpload"
+                @change="$emit('image-changed', $event, 'introBg')"
+                class="editor-input w-1/4"
+                style="display: none"
+            />
         </section>
     </section>
     <!-- Section: End of page information -->
@@ -245,8 +305,8 @@ export default class MetadataEditorV extends Vue {
     @Prop() metadata!: MetadataContent;
     @Prop({ default: true }) editing!: boolean;
 
-    openFileSelector(): void {
-        document.getElementById('logoUpload')?.click();
+    openFileSelector(where: string = 'logoUpload'): void {
+        document.getElementById(where)?.click();
     }
 
     metadataChanged(event: Event): void {
@@ -260,6 +320,11 @@ export default class MetadataEditorV extends Vue {
     removeLogo(): void {
         this.metadata.logoName = '';
         this.metadata.logoPreview = '';
+    }
+
+    removeIntroBackground(): void {
+        this.metadata.introBgName = '';
+        this.metadata.introBgPreview = '';
     }
 }
 </script>

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -36,6 +36,8 @@ export interface MetadataContent {
     logoPreview: string;
     logoName: string;
     logoAltText: string;
+    introBgName: string;
+    introBgPreview: string;
     contextLink: string;
     contextLabel: string;
     tocOrientation: string;
@@ -133,7 +135,7 @@ export interface Intro {
     title: string;
     subtitle: string;
     blurb?: string;
-    backgroundImage: string;
+    backgroundImage?: string;
 }
 
 export interface Slide {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -52,9 +52,9 @@ editor.editMetadata.message.error.noResponseFromServer,"Failed to load product, 
 editor.editMetadata.message.error.malformedProduct,The requested product {uuid} is malformed.,1,Le produit demandé {uuid} est mal formé.,0
 editor.editMetadata.message.error.failedSave,Failed to save changes.,1,Échec de l'enregistrement des modifications.,0
 editor.editMetadata.message.error.unauthorized,The product is being accessed by another user. Please try again later.,1,[FR] The product is being accessed by another user. Please try again later.,0
-editor.editMetadata.message.error.logoFailedLoad,Failed to load logo image.,1,Échec du chargement de l'image du logo.,0
+editor.editMetadata.message.error.imageFailedLoad,Failed to load image.,1,Échec du chargement de l'image.,0
 editor.editMetadata.message.error.requiredFieldsNotFilled,Please fill out the required fields before proceeding.,1,Veuillez remplir les champs obligatoires avant de continuer.,0
-editor.editMetadata.message.logoSuccessfulLoad,Successfully loaded logo image.,1,Image du logo chargée avec succès.,0
+editor.editMetadata.message.imageSuccessfulLoad,Successfully loaded image.,1,Logo chargé avec succès.,0
 editor.editMetadata.message.successfulLoad,Successfully loaded storyline!,1,Scénario chargé avec succès!,0
 editor.editMetadata.message.successfulSave,Successfully saved changes!,1,Modifications enregistrées avec succès!,0
 editor.editMetadata.message.noSave,No unsaved changes detected,1,[FR] No unsaved changes detected,0
@@ -74,6 +74,7 @@ editor.metadataForm.caption.tocOrientation,"Determines the direction of the stor
 editor.metadataForm.caption.introTitle,"The intro title is the title displayed in large text on the first slide, right underneath the logo (if given).",1,"Le titre d'introduction est le titre affiché en gros texte sur la première diapositive, juste en dessous du logo (s'il est fourni).",0
 editor.metadataForm.caption.introSubtitle,"The intro subtitle displays underneath the intro title, in small text.",1,"Le sous-titre d'introduction s'affiche sous le titre d'introduction, en petit texte.",0
 editor.metadataForm.caption.logoAltText,"For accessibility purposes, provide description text for the logo.",1,"À des fins d’accessibilité, veuillez fournir un texte de description pour le logo.",0
+editor.metadataForm.caption.introBackground,"The background image is displayed on the first slide of the storyline product, behind the intro title and subtitle.",1,"L'image d'arrière-plan est affichée sur la première diapositive du produit de scénario, derrière le titre et le sous-titre d'introduction.",0
 editor.metadataForm.caption.contextLink,"Context link shows up at the bottom of the page to provide additional resources for interested users.",1,"Le lien contextuel apparaît au bas de la page pour fournir des ressources supplémentaires aux utilisateurs intéressés.",0
 editor.metadataForm.caption.contextLabel,"Context label shows up as text. When users click the context link, the linked site appears in a new tab for the user.",1,"L'étiquette de contexte s'affiche sous forme de texte. Lorsque les utilisateurs cliquent sur le lien contextuel, le site lié apparaît dans un nouvel onglet pour l'utilisateur.",0
 editor.metadataForm.introPage.heading,Introduction page details,1,Détails de la page d'introduction,0
@@ -112,6 +113,8 @@ editor.logoPreview,Logo preview,1,Aperçu du logo,1
 editor.logoPreviewAltText,Preview of product logo,1,Aperçu du logo du produit,0
 editor.logoAltText,Logo alt text,1,Lien contextuel,1
 editor.logoAltText.desc,"For accessibility purposes, provide description text for the logo.",1,"Pour des raisons d'accessibilité, fournissez un texte descriptif pour le logo.",0
+editor.introBackground,Background image,1,Image d'arrière-plan,0
+editor.introBackgroundPreview,Background image preview,1,Aperçu de l'image d'arrière-plan,0
 editor.contextLink,Context link,1,Lien contextuel,1
 editor.contextLink.info,Context link shows up at the bottom of the page to provide additional resources for interested users.,1,Le lien contextuel apparaît au bas de la page et fournit des ressources supplémentaires aux utilisateurs intéressés.,1
 editor.contextLabel,Context label,1,Étiquette de contexte,1


### PR DESCRIPTION
### Related Item(s)
#494 

### Changes
- Adds a new section to the metadata editor to allow uploading a background image for the introduction slide.
- Refactored the logo upload functions in `metadata-editor.vue` to be less logo-specific so I could reuse them for the intro background as well.

### Notes
This PR doesn't add support for modifying the text colour of the title, subtitle, and "scroll to story" button, which Storylines does support. ~~I will create a new issue and begin working on this next.~~ [PR can be found here](https://github.com/ramp4-pcar4/storylines-editor/pull/508).

### Testing
Steps:
1. Open the demo link.
2. Play around with uploading a background image to both new and existing products.
3. Try to upload just a background image and not a logo (and vice-versa). Ensure that things are being uploaded in the right place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/505)
<!-- Reviewable:end -->
