### PR TITLE
Reintroduce garbage collection

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ var bodyParser = require('body-parser'); //connects bodyParsing middleware
 var formidable = require('formidable');
 var path = require('path'); //used for file path
 var fs = require('fs-extra'); //File System-needed for renaming file etc
+var recursiveRead = require('recursive-readdir');
 var cors = require('cors');
 var moment = require('moment'); // require
 const decompress = require('decompress');
@@ -121,7 +122,46 @@ app.route(ROUTE_PREFIX + '/upload/:id').post(function (req, res, next) {
         }
         // Unzip the contents of the uploaded zip file into the target directory. Will overwrite
         // old files in the folder.
-        decompress(secureFilename, fileName).then(async () => {
+        decompress(secureFilename, fileName).then(async (files) => {
+            // Below is some logic to remove items from the server directory that are no longer used.
+            const config_en = JSON.stringify(
+                JSON.parse(files.find((file) => file.path === `${req.params.id}_en.json`).data)
+            );
+            const config_fr = JSON.stringify(
+                JSON.parse(files.find((file) => file.path === `${req.params.id}_fr.json`).data)
+            );
+            // Retrieve the existing files in the directory and change the path. Ignore all files within the
+            // .git folder
+            const existingFiles = recursiveRead(fileName).then((existing) => {
+                return existing
+                    .map((item) => {
+                        item = item.replace(/\\/g, '/');
+                        return item.substring(item.indexOf('/', item.indexOf('/', 2) + 1) + 1);
+                    })
+                    .filter((item) => item.split('/')[0] !== '.git');
+            });
+
+            // Once the existing files are retrieved, parse the new files being uploaded
+            // and check to see if any of the existing files have been removed from the
+            // project (if they've been removed, they won't be in the new file list).
+            existingFiles.then((existing) => {
+                var newFiles = files.filter((x) => x.type == 'file').map((i) => i.path);
+
+                let difference = existing
+                    .filter((x) => !newFiles.includes(x))
+                    .concat(newFiles.filter((x) => !existing.includes(x)));
+
+                // Delete the file if it doesn't exist in the newly uploaded product (either in the file system or in
+                // one of the configs)
+                difference.forEach((file) => {
+                    // TODO: remove this, but leaving it in for now just in case something was
+                    // overlooked and files start randomly disappearing.
+                    if (!config_en.includes(file) && !config_fr.includes(file)) {
+                        logger('WARNING', `Removing ${file} because it no longer exists in the product.`);
+                        fs.rm(fileName + '/' + file);
+                    }
+                });
+            });
             // SECURITY FEATURE: delete all files in the folder that don't have one of the following extensions:
             // .json, .jpg, .jpeg, .gif, .png, .csv
             // TODO: Disabled until I can find a better regex


### PR DESCRIPTION
### Related Item(s)
#563

### Changes
- Reintroduce garbage collection code (https://github.com/ramp4-pcar4/storylines-editor/pull/134) with a few additional changes:
  - Prevent the deletion of any `.git` files
  - Prevent the deletion of files that are referenced somewhere in either config

### Notes
- Currently I'm stringifying both configs and searching them for the file paths that are about to be deleted (i.e. the paths of files that exist on the server but not in the zip file received from the server)
  - This is done to prevent the deletion of files added in ways foreign to the editor (ex. text embedded images)
  - However, since I'm doing this, would it better to just _not_ compare the files in the server with the files in the zip?
  - That is, to just check if each file is referenced within either config, and if not, deleting it?
  - It seems like this approach will work in almost the same way as the current code
  - Let me know your thoughts/opinions
- Also let me know of any cases that are not being covered

### Testing
Steps:
1. Copy the new code into your local server
2. Within a product add a new image to an image panel, then save changes
4. See that file is added to assets folder
5. Delete that image and save changes
6. See that file has been removed from the assets folder
7. Add the image file again and save changes
8. Now include the image file's path somewhere else in the config (ex. as a text embedding)
9. Delete the image from the image panel and save changes
10. See that the image file is still in the assets folder

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/571)
<!-- Reviewable:end -->
