### PR TITLE
Implement unique client ID in web socket connection

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -857,13 +857,15 @@ export default class MetadataEditorV extends Vue {
     handleSessionTimeout(): void {
         // We prompt the user to extend the session when session warn minutes have passed.
         const warnTime = import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_WARN) : 5;
+        const isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+        const timeBuffer = isFirefox ? 2000 : 0;
         this.lockStore.confirmationTimeout = setTimeout(() => {
             // First, remove inactivity event listeners, otherwise moving the mouse will extend the session!.
             document.onmousemove = () => undefined;
             document.onkeydown = () => undefined;
             this.$vfm.open(`confirm-extend-session-editor`);
             this.lockStore.broadcast?.postMessage({ action: 'confirm', value: this.lockStore.timeRemaining });
-        }, this.lockStore.timeRemaining * 1000 - warnTime * 60 * 1000);
+        }, this.lockStore.timeRemaining * 1000 - warnTime * 60 * 1000 + timeBuffer);
         // After the timer has run out, if the session was not extended, go back to the landing page (which will unlock the storyline).
         this.lockStore.endTimeout = setTimeout(() => {
             // First, remove inactivity event listeners, otherwise moving the mouse will extend the session!.
@@ -876,7 +878,7 @@ export default class MetadataEditorV extends Vue {
             } else {
                 this.generateConfig();
             }
-        }, this.lockStore.timeRemaining * 1000 + 1000);
+        }, this.lockStore.timeRemaining * 1000 + 1000 + timeBuffer);
         // Now add event listeners to detect for inactivity.
         document.onmousemove = () => this.extendSession();
         document.onkeydown = () => this.extendSession();

--- a/src/stores/lockStore.ts
+++ b/src/stores/lockStore.ts
@@ -1,23 +1,24 @@
 import { defineStore } from 'pinia';
+import { v4 as uuidv4 } from 'uuid';
 
 export const useLockStore = defineStore('lock', {
     state: () => ({
         socket: undefined as WebSocket | undefined,
         uuid: '',
         secret: '',
+        clientId: '',
         connected: false,
         received: false,
         timeInterval: undefined as NodeJS.Timeout | undefined,
         timeRemaining: 100000000000000, // in seconds
-        result: {} as any,
         broadcast: undefined as BroadcastChannel | undefined,
         confirmationTimeout: undefined as NodeJS.Timeout | undefined, // the timer to show the session extension confirmation modal
-        endTimeout: undefined as NodeJS.Timeout | undefined, // the timer to kill the session due to timeout
+        endTimeout: undefined as NodeJS.Timeout | undefined // the timer to kill the session due to timeout
     }),
     actions: {
         // Opens a connection with the web socket
         initConnection() {
-            return new Promise((resolve) => {
+            return new Promise<void>((resolve) => {
                 const socketUrl = `${
                     import.meta.env.VITE_APP_CURR_ENV ? import.meta.env.VITE_APP_API_URL : 'http://localhost:6040'
                 }`;
@@ -26,18 +27,27 @@ export const useLockStore = defineStore('lock', {
                 // Connection opened
                 this.socket.onopen = () => {
                     this.connected = true;
+                    this.clientId = uuidv4();
                     resolve();
                 };
 
-                // Listen for messages
-                this.socket.onmessage = (event) => {
-                    const res = JSON.parse(event.data);
-                    this.received = true;
-                    this.result = res;
+                this.socket.onerror = () => {
+                    console.log('Socket connection errored!');
                 };
+
+                // Spam the server with nonsense messages every 30 seconds to prevent firefox from nuking the connection.
+                const msgSpam = setInterval(() => {
+                    this.socket?.send(JSON.stringify({ status: 'nonsense' }));
+                }, 30000);
+
+                // Close the socket connection before the user closes the window.
+                window.addEventListener('beforeunload', () => {
+                    clearInterval(msgSpam);
+                    this.socket?.close();
+                });
             });
         },
-         // Attempts to lock a storyline for this user.
+        // Attempts to lock a storyline for this user.
         // Returns a promise that resolves if the lock was successfully fetched and rejects if it was not.
         async lockStoryline(uuid: string): Promise<void> {
             // Stop the previous storyline's timer
@@ -50,25 +60,26 @@ export const useLockStore = defineStore('lock', {
 
             return new Promise((resolve, reject) => {
                 this.received = false;
-                this.socket?.send(JSON.stringify({ uuid, lock: true }));
+                this.socket?.send(JSON.stringify({ uuid, lock: true, clientId: this.clientId }));
 
                 const handleMessage = (event: MessageEvent) => {
                     const data = JSON.parse(event.data);
 
-                    if(data !== undefined){
-                        if(data.status === 'fail'){
-                            this.socket!.removeEventListener('message', handleMessage);
-                            reject(new Error(data.message || 'Failed to lock storyline.'));
-                        }
-                        else if (data.status === 'success') {
-                            this.socket!.removeEventListener('message', handleMessage);
+                    if (!data || data.status === 'nonsense' || data.clientId !== this.clientId) {
+                        return;
+                    }
 
-                            this.uuid = uuid;
-                            this.secret = data.secret; 
-                            this.broadcast = new BroadcastChannel(data.secret);
+                    if (data.status === 'fail') {
+                        this.socket!.removeEventListener('message', handleMessage);
+                        reject(new Error(data.message || 'Failed to lock storyline.'));
+                    } else if (data.status === 'success') {
+                        this.socket!.removeEventListener('message', handleMessage);
 
-                            resolve();
-                        }
+                        this.uuid = uuid;
+                        this.secret = data.secret;
+                        this.broadcast = new BroadcastChannel(data.secret);
+
+                        resolve();
                     }
                 };
 
@@ -79,7 +90,7 @@ export const useLockStore = defineStore('lock', {
         unlockStoryline() {
             clearInterval(this.timeInterval);
             if (this.connected) {
-                this.socket!.send(JSON.stringify({ uuid: this.uuid, lock: false }));
+                this.socket!.send(JSON.stringify({ uuid: this.uuid, lock: false, clientId: this.clientId }));
                 this.uuid = '';
                 this.secret = '';
                 this.broadcast?.postMessage({ action: 'end' });


### PR DESCRIPTION
### Changes
- Fixed an issue where one storyline could acquire the secret key of a different storyline due to a race condition, which would prevent it from saving itself.
- Fixed an issue where the web socket server connection would be lost mid session in Firefox, causing storylines to be locked forever.

### Testing
Steps for first fix:

1. Open the dev site in several tabs (or partner up with someone on the team).
2. Attempt to load and save several different storylines simultaneously or as close to each other as possible.
3. Ensure everything is respectful.

Steps for second fix:

1. Open the dev site in Firefox.
2. Load storylines, create new storylines, save storylines, let the timer expire, try other stuff.
3. Ensure that at no point in time you get a message in the console along the lines of "The connection to wss:// was interrupted while the page was loading."
4. Ensure storylines are not locked forever.