### PR TITLE
add colour picker for intro title, subtitle and button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
                 "url": "^0.11.3",
                 "uuid": "^9.0.0",
                 "vue": "^3.4.37",
+                "vue-accessible-color-picker": "^5.1.1",
                 "vue-class-component": "^8.0.0-rc.1",
                 "vue-final-modal": "^4.4.5",
                 "vue-i18n": "^9.2.2",
@@ -8326,6 +8327,14 @@
                 "node": ">=10"
             }
         },
+        "node_modules/ramp-pcar/node_modules/vue-accessible-color-picker": {
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/vue-accessible-color-picker/-/vue-accessible-color-picker-4.1.4.tgz",
+            "integrity": "sha512-uq5wPWiR+VeuaZGxWRKuZSKpf2WH1EHa0Oas+rsEdgw35zZ/zotpw5LvyMiqbAagpiHxCp0AzqwDkMJ7dSbGQA==",
+            "peerDependencies": {
+                "vue": "^3.2.x"
+            }
+        },
         "node_modules/ramp-storylines_demo-scenarios-pcar": {
             "version": "3.2.9",
             "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.2.9.tgz",
@@ -10364,10 +10373,9 @@
             }
         },
         "node_modules/vue-accessible-color-picker": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/vue-accessible-color-picker/-/vue-accessible-color-picker-4.1.4.tgz",
-            "integrity": "sha512-uq5wPWiR+VeuaZGxWRKuZSKpf2WH1EHa0Oas+rsEdgw35zZ/zotpw5LvyMiqbAagpiHxCp0AzqwDkMJ7dSbGQA==",
-            "license": "MIT",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/vue-accessible-color-picker/-/vue-accessible-color-picker-5.1.1.tgz",
+            "integrity": "sha512-vk+0OicECr58EnxaQ8h/MuYfzRLS7FgBGUkBVEiRy71j/XVPZ84QCwho2KsURGeoDSr16ELI1+Ao3Hqp2PPCHw==",
             "peerDependencies": {
                 "vue": "^3.2.x"
             }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "url": "^0.11.3",
         "uuid": "^9.0.0",
         "vue": "^3.4.37",
+        "vue-accessible-color-picker": "^5.1.1",
         "vue-class-component": "^8.0.0-rc.1",
         "vue-final-modal": "^4.4.5",
         "vue-i18n": "^9.2.2",

--- a/src/components/helpers/colour-picker-input.vue
+++ b/src/components/helpers/colour-picker-input.vue
@@ -1,0 +1,95 @@
+<template>
+    <div class="flex flex-col items-start relative">
+        <div class="metadata-input flex flex-col p-0 w-full">
+            <div class="flex">
+                <div
+                    @click="togglePicker"
+                    @keypress.enter="togglePicker"
+                    :style="{ 'background-color': selectedColour }"
+                    :class="!disabled ? 'cursor-pointer' : ''"
+                    class="flex flex-1 rounded-l w-10"
+                    :tabindex="!disabled ? 0 : -1"
+                    v-tippy="{
+                        delay: '200',
+                        placement: 'top',
+                        content: !disabled
+                            ? isOpen
+                                ? $t('editor.colourPicker.close')
+                                : $t('editor.colourPicker.open')
+                            : '',
+                        animateFill: true
+                    }"
+                >
+                    <span v-if="isOpen" class="text-white mx-auto self-center font-bold mix-blend-difference">X</span>
+                </div>
+                <input
+                    :disabled="disabled"
+                    class="text-center py-2 rounded-r hover:bg-gray-100"
+                    :aria-label="name"
+                    :value="selectedColour"
+                    @input="(evt) => selectedColour = (evt.target as HTMLInputElement).value"
+                />
+            </div>
+            <ColorPicker
+                v-if="isOpen"
+                :color="value"
+                alpha-channel="hide"
+                :visible-formats="['hex']"
+                default-format="hex"
+                @color-change="(evt: any) => this.selectedColour = evt.cssColor"
+            >
+                <template #copy-button></template>
+            </ColorPicker>
+        </div>
+    </div>
+</template>
+
+<script lang="ts">
+import { Prop, Vue, Watch } from 'vue-property-decorator';
+
+export default class LoadingPageV extends Vue {
+    @Prop() value!: string;
+    @Prop() name!: string;
+    @Prop() disabled?: boolean;
+
+    isOpen: boolean = false;
+    selectedColour: string = '';
+
+    beforeMount(): void {
+        this.selectedColour = this.value;
+    }
+
+    /**
+     * If component is enabled, toggle the colour picker visibility.
+     */
+    togglePicker(): void {
+        if (!this.disabled) this.isOpen = !this.isOpen;
+    }
+
+    /**
+     * Watches the selectedColour property and emits a change event when it changes. The event emitted mimics an "HTMLInputEvent" so that
+     * we don't need to make any modifications to the `metadataChanged` event listener in `metadata-content.vue`.
+     * @param evt a string representing the new colour value.
+     */
+    @Watch('selectedColour')
+    colourChanged(evt: Event): void {
+        // If the value didn't change, don't fire the event.
+        if (this.value === this.selectedColour) return;
+
+        this.$emit('change', {
+            target: {
+                name: this.name,
+                value: this.selectedColour
+            }
+        });
+    }
+}
+</script>
+
+<style scoped lang="scss">
+:deep(.vacp-color-inputs),
+:deep(.vacp-copy-button),
+:deep(.vacp-range-input-label-text--hue) {
+    display: none;
+}
+</style>

--- a/src/components/helpers/metadata-content.vue
+++ b/src/components/helpers/metadata-content.vue
@@ -177,6 +177,58 @@
                 </div>
                 <p v-if="!editing">{{ metadata.logoAltText || $t('editor.metadataForm.na') }}</p>
             </div>
+            <div class="flex flex-wrap gap-4">
+                <div class="metadata-item">
+                    <span class="metadata-label">{{ $t('editor.introTitleColour') }}</span>
+                    <ColourPickerInput
+                        name="titleColour"
+                        :value="metadata.titleColour"
+                        @change="metadataChanged"
+                        :disabled="!editing"
+                    />
+                </div>
+                <div class="metadata-item">
+                    <span class="metadata-label">{{ $t('editor.introSubtitleColour') }}</span>
+                    <ColourPickerInput
+                        name="subtitleColour"
+                        :value="metadata.subtitleColour"
+                        @change="metadataChanged"
+                        :disabled="!editing"
+                    />
+                </div>
+                <div class="metadata-item">
+                    <div class="flex gap-2 items-center">
+                        <span class="metadata-label">{{ $t('editor.introButtonColour') }}</span>
+                        <span
+                            :content="$t('editor.colourPicker.label.buttonLabel')"
+                            v-tippy="{ placement: 'top', hideOnClick: false, animateFill: true }"
+                            tabindex="0"
+                        >
+                            <svg
+                                class="fill-current"
+                                xmlns="http://www.w3.org/2000/svg"
+                                xmlns:xlink="http://www.w3.org/1999/xlink"
+                                width="16"
+                                height="16"
+                                viewBox="0 0 416.979 416.979"
+                                xml:space="preserve"
+                            >
+                                <g>
+                                    <path
+                                        d="M356.004,61.156c-81.37-81.47-213.377-81.551-294.848-0.182c-81.47,81.371-81.552,213.379-0.181,294.85   c81.369,81.47,213.378,81.551,294.849,0.181C437.293,274.636,437.375,142.626,356.004,61.156z M237.6,340.786   c0,3.217-2.607,5.822-5.822,5.822h-46.576c-3.215,0-5.822-2.605-5.822-5.822V167.885c0-3.217,2.607-5.822,5.822-5.822h46.576   c3.215,0,5.822,2.604,5.822,5.822V340.786z M208.49,137.901c-18.618,0-33.766-15.146-33.766-33.765   c0-18.617,15.147-33.766,33.766-33.766c18.619,0,33.766,15.148,33.766,33.766C242.256,122.755,227.107,137.901,208.49,137.901z"
+                                    />
+                                </g>
+                            </svg>
+                        </span>
+                    </div>
+                    <ColourPickerInput
+                        name="buttonColour"
+                        :value="metadata.buttonColour"
+                        @change="metadataChanged"
+                        :disabled="!editing"
+                    />
+                </div>
+            </div>
         </section>
     </section>
     <!-- Section: End of page information -->
@@ -239,8 +291,14 @@
 
 <script lang="ts">
 import { MetadataContent } from '@/definitions';
-import { Prop, Vue } from 'vue-property-decorator';
+import { Options, Prop, Vue } from 'vue-property-decorator';
+import ColourPickerInput from './colour-picker-input.vue';
 
+@Options({
+    components: {
+        ColourPickerInput: ColourPickerInput
+    }
+})
 export default class MetadataEditorV extends Vue {
     @Prop() metadata!: MetadataContent;
     @Prop({ default: true }) editing!: boolean;

--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -691,6 +691,9 @@ export default class MetadataEditorV extends Vue {
         logoPreview: '',
         logoName: '',
         logoAltText: '',
+        titleColour: '#1f2937',
+        subtitleColour: '#6b7280',
+        buttonColour: '#00d2d3',
         contextLink: '',
         contextLabel: '',
         tocOrientation: '',
@@ -706,6 +709,9 @@ export default class MetadataEditorV extends Vue {
         logoPreview: '',
         logoName: '',
         logoAltText: '',
+        titleColour: '',
+        subtitleColour: '',
+        buttonColour: '',
         contextLink: '',
         contextLabel: '',
         tocOrientation: '',
@@ -983,7 +989,10 @@ export default class MetadataEditorV extends Vue {
                     src: ''
                 },
                 title: this.metadata.introTitle,
-                subtitle: this.metadata.introSubtitle
+                subtitle: this.metadata.introSubtitle,
+                titleColour: this.metadata.titleColour,
+                subtitleColour: this.metadata.subtitleColour,
+                buttonColour: this.metadata.buttonColour
             },
             slides: [],
             contextLabel: this.metadata.contextLabel,
@@ -1491,6 +1500,9 @@ export default class MetadataEditorV extends Vue {
         this.metadata.title = config.title;
         this.metadata.introTitle = config.introSlide.title;
         this.metadata.introSubtitle = config.introSlide.subtitle;
+        this.metadata.titleColour = config.introSlide.titleColour ?? '#1f2937';
+        this.metadata.subtitleColour = config.introSlide.subtitleColour ?? '#6b7280';
+        this.metadata.buttonColour = config.introSlide.buttonColour ?? '#00d2d3';
         this.metadata.contextLink = config.contextLink;
         this.metadata.contextLabel = config.contextLabel;
         this.metadata.tocOrientation = config.tocOrientation;
@@ -1766,6 +1778,9 @@ export default class MetadataEditorV extends Vue {
             config.title = this.metadata.title;
             config.introSlide.title = this.metadata.introTitle;
             config.introSlide.subtitle = this.metadata.introSubtitle;
+            config.introSlide.titleColour = this.metadata.titleColour;
+            config.introSlide.subtitleColour = this.metadata.subtitleColour;
+            config.introSlide.buttonColour = this.metadata.buttonColour;
             config.contextLink = this.metadata.contextLink;
             config.contextLabel = this.metadata.contextLabel;
             config.tocOrientation = this.metadata.tocOrientation;
@@ -1813,6 +1828,9 @@ export default class MetadataEditorV extends Vue {
             title: '',
             introTitle: '',
             introSubtitle: '',
+            titleColour: '',
+            subtitleColour: '',
+            buttonColour: '',
             contextLink: '',
             contextLabel: '',
             dateModified: '',

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -36,6 +36,9 @@ export interface MetadataContent {
     logoPreview: string;
     logoName: string;
     logoAltText: string;
+    titleColour?: string;
+    subtitleColour?: string;
+    buttonColour?: string;
     contextLink: string;
     contextLabel: string;
     tocOrientation: string;
@@ -134,6 +137,9 @@ export interface Intro {
     subtitle: string;
     blurb?: string;
     backgroundImage: string;
+    titleColour?: string;
+    subtitleColour?: string;
+    buttonColour?: string;
 }
 
 export interface Slide {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -112,6 +112,12 @@ editor.logoPreview,Logo preview,1,Aperçu du logo,1
 editor.logoPreviewAltText,Preview of product logo,1,Aperçu du logo du produit,0
 editor.logoAltText,Logo alt text,1,Lien contextuel,1
 editor.logoAltText.desc,"For accessibility purposes, provide description text for the logo.",1,"Pour des raisons d'accessibilité, fournissez un texte descriptif pour le logo.",0
+editor.introTitleColour,"Title colour",1,Couleur du titre,0
+editor.introSubtitleColour,"Subtitle colour",1,Couleur du sous-titre,0
+editor.introButtonColour,"Button colour",1,Couleur du bouton,0
+editor.colourPicker.open,Open colour picker,1,Ouvrir le sélecteur de couleur,0
+editor.colourPicker.close,Close colour picker,1,Fermer le sélecteur de couleur,0
+editor.colourPicker.label.buttonLabel,Refers to the "scroll to story" button in the introduction slide.,1,Se réfère au bouton « défilement vers l’histoire » dans la diapositive d’introduction.,0
 editor.contextLink,Context link,1,Lien contextuel,1
 editor.contextLink.info,Context link shows up at the bottom of the page to provide additional resources for interested users.,1,Le lien contextuel apparaît au bas de la page et fournit des ressources supplémentaires aux utilisateurs intéressés.,1
 editor.contextLabel,Context label,1,Étiquette de contexte,1

--- a/src/main.ts
+++ b/src/main.ts
@@ -32,6 +32,9 @@ import HighchartsVue from 'highcharts-vue';
 import Message from 'vue-m-message';
 import 'vue-m-message/dist/style.css';
 
+import ColorPicker from 'vue-accessible-color-picker';
+import 'vue-accessible-color-picker/styles';
+
 import StorylinesViewer from 'ramp-storylines_demo-scenarios-pcar';
 import 'ramp-storylines_demo-scenarios-pcar/dist/style.css';
 
@@ -52,6 +55,7 @@ app.use(pinia)
     .use(Message)
     .use(StorylinesViewer)
     .use(VueMarkdownEditor)
+    .use(ColorPicker)
     .use(vfm);
 
 app.directive('focus-container', FocusContainer);

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -18,3 +18,4 @@ declare module 'vue-m-message';
 declare module 'vue3-json-editor';
 declare module 'highcharts-vue';
 declare module 'vue-tippy';
+declare module 'vue-accessible-color-picker';


### PR DESCRIPTION
### Related Item(s)
#506, https://github.com/ramp4-pcar4/storylines-editor/issues/494

### Changes
- Adds a new colour picker component. Allows the user to change the colour of the intro title, subtitle and "scroll to story" button.
- The colour picker is fully keyboard accessible.

### Notes
Open to feedback on the design and functionality!

### Testing
Steps:
1. Create a new product.
2. Play around with the new colour picker fields and ensure everything works properly.
3. Save the product and ensure everything saves correctly.
4. Load an existing product.
5. Repeat step 3 again.
6. Save the product and ensure everything saves correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/508)
<!-- Reviewable:end -->
