### PR TITLE
Delay metadata component load until after config is received

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -1102,6 +1102,7 @@ export default class MetadataEditorV extends Vue {
                                 this.extendSession();
                                 this.error = false;
                                 this.warning = 'none';
+                                this.loadStatus = 'loaded';
                             });
                         });
                     }
@@ -1209,7 +1210,6 @@ export default class MetadataEditorV extends Vue {
             } else {
                 res.json().then((json) => {
                     this.storylineHistory = json;
-                    this.loadStatus = 'loaded';
                 });
             }
         });


### PR DESCRIPTION
### Related Item(s)
#521

### Changes
- Prevent the metadata content component from loading in (via setting `loadStatus` to 'loaded') until the product's config is received from the server
- Fix issue with `broadcastToClients()` in the server

### Testing
Steps:
1. Load in a large product (ex. TCEI)
2. Notice that the metadata component loads in with all metadata visible (i.e. no N/A values, unless explicitly left blank)
3. Click Next to proceed to editor-main
4. There should be no toast with the message "No config exists for storylines product"

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/553)
<!-- Reviewable:end -->
