### PR TITLE
Load product on page lang change and router param update

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -670,7 +670,7 @@ wss.on('connection', (ws) => {
                 logger('INFO', `A client successfully unlocked the storyline ${uuid}.`);
                 delete lockedUuids[uuid];
                 delete ws.uuid;
-                ws.send(JSON.stringify({ status: 'success', clientId }));
+                //ws.send(JSON.stringify({ status: 'success', clientId }));
 
                 broadcastToClients({
                     type: 'unlock',

--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -20,7 +20,7 @@
                             v-if="!currentRoute.includes('index-ca')"
                             :to="{
                                 name: editExisting ? 'metadataExisting' : 'metadataNew',
-                                params: { lang: currLang === 'en' ? 'fr' : 'en' }
+                                params: { lang: currLang === 'en' ? 'fr' : 'en', uid: uuid }
                             }"
                             class="sub-link"
                         >
@@ -747,7 +747,6 @@ export default class MetadataEditorV extends Vue {
 
     created(): void {
         this.loadExisting = this.editExisting;
-
         // Generate UUID for new product
         this.uuid = (this.$route.params.uid as string) ?? (this.loadExisting ? undefined : uuidv4());
         this.configLang = (this.$route.params.lang as string) || 'en';

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -32,7 +32,7 @@ const routes = [
         }
     },
     {
-        path: '/:lang/editor-metadata',
+        path: '/:lang/editor-metadata/:uid?',
         name: 'metadataExisting',
         component: MetadataEditorV,
         props: { editExisting: true },
@@ -43,11 +43,6 @@ const routes = [
         name: 'metadataNew',
         component: MetadataEditorV,
         props: { editExisting: false },
-        meta: { title: 'editor.window.title' }
-    },
-    {
-        path: '/:lang/editor-metadata/:uid',
-        component: MetadataEditorV,
         meta: { title: 'editor.window.title' }
     },
     {


### PR DESCRIPTION
### Related Item(s)
#552

### Changes
- Within `editor-metadata`, product gets loaded in again upon a page lang change, by passing the product's uuid in the router link
   - Also set `uid` as a temporary prop for the `metadataExisting` route
- When updating router param from `editor-main` to `editor-metadata` (as well as changing page lang), the product gets loaded successfully, by preventing an unlock message from being sent to the web socket

### Notes
- I noticed that, when updating the router params to access a product, the message to unlock the product gets sent (almost) at the same time as the message to lock the product
- Due to this, the `handleMessage` event handler is only able to process one of them, and since the unlock message is sent slightly before the lock message, that is the one that gets processed
- This message handling causes the secret to be removed from the lock store, and thus prevents the product from loading in
- Since a call to `unlockStorylines()` already takes place upon updating router params, I decided to comment out [this](https://github.com/ramp4-pcar4/storylines-editor/blob/be1b4344027aca9e5544adbb0ea6e5b2113b9bdd/server/index.js#L663) line to prevent a message from being sent to the web socket upon product unlock. This doesn't seem to cause any issues based on my testing, but lmk if this could be problematic

### Testing
Will need to update server locally to test this

Steps:
1. Comment out  [this](https://github.com/ramp4-pcar4/storylines-editor/blob/be1b4344027aca9e5544adbb0ea6e5b2113b9bdd/server/index.js#L663)  line in your local server
2. Load any product 
3. Switch the page lang using the lang toggle
4. Observe that the product loads in again
5. Switch the page lang in the router params
6. Observe that the product loads in again
7. Click next to move to `editor-main`
8. Go back to `editor-metadata` by updating the router params
9. Observe that the product load in again

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/555)
<!-- Reviewable:end -->
