### PR TITLE
set loadStatus to loaded when image fails to load

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -809,17 +809,24 @@ export default class MetadataEditorV extends Vue {
                     } else {
                         // Fill in the field with this value whether it exists or not.
                         this.metadata.logoName = logo;
-
                         // If it doesn't exist, maybe it's a remote file?
-                        fetch(logo).then((data: Response) => {
-                            if (data.status !== 404) {
-                                data.blob().then((blob: Blob) => {
-                                    this.logoImage = new File([blob], this.metadata.logoName);
-                                    this.metadata.logoPreview = logo;
+                        fetch(logo)
+                            .then((data: Response) => {
+                                if (data.status === 200) {
+                                    data.blob().then((blob: Blob) => {
+                                        this.logoImage = new File([blob], this.metadata.logoName);
+                                        this.metadata.logoPreview = logo;
+                                        this.loadStatus = 'loaded';
+                                    });
+                                } else {
                                     this.loadStatus = 'loaded';
-                                });
-                            }
-                        });
+                                    this.metadata.logoPreview = 'error';
+                                }
+                            })
+                            .catch((err) => {
+                                this.loadStatus = 'loaded';
+                                this.metadata.logoPreview = 'error';
+                            });
                     }
                 } else {
                     // No logo to load.
@@ -1530,17 +1537,24 @@ export default class MetadataEditorV extends Vue {
             } else {
                 // Fill in the field with this value whether it exists or not.
                 this.metadata.logoName = logo;
-
                 // If it doesn't exist, maybe it's a remote file?
-                fetch(logo).then((data: Response) => {
-                    if (data.status !== 404) {
-                        data.blob().then((blob: Blob) => {
-                            this.logoImage = new File([blob], logoName);
-                            this.metadata.logoPreview = logo;
+                fetch(logo)
+                    .then((data: Response) => {
+                        if (data.status === 200) {
+                            data.blob().then((blob: Blob) => {
+                                this.logoImage = new File([blob], logoName);
+                                this.metadata.logoPreview = logo;
+                                this.loadStatus = 'loaded';
+                            });
+                        } else {
                             this.loadStatus = 'loaded';
-                        });
-                    }
-                });
+                            this.metadata.logoPreview = 'error';
+                        }
+                    })
+                    .catch((err) => {
+                        this.loadStatus = 'loaded';
+                        this.metadata.logoPreview = 'error';
+                    });
             }
         } else {
             // If there's no logo, mark the product as loaded and remove any existing logos


### PR DESCRIPTION
### Related Item(s)
#498 

### Changes
- The editor should no longer display a blank screen when loading a product with a broken logo URL. This was happening because we never set `loadStatus` to `loaded` in the case where the URL errored.
- If the image fails to load, the logo preview state will be set to `error`.

### Testing
Steps:
1. Open the demo link.
2. Attempt to load the `00000000-0000-0000-0000-000000000000` product (the logo URL from GitHub should return a 404).
3. Ensure that the product loads as expected. The `logo preview` section should be in the errored state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/519)
<!-- Reviewable:end -->
