### PR TITLE
Close BroadcastChannel upon lang change in preview

### DIFF
--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -774,6 +774,7 @@ export default class EditorV extends Vue {
             return slide ?? JSON.parse(JSON.stringify(this.defaultBlankSlide));
         });
         const lockStore = useLockStore();
+
         setTimeout(() => {
             const routeData = this.$router.resolve({
                 name: 'preview',

--- a/src/stores/lockStore.ts
+++ b/src/stores/lockStore.ts
@@ -78,7 +78,6 @@ export const useLockStore = defineStore('lock', {
                         this.uuid = uuid;
                         this.secret = data.secret;
                         this.broadcast = new BroadcastChannel(data.secret);
-
                         resolve();
                     }
                 };


### PR DESCRIPTION
### Related Item(s)
#520

### Changes
- ~~Persist the state of the lock store between tabs, in particular the editor and preview tabs~~
- Close the preview's BroadcastChannel upon lang change (this was causing the reported error)
- Include `secret` within the window props upon lang change in the preview

### Notes
<del> -  I decided to use [this](https://github.com/prazdevs/pinia-plugin-persistedstate) plugin to persist the state of the lock store. If we don't want to use this, let me know of preferred alternatives. I could also try creating our own composable if needed</del>
<del>- I noticed that, within the preview component, when `window.props` is not defined (which occurs upon reloading the tab), the BroadcastChannel was not being created. Was this intentional? Currently I'm creating the BroadcastChannel in both cases (hence the plugin), but I can revert this if necessary </del>

### Testing
Steps:
1. Load any product
2. Open devtools
3. Within the metadata editor, preview the product
4. Within the preview tab open devtools
5. Move your mouse around in the preview tab
6. Switch back to the editor tab, and notice the console logs indicating that the messages sent by the preview's BroadcastChannel were received
7. Within the preview tab switch languages and repeat 5-6
8. Within the preview tab refresh and repeat 5-6
9. Throughout the testing, the 'Session Extended' toast should not appear on mouse movement in the preview tab

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/531)
<!-- Reviewable:end -->
