### PR TITLE
fix broken env variable reference when renaming

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -1217,8 +1217,8 @@ export default class MetadataEditorV extends Vue {
                 })
                 .then(async (res: AxiosResponse) => {
                     // Once the server has processed the renaming, update the UUID in the database if not in dev mode.
-                    if (process.env.VUE_APP_NET_API_URL !== undefined) {
-                        await axios.post(process.env.VUE_APP_NET_API_URL + '/api/version/update', {
+                    if (import.meta.env.VITE_APP_NET_API_URL !== undefined) {
+                        await axios.post(import.meta.env.VITE_APP_NET_API_URL + '/api/version/update', {
                             uuid: prevUuid,
                             changeUuid: this.changeUuid
                         });


### PR DESCRIPTION
### Related Item(s)
#523 

### Changes
- Change `process.env.VUE_APP_NET_API_URL` to `import.meta.env.VITE_APP_NET_API_URL` when renaming so that the  `/api/version/update/` endpoint is hopefully hit.

### Notes
Can't say 100% that this will fix the linked issue until we test it on the dev site, but the environment variable should at least be correct now so the POST should be sent.

### Testing
This will require the dev site to be updated in order to test.

Steps:
1. Open the developer console.
2. Load an existing product.
3. Rename the product.
4. Ensure that the `/api/version/update/` endpoint is being hit correctly. 
5. (BONUS) Hopefully the entire issue will be fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/526)
<!-- Reviewable:end -->
