### PR TITLE
Implement robust, lightweight state tracking

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
             "name": "storylines-editor",
             "version": "1.0.0",
             "dependencies": {
+                "@fastify/deepmerge": "^2.0.2",
                 "@kangc/v-md-editor": "^2.3.17",
                 "@rollup/plugin-dsv": "^3.0.4",
                 "@tailwindcss/typography": "^0.4.0",
@@ -15,6 +16,7 @@
                 "@types/marked": "^4.0.1",
                 "axios": "^1.2.0",
                 "clone-deep": "^4.0.1",
+                "deep-object-diff": "^1.1.9",
                 "file-saver": "^2.0.5",
                 "highcharts": "^9.3.2",
                 "highcharts-vue": "^1.4.3",
@@ -652,6 +654,22 @@
             "bin": {
                 "spriter": "bin/spriter.js"
             }
+        },
+        "node_modules/@fastify/deepmerge": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@fastify/deepmerge/-/deepmerge-2.0.2.tgz",
+            "integrity": "sha512-3wuLdX5iiiYeZWP6bQrjqhrcvBIf0NHbQH1Ur1WbHvoiuTYUEItgygea3zs8aHpiitn0lOB8gX20u1qO+FDm7Q==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/@floating-ui/core": {
             "version": "1.6.9",
@@ -4144,6 +4162,11 @@
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true
         },
+        "node_modules/deep-object-diff": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.9.tgz",
+            "integrity": "sha512-Rn+RuwkmkDwCi2/oXOFS9Gsr5lJZu/yTGpK7wAaAIE75CC+LCGEZHpY6VQJa/RoJcrmaA/docWJZvYohlNkWPA=="
+        },
         "node_modules/deepmerge": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -6345,7 +6368,8 @@
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+            "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+            "license": "MIT"
         },
         "node_modules/lodash-es": {
             "version": "4.17.21",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
         "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src"
     },
     "dependencies": {
+        "@fastify/deepmerge": "^2.0.2",
         "@kangc/v-md-editor": "^2.3.17",
         "@rollup/plugin-dsv": "^3.0.4",
         "@tailwindcss/typography": "^0.4.0",
@@ -16,6 +17,7 @@
         "@types/marked": "^4.0.1",
         "axios": "^1.2.0",
         "clone-deep": "^4.0.1",
+        "deep-object-diff": "^1.1.9",
         "file-saver": "^2.0.5",
         "highcharts": "^9.3.2",
         "highcharts-vue": "^1.4.3",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_en.json
@@ -2,7 +2,7 @@
     "title": "Test StoryRAMP",
     "introSlide": {
         "logo": {
-            "src": "https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/assets/logo.svg",
+            "src": "",
             "altText": "Logo"
         },
         "title": "Test StoryRAMP",

--- a/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.json
+++ b/public/00000000-0000-0000-0000-000000000000/00000000-0000-0000-0000-000000000000_fr.json
@@ -2,7 +2,7 @@
     "title": "Aperçu des secteurs de l’INRP : extraction de sables bitumineux111111",
     "introSlide": {
         "logo": {
-            "src": "https://raw.githubusercontent.com/ramp4-pcar4/ramp4-pcar4/master/assets/logo.svg",
+            "src": "",
             "altText": "Logo"
         },
         "title": "Aperçu des secteurs de l’INRP : extraction de sables bitumineux",

--- a/src/components/chart-editor.vue
+++ b/src/components/chart-editor.vue
@@ -298,7 +298,8 @@ export default class ChartEditorV extends Vue {
 
     onChartsEdited(): void {
         this.edited = true;
-        this.$emit('slide-edit');
+        this.saveChanges();
+        this.$emit('slide-edit', 'Chart editor');
     }
 }
 </script>

--- a/src/components/dynamic-editor.vue
+++ b/src/components/dynamic-editor.vue
@@ -91,7 +91,7 @@
                     :sourceCounts="sourceCounts"
                     :centerSlide="centerSlide"
                     :dynamicSelected="dynamicSelected"
-                    @slide-edit="$emit('slide-edit')"
+                    @slide-edit="$emit('slide-edit', 'Dynamic editor')"
                     @shared-asset="(oppositeAssetPath: string, sharedAssetPath: string, oppositeLang: string) => {
                         $emit('shared-asset', oppositeAssetPath, sharedAssetPath, oppositeLang);
                     }"

--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -237,6 +237,7 @@
                             <span
                                 tabindex="0"
                                 class="font-semibold text-lg line-clamp-1 leading-snug"
+                                :class="{ italic: !metadata.title }"
                                 v-truncate="{
                                     options: {
                                         delay: '200',
@@ -246,7 +247,7 @@
                                         touch: ['hold', 500]
                                     }
                                 }"
-                                >{{ metadata.title }}</span
+                                >{{ metadata.title || $t('editor.untitledProject') }}</span
                             >
                             <span
                                 tabindex="0"
@@ -440,6 +441,7 @@
                     :currentSlide="currentSlide"
                     :slideIndex="slideIndex"
                     @slide-change="selectSlide"
+                    @slide-edit="$emit('save-status', undefined, 'ToC')"
                     @slides-updated="updateSlides"
                     @open-metadata-modal="$vfm.open('metadata-edit-modal')"
                     @shared-asset="(oppositeAssetPath: string, sharedAssetPath: string, oppositeLang: string) => {
@@ -713,6 +715,8 @@ export default class EditorV extends Vue {
         );
         this.configs.en!.slides = this.slides.map((slides) => slides.en!);
         this.configs.fr!.slides = this.slides.map((slides) => slides.fr!);
+
+        this.$emit('save-status', undefined, 'Slide updated');
     }
 
     /**

--- a/src/components/image-editor.vue
+++ b/src/components/image-editor.vue
@@ -148,15 +148,16 @@
 </template>
 
 <script lang="ts">
-import { Options, Prop, Vue } from 'vue-property-decorator';
 import {
+    BaseStartingConfig,
     ConfigFileStructure,
     ImageFile,
     ImagePanel,
     PanelType,
-    SlideshowImagePanel,
+    SlideshowPanel,
     SourceCounts
 } from '@/definitions';
+import { Options, Prop, Vue } from 'vue-property-decorator';
 import draggable from 'vuedraggable';
 import ImagePreviewV from './helpers/image-preview.vue';
 import JSZip from 'jszip';
@@ -542,7 +543,8 @@ export default class ImageEditorV extends Vue {
 
     onImagesEdited(): void {
         this.edited = true;
-        this.$emit('slide-edit');
+        this.saveChanges();
+        this.$emit('slide-edit', 'Image editor');
     }
 }
 </script>

--- a/src/components/map-editor.vue
+++ b/src/components/map-editor.vue
@@ -34,7 +34,12 @@
                 />
             </div>
 
-            <div class="ramp-editor mt-5" ref="editor" style="width: 70vw; height: 80vh"></div>
+            <div
+                class="ramp-editor mt-5"
+                ref="editor"
+                style="width: 70vw; height: 80vh"
+                @input="stateStore.overrideChangeState(true)"
+            ></div>
         </div>
         <vue-final-modal
             modalId="time-slider-edit-modal"
@@ -62,6 +67,7 @@
 </template>
 
 <script lang="ts">
+import { useStateStore } from '@/stores/stateStore';
 import { Options, Prop, Vue } from 'vue-property-decorator';
 import { ConfigFileStructure, MapPanel, SourceCounts, TimeSliderConfig } from '@/definitions';
 import { VueFinalModal } from 'vue-final-modal';
@@ -83,6 +89,8 @@ export default class MapEditorV extends Vue {
     @Prop() sourceCounts!: SourceCounts;
     @Prop({ default: false }) centerSlide!: boolean;
     @Prop({ default: false }) dynamicSelected!: boolean;
+
+    stateStore = useStateStore();
 
     // config editor
     rampEditorApi: any = '';
@@ -123,6 +131,10 @@ export default class MapEditorV extends Vue {
         }
 
         this.openEditor();
+    }
+
+    beforeUnmount(): void {
+        this.$emit('slide-edit', 'Kill map editor');
     }
 
     beforeDestroy(): void {
@@ -187,7 +199,7 @@ export default class MapEditorV extends Vue {
         if (!this.timeSliderError || !this.usingTimeSlider) {
             this.panel.timeSlider = this.usingTimeSlider ? this.timeSliderConf : undefined;
         }
-        this.$emit('slide-edit');
+        this.$emit('slide-edit', 'Map editor time slider');
         this.$vfm.close('time-slider-edit-modal');
     }
 
@@ -200,7 +212,7 @@ export default class MapEditorV extends Vue {
     }
 
     onConfigEdit(): void {
-        this.$emit('slide-edit');
+        this.$emit('slide-edit', 'Map editor');
     }
 
     onTimeSliderInput(property: 'range' | 'start' | 'attribute' | 'layers', index: number, value: string): void {

--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -572,6 +572,7 @@
 
 <script lang="ts">
 import ActionModal from '@/components/helpers/action-modal.vue';
+import { Save, useStateStore } from '@/stores/stateStore';
 import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
 import { RouteLocationNormalized } from 'vue-router';
 import { AxiosResponse } from 'axios';
@@ -669,6 +670,7 @@ export default class MetadataEditorV extends Vue {
     showDropdown = false;
     highlightedIndex = -1;
     lockStore = useLockStore();
+    stateStore = useStateStore();
     latestSchemaVersion = '';
 
     storylineHistory: History[] = [];
@@ -677,7 +679,20 @@ export default class MetadataEditorV extends Vue {
 
     // Saving properties.
     saving = false;
-    unsavedChanges = false;
+    unsavedChanges = this.stateStore.isChanged;
+
+    @Watch('stateStore.isChanged')
+    onChanged() {
+        this.unsavedChanges = this.stateStore.isChanged;
+    }
+
+    @Watch('stateStore.reconcileToggler')
+    onReconciliationRequest() {
+        const newConfigs = this.stateStore.addChangesToNewSave(this.stateStore.getCurrentChangeLocation());
+
+        this.configs.en = newConfigs.en;
+        this.configs.fr = newConfigs.fr;
+    }
 
     controller = new AbortController();
 
@@ -754,6 +769,11 @@ export default class MetadataEditorV extends Vue {
     sourceCounts: SourceCounts = {};
     sessionExpired: boolean = false;
     totalTime = import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_END) : 30;
+
+    // Debounce timer used for updateSaveStatus only.
+    // IMPORTANT: Avoid using stateStore's handlePotentialChange() directly, this timer may cause issues with change detection and saving to the configs variable.
+    // Instead, ALWAYS call either updateSaveStatus() (if in metadata-editor) or emit the 'save-status' event instead!
+    debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
     @Watch('loadEditor')
     @Watch('loadStatus')
@@ -1887,31 +1907,53 @@ export default class MetadataEditorV extends Vue {
             return;
         }
 
+        // Fix various problems inside the config before load
+        // Add more as they're discovered
+        const fixConfigProblems = (config: StoryRampConfig) => {
+            config.slides.forEach((slide) => {
+                // If the slide has an undefined value for includeInToc, it's treated as true (as the schema wishes)
+                // This change prevents state management detection issues (undefined != true when compared)
+                slide.includeInToc = slide.includeInToc === undefined ? true : slide.includeInToc;
+            });
+
+            return config;
+        };
+
         try {
+            const stateSave = { en: {}, fr: {} };
+
             const enFile = this.configFileStructure?.zip.file(`${this.uuid}_en.json`);
             const frFile = this.configFileStructure?.zip.file(`${this.uuid}_fr.json`);
             await enFile?.async('string').then((res: string) => {
-                this.configs['en'] = JSON.parse(res);
+                const config = fixConfigProblems(JSON.parse(res));
+
+                this.configs['en'] = config;
+                stateSave.en = JSON.parse(JSON.stringify(config));
 
                 // Check if config contains a link to the default stylesheet, and if so add it in (only if it doesn't
                 // already contain it)
-                if (!this.configs['en'].stylesheets) {
-                    this.configs['en'].stylesheets = [`${this.uuid}/styles/main.css`];
-                } else if (!this.configs['en'].stylesheets.includes(`${this.uuid}/styles/main.css`)) {
-                    this.configs['en'].stylesheets.push([`${this.uuid}/styles/main.css`]);
-                }
+                // TODO: Fix (current implementation breaks state management)
+                // if (!this.configs['en'].stylesheets) {
+                //     this.configs['en'].stylesheets = [`${this.uuid}/styles/main.css`];
+                // } else if (!this.configs['en'].stylesheets.includes(`${this.uuid}/styles/main.css`)) {
+                //     this.configs['en'].stylesheets.push([`${this.uuid}/styles/main.css`]);
+                // }
             });
             await frFile?.async('string').then((res: string) => {
-                this.configs['fr'] = JSON.parse(res);
+                const config = fixConfigProblems(JSON.parse(res));
+                this.configs['fr'] = config;
+                stateSave.fr = JSON.parse(JSON.stringify(this.configs['fr']));
 
                 // Check if config contains a link to the default stylesheet, and if so add it in (only if it doesn't
                 // already contain it)
-                if (!this.configs['fr'].stylesheets) {
-                    this.configs['fr'].stylesheets = [`${this.uuid}/styles/main.css`];
-                } else if (!this.configs['fr'].stylesheets.includes(`${this.uuid}/styles/main.css`)) {
-                    this.configs['fr'].stylesheets.push([`${this.uuid}/styles/main.css`]);
-                }
+                // TODO: Fix (current implementation breaks state management)
+                // if (!this.configs['fr'].stylesheets) {
+                //     this.configs['fr'].stylesheets = [`${this.uuid}/styles/main.css`];
+                // } else if (!this.configs['fr'].stylesheets.includes(`${this.uuid}/styles/main.css`)) {
+                //     this.configs['fr'].stylesheets.push([`${this.uuid}/styles/main.css`]);
+                // }
             });
+            this.stateStore.save(stateSave as Save);
         } catch {
             Message.error(this.$t('editor.editMetadata.message.error.malformedProduct', this.uuid ?? ''));
             this.loadStatus = 'waiting';
@@ -1930,10 +1972,11 @@ export default class MetadataEditorV extends Vue {
         if (this.configs[this.configLang]) {
             this.useConfig(this.configs[this.configLang] as StoryRampConfig);
             this.findSources(this.configs); // increments source counts for all panels
+
             // Update router path
             if (this.reloadExisting) {
                 this.loadEditor = true;
-                this.unsavedChanges = false;
+                this.stateStore.isChanged = false;
                 this.updateEditorPath();
             } else if (!this.loadExisting) {
                 this.loadEditor = true;
@@ -2044,13 +2087,22 @@ export default class MetadataEditorV extends Vue {
         const frFileName = `${this.uuid}_fr.json`;
 
         // Replace undefined slides with empty objects
-        this.configs.en.slides = this.configs.en?.slides.map((slide) => {
-            return slide ?? {};
-        });
-        this.configs.fr.slides = this.configs.fr?.slides.map((slide) => {
-            return slide ?? {};
-        });
+        if (this.configs.en) {
+            this.configs.en.slides = this.configs.en.slides.map((slide) => {
+                return slide ?? {};
+            });
+        }
+
+        if (this.configs.fr) {
+            this.configs.fr.slides = this.configs.fr.slides.map((slide) => {
+                return slide ?? {};
+            });
+        }
+
         this.loadSlides(this.configs);
+
+        // TODO: Should we make stateStore save on every generateConfig activation, or just on pubish = true??
+        this.stateStore.save({ en: this.configs.en, fr: this.configs.fr });
 
         const engFormattedConfigFile = JSON.stringify(this.configs.en, null, 4);
         const frFormattedConfigFile = JSON.stringify(this.configs.fr, null, 4);
@@ -2060,7 +2112,6 @@ export default class MetadataEditorV extends Vue {
 
         // Upload the ZIP file.
         if (publish) {
-            this.unsavedChanges = false;
             this.configFileStructure?.zip.generateAsync({ type: 'blob' }).then((content: Blob) => {
                 const formData = new FormData();
                 formData.append('data', content, `${this.uuid}.zip`);
@@ -2187,12 +2238,18 @@ export default class MetadataEditorV extends Vue {
                 this.extendSession(true);
                 this.lockStore.broadcast?.postMessage({ action: 'saved' });
             }
+
+            // This may be necessary to allow for changes to be properly detected after saving.
+            // Without it, even attempted changes (e.g. keypress in an input field) are no longer detected, and the potential change handlers
+            // aren't even run.
+            // There's likely a better solution, please add if you find it.
+            this.loadConfig();
         }, 500);
     }
 
     updateMetadata<K extends keyof MetadataContent>(key: K, value: MetadataContent[K]): void {
         this.metadata[key] = value;
-        this.unsavedChanges = true;
+        this.updateSaveStatus(true, 'Update metadata');
     }
 
     discardMetadataUpdates(): void {
@@ -2255,6 +2312,8 @@ export default class MetadataEditorV extends Vue {
 
             const userStore = useUserStore();
             userStore.fetchUserProfile();
+
+            this.updateSaveStatus(true, 'Save metadata');
         }
         this.$vfm.close('metadata-edit-modal');
     }
@@ -2514,9 +2573,17 @@ export default class MetadataEditorV extends Vue {
 
     /**
      * Update the unsaved changes value to the payload.
+     * Debounced to prevent being called too often.
      */
-    updateSaveStatus(payload: boolean): void {
-        this.unsavedChanges = this.saving ? false : payload;
+    updateSaveStatus(payload: boolean, origin?: string): void {
+        if (this.debounceTimer) clearTimeout(this.debounceTimer);
+
+        this.debounceTimer = setTimeout(() => {
+            this.stateStore.handlePotentialChange(
+                { en: JSON.parse(JSON.stringify(this.configs.en)), fr: JSON.parse(JSON.stringify(this.configs.fr)) },
+                origin
+            );
+        }, 300);
     }
 
     refreshConfig(): void {

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -442,8 +442,9 @@
                 ></component>
             </div>
         </div>
-        <div v-else class="flex h-fit mt-4 justify-center text-gray-600 text-xl">
-            <span>{{ $t('editor.slides.select') }}</span>
+        <div v-else class="h-fit mt-4 text-center">
+            <h4 class="text-lg font-bold">{{ $t('editor.slides.selectHeader') }}</h4>
+            <p class="text-sm font-semibold text-gray-500">{{ $t('editor.slides.select') }}.</p>
         </div>
         <action-modal
             :name="`change-slide-${slideIndex}`"

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -71,6 +71,14 @@
             <br />
         </div>
 
+        <!-- No slides message -->
+        <div v-if="slides.length === 0" class="text-center px-6 py-6">
+            <h4 class="text-lg font-bold">
+                {{ $t('editor.slides.toc.noSlides') }}
+            </h4>
+            <p class="text-sm font-semibold text-gray-500">{{ $t('editor.slides.toc.selectNewSlideMessage') }}</p>
+        </div>
+
         <!-- Slide list -->
         <ul class="toc-slide-list">
             <!-- Slide -->
@@ -425,7 +433,8 @@ export default class SlideTocV extends Vue {
                 title: '',
                 content: ''
             } as TextPanel
-        ]
+        ],
+        includeInToc: true
     };
 
     /**
@@ -588,13 +597,15 @@ export default class SlideTocV extends Vue {
 
     removeSlide(index: number): void {
         if (index === this.slideIndex) {
-            this.$emit('slide-change', -1);
+            this.selectSlide(-1, this.lang);
+            // this.$emit('slide-change', -1);
         }
 
         // Before removing the slide, updated the sources for the panels.
         this.removeSourceCounts(index);
 
         this.slides.splice(index, 1);
+        this.selectSlide(this.slides.length - 1, this.lang);
         this.$emit('slides-updated', this.slides);
     }
 

--- a/src/components/text-editor.vue
+++ b/src/components/text-editor.vue
@@ -15,7 +15,7 @@
 </template>
 
 <script lang="ts">
-import { Prop, Vue } from 'vue-property-decorator';
+import { Prop, Vue, Watch } from 'vue-property-decorator';
 import { TextPanel } from '@/definitions';
 
 interface MDEditor {
@@ -26,6 +26,11 @@ export default class TextEditorV extends Vue {
     @Prop() panel!: TextPanel;
     @Prop({ default: false }) centerSlide!: boolean;
     @Prop({ default: false }) dynamicSelected!: boolean;
+
+    @Watch('panel.content', { deep: true })
+    onContentChanged() {
+        this.$emit('slide-edit');
+    }
 
     // A ridiculous workaround to make the toolbar buttons (and the preview) in the md-editor tabbable.
     // Hopefully a better solution can be found eventually.

--- a/src/components/video-editor.vue
+++ b/src/components/video-editor.vue
@@ -8,7 +8,7 @@
                 class="editor-input w-full lg:w-3/5"
                 type="text"
                 v-model="videoPreview.title"
-                @change="onVideoEdited"
+                @input="onVideoEdited"
             />
         </div>
 
@@ -412,8 +412,7 @@ export default class VideoEditorV extends Vue {
             return;
         }
 
-        this.addUploadedFile(file, 'src');
-        this.onVideoEdited();
+        this.addUploadedFile(file, 'src').then(this.onVideoEdited);
     }
 
     findFileType(file: string): void {
@@ -458,6 +457,7 @@ export default class VideoEditorV extends Vue {
         };
         this.edited = true;
         this.$emit('slide-edit');
+        this.onVideoEdited();
     }
 
     updateCaptions(e: Event): void {
@@ -500,6 +500,7 @@ export default class VideoEditorV extends Vue {
     saveChanges(): void {
         if (this.edited && this.videoPreview) {
             // save all changes to panel config (cannot directly set to avoid prop mutate)
+            console.log('SAVING PROPERLY');
             this.panel.title = this.videoPreview.title;
             this.panel.videoType = this.videoPreview.videoType;
 
@@ -512,7 +513,8 @@ export default class VideoEditorV extends Vue {
 
     onVideoEdited(): void {
         this.edited = true;
-        this.$emit('slide-edit');
+        this.saveChanges();
+        this.$emit('slide-edit', 'Video editor');
     }
 }
 </script>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -28,6 +28,7 @@ fullscreen.deactivate,Exit Fullscreen,1,Quitter le mode plein écran,1
 editor.lang.en,English,1,Anglais,1
 editor.lang.fr,French,1,Français,1
 editor.ok,Ok,1,D'accord,1
+editor.untitledProject,Untitled project,1,Projet sans titre,0
 editor.swapConfigs,Switch to other language configuration,1,Passer à la configuration dans une autre langue,1
 editor.feedback,Send Us Feedback,1,Envoyez-nous vos commentaires,0
 editor.feedback.subject,Storylines Editor Feedback,1,Commentaires de l'éditeur de scénarios,0
@@ -246,6 +247,8 @@ editor.slides.copyAll,Copy all,1,Copier tout,1
 editor.slides.copyAll.confirm,Are you sure you want to copy all slides?,1,Êtes-vous sûr de vouloir copier toutes les diapositives ?,0
 editor.slides.copy,Copy,1,Copier,1
 editor.slides.slide,Slide,1,Diapositive,1
+editor.slides.toc.noSlides,No Slides,1,Pas de diapositives,0
+editor.slides.toc.selectNewSlideMessage,Select 'New Blank Slide' to add your first slide.,1,Sélectionnez « Nouvelle diapositive vierge » pour ajouter votre première diapositive.,0
 editor.slides.toc.dropdownTooltip,Options,1,Options,0
 editor.slides.toc.dropdown.copy,Copy from other config,1,Copier à partir d'une autre config.,0
 editor.slides.toc.dropdown.clear,Clear content,1,Contenu clair,0
@@ -283,6 +286,7 @@ editor.slides.advanced.details,Click here for more details.,1,Cliquez ici pour p
 editor.slides.advanced.error,This configuration contains one or more errors. Leaving it as-is may cause unexpected behaviour in the editor and published product.,1,Cette configuration contient une ou plusieurs erreurs. La laisser telle quelle peut entraîner un comportement inattendu dans l'éditeur et dans le produit publié.,0
 editor.slides.contentType,Content type,1,Type de contenu,1
 editor.slides.content,Content,1,Contenu,1
+editor.slides.selectHeader,No slide selected,1,Aucune diapositive sélectionnée,0
 editor.slides.assetNameChange,Asset {oldName} has been uploaded with name {newName},1,L'actif {oldName} a été téléchargé avec le nom {newName},0
 editor.slides.select,Please select a slide to edit,1,Veuillez sélectionner une diapositive à modifier,1
 editor.slides.panelNumber,Panel {num},1,Panneau {num},0

--- a/src/stores/stateStore.ts
+++ b/src/stores/stateStore.ts
@@ -1,0 +1,376 @@
+/**
+ * Handles state tracking functionality throughout the Storylines Editor.
+ */
+
+/**
+ * HOW IT WORKS
+ * 1. On initial load, the stateStore saves the loaded-in (or created) config as the
+ *    "latest saved state" (latestSavedState).
+ * 2. A change is made in a certain module (a panel editor, the metadata modal, etc.).
+ *    The module "saves" the changes to the local 'configs' object (usually this.configs
+ *    in the editor/metadata editor) and then either emits a "slide-edit" event, if inside
+ *    a panel editor, or a "save-status" event in the slide editor or above (OR, if in the
+ *    metadata editor already, the updateSaveStatus() function directly).
+ * 3. The metadata editor (may be updated in the future) catches the event and calls the
+ *    updateSaveStatus() function, if not already called in step 2.
+ * 4. The function calls a debounced handlePotentialChange() function, which parses the
+ *    local configs object for any differences from the latestSavedState. It creates
+ *    a diff between the local configs object and the latestSavedState and determines
+ *    if it is empty.
+ *
+ * > NOTE: Ensure that you only use handlePotentialChange() through the save-status/slide-edit
+ *         event or updateSaveStatus(). Avoid calling it directly! The debouncing done in
+ *         updateSaveStatus() may cause changes not to be saved properly.
+ *
+ * 5. Based on step 4, the function determines the value of isChanged, a boolean showing
+ *    if any changes have been made from the latestSavedState. If the isChanged flag
+ *    is changed, the app detects it via change-listeners and updates the "Unsaved Changes"
+ *    indicator accordingly.
+ * 6. A running "list of changes" stateChangesList is kept; handlePotentialChanges() adds
+ *    the diff created in step 4 to this list, so long as it isn't the exact same as the
+ *    current last item in stateChangesList.
+ *
+ * > NOTE: There's a maximum number of items that will be stored in stateChangesList
+ *         (MAX_STATE_CHANGES); that number is currently set at 30. If that number is about
+ *         to be exceeded, the first item in the list will be purged to make way for the
+ *         new addition.
+ *
+ * 7. On save, the save() function is called, which updates the latestSavedState,
+ *    deletes all items in the the stateChangesList, and resets the isChanged flag.
+ *
+ * > IN THE FUTURE: Functions like undo(), redo(), and reconcileAppState() will be used
+ *   for undo/redo functionality (reconcileAppState is essentially meant to tell the app
+ *   to refresh its config variables).
+ */
+
+import { StoryRampConfig } from '@/definitions';
+import { DetailedDiff, detailedDiff, diff } from 'deep-object-diff';
+import { defineStore } from 'pinia';
+import { deepmerge } from '@fastify/deepmerge';
+
+interface StateChange {
+    timestamp: number;
+    origin: string | 'unknown';
+    changes: DetailedDiff | 'external';
+}
+
+export interface Save {
+    en: StoryRampConfig | undefined;
+    fr: StoryRampConfig | undefined;
+}
+
+const MAX_STATE_CHANGES = 30;
+
+// @ts-ignore
+function replaceByClonedSource(options) {
+    const clone = options.clone;
+    // @ts-ignore
+    return function (target, source) {
+        return clone(source);
+    };
+}
+
+function purgeFalses(obj: any): any {
+    if (Array.isArray(obj)) {
+        return obj.map((item) => purgeFalses(item));
+    }
+
+    return Object.entries(obj).reduce((acc, [key, value]) => {
+        if (value !== null && value !== undefined && value) {
+            acc[key] = typeof value === 'object' ? purgeFalses(value) : value;
+        }
+        return acc;
+    }, {} as Record<string, any>);
+}
+
+const deepMerge = deepmerge({ all: true, mergeArray: replaceByClonedSource });
+
+export const useStateStore = defineStore('state', {
+    state: () => ({
+        /**
+         * Indicates whether there are any unsaved changes.
+         */
+        isChanged: false,
+
+        /**
+         * The latest saved state. Things are only saved if they're in here
+         * (items in stateChangesList are NOT saved).
+         */
+        latestSavedState: { en: undefined, fr: undefined } as Save,
+
+        /**
+         * All current change diffs. Nothing in here is saved.
+         * Each diff contains the cumulative changes from all previous diffs,
+         * making a lot of internal operations easier.
+         */
+        stateChangesList: [] as StateChange[],
+
+        /**
+         * Current location in stateChangesList. Might not be equal to stateChangesList.length - 1,
+         * to allow for undo AND REDO operations. -1 indicates there are no changes.
+         * May be obvious, but: it's equal to the INDEX value (0-index), not the .length value (1-index).
+         */
+        currentLoc: -1,
+
+        /**
+         * Variable used to flag if the state store wants the app to refresh its config variables.
+         * The value itself (true/false) doesn't matter, only the change event itself.
+         * When this changes, outside listeners should run `addChangesToNewSave` with `loc` = `getCurrentChangeLocation()`
+         * to get the latest save, and replace the various non-save config variables (e.g. `configs` in the editor, for now)
+         * with its values.
+         */
+        reconcileToggler: false
+    }),
+    actions: {
+        // ================================
+        // ACTIONS
+
+        /**
+         * Manual override for the current "is state changed" value, when you want to modify it directly. Use sparingly.
+         * @param changeStateValue Value to change the "is state changed" value to.
+         */
+        overrideChangeState(changeStateValue: boolean): void {
+            this.isChanged = changeStateValue;
+        },
+
+        /**
+         * Function that should be run whenever the application believes there may be changes. It will run a lot, so it should be fast!
+         * @param newConfigs Up-to-date configs (en and fr) with all the new changes
+         * @param origin A string indicating where the change come from. Useful for determining origin of changes for undo/redo functionality
+         */
+        handlePotentialChange(newConfigs: Save, origin?: string): boolean {
+            newConfigs.en!.slides = newConfigs.en!.slides.map((slide) => {
+                if (slide && Object.keys(slide)?.length) {
+                    return purgeFalses(slide);
+                } else {
+                    return {};
+                }
+            });
+
+            newConfigs.fr!.slides = newConfigs.fr!.slides.map((slide) => {
+                if (slide && Object.keys(slide)?.length) {
+                    return purgeFalses(slide);
+                } else {
+                    return {};
+                }
+            });
+
+            // The last diff holds the sum of all diffs before it
+            // AKA A diff at n holds the combined diffs 0 ... n - 1, plus any new changes
+            const combinedPreviousDiffs = this.stateChangesList[this.currentLoc]?.changes ?? {
+                added: {},
+                deleted: {},
+                updated: {}
+            };
+
+            // Determine all differences between the latest config and the latest save
+            const newDiff = detailedDiff(this.latestSavedState, newConfigs);
+
+            // There are no changes whatsoever from the last save. Set stuff accordingly.
+            if (this.isDiffEmpty(newDiff)) {
+                // Add an 'empty diff' to the list, indicating past changes have been erased.
+                // Doing this allows the erasing to be undone too (bring back past changes).
+                this.recordNewChange({
+                    timestamp: Date.now(),
+                    origin: origin ?? 'unknown',
+                    changes: newDiff
+                });
+
+                this.isChanged = false;
+                return false;
+            }
+            // Check if there are any additional changes beyond the last recorded change. If there isn't, exit
+            else if (
+                !Object.keys(diff(combinedPreviousDiffs !== 'external' ? combinedPreviousDiffs : {}, newDiff)).length
+            ) {
+                return false;
+            }
+
+            // Save new diff to stateChangesList
+            this.recordNewChange({
+                timestamp: Date.now(),
+                origin: origin ?? 'unknown',
+                // Considered saving the diff between the combinedPreviousDiffs and the newDiffs,
+                // but I think this pointlessly increases the number of operations for detecting
+                // new changes (we'd need to merge all preceding entries in stateChangesList every
+                // single time) in exchange for a negligible decrease in memory usage.
+                // If anyone disagrees, feel free to @ me.
+                changes: newDiff
+            });
+            this.isChanged = true;
+            return true;
+        },
+
+        /**
+         * Delete all recorded diffs since the last save.
+         * @param reconcile Whether to ask the app to 'refresh'.
+         */
+        resetAllChanges(reconcile: boolean = true): void {
+            this.currentLoc = -1;
+            this.stateChangesList = [];
+            this.isChanged = false;
+            if (reconcile) {
+                this.reconcileAppState(true);
+            }
+        },
+
+        // Reverts the diff at currentLoc. currentLoc will be placed at currentLoc - 1.
+        // TODO: Proper implementation
+        undo(): void {
+            if (this.currentLoc === -1) return;
+
+            this.currentLoc--;
+            this.reconcileAppState();
+        },
+
+        // Re-applies the diff at currentLoc + 1, and sets currentLoc to that.
+        // TODO: Proper implementation
+        redo(): void {
+            if (this.currentLoc === this.getNumberOfChanges() - 1) return;
+
+            this.currentLoc++;
+            this.reconcileAppState();
+        },
+
+        /**
+         * Adds a new item to the list of recorded diffs. Sets currentLoc to the position of the new diff.
+         * @param newChanges The diff to add
+         */
+        recordNewChange(newChanges: StateChange): void {
+            // Stuff the new changes into the stack
+            this.eraseSubsequentChanges(); // all changes after this should be erased
+            this.isChanged = true;
+
+            // If we've reached the max number of state changes allowed, erase the earliest one.
+            if (this.stateChangesList.length === MAX_STATE_CHANGES) {
+                this.stateChangesList.shift();
+            }
+
+            this.stateChangesList.push(newChanges);
+            this.currentLoc++;
+        },
+
+        /**
+         * Changes the app's state to be in line with the current stateChangesList and currentLoc.
+         * Use this after applying some sort of change to the above variables (e.g. erasing all changes)
+         * @param eraseAllSubsequent Whether all items after currentLoc on savedChangesList should be deleted.
+         */
+        reconcileAppState(eraseAllSubsequent?: boolean): void {
+            // TODO: Determine if reconcileAppState works properly (currently not used much since undo/redo not implemented yet)
+
+            // Basic philosophy: Take the current stateChangesList, compare to oldLoc, undo or redo the intermediate diffs
+            // if eraseAllSubsequent is true, run eraseSubsequentChanges at end
+
+            if (eraseAllSubsequent) {
+                // Erase all changes after currentLoc
+                this.eraseSubsequentChanges();
+            }
+
+            this.reconcileToggler = !this.reconcileToggler;
+        },
+
+        /**
+         * Saves all current changes. Functionality for pressing the 'save' button.
+         * Adds all current changes to latestSavedState and resets the stateChangesList stack and currentLoc.
+         * @param savedConfigs Configs with all the changes, to be saved.
+         */
+        save(savedConfigs: Save): void {
+            // Clear out any key-value properties with empty values
+
+            savedConfigs.en!.slides = savedConfigs.en!.slides.map((slide) => {
+                if (slide && Object.keys(slide)?.length) {
+                    return purgeFalses(slide);
+                } else {
+                    return {};
+                }
+            });
+
+            savedConfigs.fr!.slides = savedConfigs.fr!.slides.map((slide) => {
+                if (slide && Object.keys(slide)?.length) {
+                    return purgeFalses(slide);
+                } else {
+                    return {};
+                }
+            });
+
+            // Add cleaned configs as the latest save
+            this.latestSavedState = JSON.parse(JSON.stringify(savedConfigs));
+
+            // Erase the stateChangesList stack and reset currentLoc
+            this.resetAllChanges(false);
+        },
+
+        // ====================================
+        // UPDATERS AND HELPERS
+
+        /**
+         * Determines if a diff is empty. Also returns true if the diff has keys but all the values are empty (e.g. something like {a:{b:{}}} returns true).
+         * @param diff The diff to check.
+         */
+        isDiffEmpty(diff: DetailedDiff): boolean {
+            if (typeof diff !== 'object' || diff === null) {
+                return false; // Non-object values won't be treated as "empty"
+            }
+
+            return Object.values(diff).every((value) => typeof value === 'object' && this.isDiffEmpty(value));
+        },
+
+        /**
+         * Creates a new Save object based on the changes up to the given loc, and returns it. Non-mutating.
+         * @param loc The location up to which you want changes considered for the save.
+         */
+        addChangesToNewSave(loc?: number): Save {
+            loc = loc ?? this.currentLoc;
+
+            const changesToAdd = this.stateChangesList[loc].changes;
+
+            let newSave = JSON.parse(JSON.stringify(this.latestSavedState));
+
+            // TODO: CHECK IF THIS ACTUALLY WORKS
+            newSave = deepMerge(newSave, changesToAdd.added, changesToAdd.deleted, changesToAdd.updated);
+
+            return newSave;
+        },
+
+        // Erases all changes after the change at currentLoc.
+        // (If currentLoc != stateChangesList.length, and you make a change, a stateChange is added overwriting the previous items in the list).
+        // This function ONLY handles the erasing part. Use other functions for anything else you need
+        eraseSubsequentChanges(): void {
+            this.stateChangesList.splice(this.currentLoc + 1, Infinity);
+        },
+
+        // ===============================
+        // GETTERS
+
+        /**
+         * Returns a boolean indicating if there are any unsaved changes.
+         */
+        getIsChanged(): boolean {
+            // return this.stateChangesList.length !== 0;
+            return this.isChanged;
+        },
+
+        getNumberOfChanges(): number {
+            return this.stateChangesList.length;
+        },
+
+        getChangeAtIndex(index: number): StateChange | undefined {
+            return this.stateChangesList[index];
+        },
+
+        getAllCurrentChanges(): StateChange[] {
+            return this.stateChangesList;
+        },
+
+        getLatestChange(): StateChange | undefined {
+            // Just in case, ensures function returns 'undefined' if current position is negative
+            if (this.currentLoc === -1) return undefined;
+
+            return this.stateChangesList[this.currentLoc];
+        },
+
+        getCurrentChangeLocation(): number {
+            return this.currentLoc;
+        }
+    }
+});


### PR DESCRIPTION
### Related Item(s)

Partial:
#512 

Donethanks: 
#123 
#509
#596 

### Changes
- [FEATURE] Implements a comprehensive state-tracking system throughout the storylines editor.
  - Works via saving and checking diffs when possible changes are detected.
  - Ensures that erasing all changes will remove the "Unsaved Changes" indicator.
  - Allows for future implementation of undo/redo functionality (not implemented in this PR).
- [FEATURE] Add new messages for untitled projects, no slides, and no selected slides. 

### Notes

![image](https://github.com/user-attachments/assets/982d9e3e-98b9-4828-9f94-b047828e13d4)

#### How it works

 1. On initial load, the `stateStore` saves the loaded-in (or created) config as the "latest saved state" (`latestSavedState`). 
 2. A change is made in a certain module (a panel editor, the metadata modal, etc.). The module "saves" the changes to the local 'configs' object (usually `this.configs` in the editor/metadata editor) and then either emits a "slide-edit" event , if inside a panel editor, or a "save-status" event in the slide editor or above (OR, if in the metadata editor already, the `updateSaveStatus()` function directly).
 3. The metadata editor (may be updated in the future) catches the event and calls the `updateSaveStatus()` function, if not already called in step 2. 
 4. The function calls a debounced `handlePotentialChange()` function, which parses the local configs object for any differences from the `latestSavedState`. It creates a diff between the local configs object and the `latestSavedState` and determines if it is empty.

> **Note**: Ensure that you only use `handlePotentialChange()` through the `save-status`/`slide-edit` event or `updateSaveStatus()`. Avoid calling it directly! The debouncing done in updateSaveStatus() may cause changes not to be saved properly.

 5. Based on step 4, the function determines the value of `isChanged`, a boolean showing if any changes have been made from the `latestSavedState`. If the `isChanged` flag is changed, the app detects it via change-listeners and updates the "Unsaved Changes" indicator accordingly.
 6. A running "list of changes" `stateChangesList` is kept; `handlePotentialChanges()` adds the diff created in step 4 to this list, so long as it isn't the exact same as the current last item in `stateChangesList`.
     
 > **Note**: There's a maximum number of items that will be stored in `stateChangesList` (`MAX_STATE_CHANGES`); that number is currently set at 30. If that number is about to be exceeded, the first item in the list will be purged to make way for the new addition.
 
 7. On save, the `save()` function is called, which updates the `latestSavedState`, deletes all items in the the `stateChangesList`, and resets the `isChanged` flag.
    
 > **In the future**: Functions like `undo()`, `redo()`, and `reconcileAppState()` will be used for undo/redo functionality (`reconcileAppState` is essentially meant to tell the app to refresh its config variables).

#### REMAINING TODOs (for myself)

- [x] More comments
- [x] Another thorough round of error-checking (lots of possible bugs, because of how comprehensive this is). Esp check: Behaviour w/ new products (instead of existing product); advanced editor.
- [x] Add thorough explanation of how the state-tracking system works to PR/code comments (process, etc.)
- [x] Further performance improvements?
  - Debounced change checker function.
- [x] Limit max number of items in diff list?

#### DISCOVERED BUGS

- [x] Unsaved changes indicator won't appear anymore after saving once, even if new changes are made
  - Fixed by reloading the configs after saving with `loadConfig`. For some reason the change events `save-status` didn't seem to be firing, and the potential change handlers therefore weren't running. This solution is a little hacky, if there are better options please let me know.
- [x] Saving will randomly "fail"? If you modify multiple things and then save, the changes _may_ seem to be erased. If you refresh the page, however, those changes may appear properly in part or in full. (May be a problem w/ async/promises).
  - Fixed. **Ensure that you only use `handlePotentialChange()` through `save-status` event or `updateSaveStatus()`!**
- [x] Map editor changes not detected, at all.
- ~~[ ] Chart editor: changes to chart not detected.~~ **DELAYED UNTIL NEW HIGHCHARTS EDITOR ADDED - Implement in future PR**

### Testing
Steps:
1. Open any product/a new product.
2. Check if the "Unsaved Changes" indicator appears at the right times. 
    - Make change, erase change
    - Add new slide, delete slide
    - Move slide, move slide back
    - Copying slide
    - Advanced editor
    - Anything else you can think of

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/575)
<!-- Reviewable:end -->
