### PR TITLE
fix infinite loading spinner when incorrect UUID is provided

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -1036,6 +1036,7 @@ export default class MetadataEditorV extends Vue {
                         this.clearConfig();
                         // Product was not found, unlock the UUID
                         this.lockStore.unlockStoryline();
+                        reject();
                     } else {
                         const configZip = new JSZip();
                         // Files retrieved. Convert them into a JSZip object.

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -48,7 +48,6 @@ editor.editMetadata.loading,Storyline product is loading. Larger products can ta
 editor.editMetadata.message.error.noConfig,No config exists for storylines product.,1,Aucune configuration n'existe pour le produit Storylines.,0
 editor.editMetadata.message.error.failedZipFile,Failed to process ZIP file.,1,Échec du traitement du fichier ZIP.,0
 editor.editMetadata.message.error.noRequestedVersion,The requested version does not exist.,1,La version demandée n'existe pas.,0
-editor.editMetadata.message.error.noResponseFromServer,"Failed to load product, no response from server",1,"Échec du chargement du produit, aucune réponse du serveur",0
 editor.editMetadata.message.error.malformedProduct,The requested product {uuid} is malformed.,1,Le produit demandé {uuid} est mal formé.,0
 editor.editMetadata.message.error.failedSave,Failed to save changes.,1,Échec de l'enregistrement des modifications.,0
 editor.editMetadata.message.error.unauthorized,The product is being accessed by another user. Please try again later.,1,[FR] The product is being accessed by another user. Please try again later.,0


### PR DESCRIPTION
### Related Item(s)
#522 

### Changes
- Fixes an issue where the loading spinner never disappeared if a non-existent UUID was provided.

### Testing
Steps:
1. Open the demo link.
2. Click "Load Existing Storylines Product".
3. Enter a UUID that doesn't exist.
4. Ensure that the loading spinner doesn't stick around forever. It should disappear as soon as the "UUID doesn't exist" alert pops up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/527)
<!-- Reviewable:end -->
