### PR TITLE
Notify user of asset name change, move to shared folder, and deletion of asset

### DIFF
--- a/src/components/chart-editor.vue
+++ b/src/components/chart-editor.vue
@@ -79,6 +79,7 @@ import {
 import ChartPreviewV from './helpers/chart-preview.vue';
 import ConfirmationModalV from './helpers/confirmation-modal.vue';
 import draggable from 'vuedraggable';
+import Message from 'vue-m-message';
 
 @Options({
     components: {
@@ -249,6 +250,13 @@ export default class ChartEditorV extends Vue {
             this.sourceCounts[`${this.configFileStructure.uuid}/charts/${this.lang}/${chart.name}.json`] -= 1;
             if (this.sourceCounts[`${this.configFileStructure.uuid}/charts/${this.lang}/${chart.name}.json`] === 0) {
                 this.configFileStructure.charts[this.lang].remove(`${chart.name}.json`);
+                Message.info(
+                    this.$t('editor.slides.assetRemoved', {
+                        assetType: 'Chart',
+                        assetName: `${chart.name}.json`,
+                        folder: `charts/${this.lang}`
+                    })
+                );
             }
             this.chartConfigs.splice(idx, 1);
         }

--- a/src/components/helpers/metadata-content.vue
+++ b/src/components/helpers/metadata-content.vue
@@ -378,11 +378,13 @@ export default class MetadataEditorV extends Vue {
     removeLogo(): void {
         this.metadata.logoName = '';
         this.metadata.logoPreview = '';
+        this.$emit('logoRemoved');
     }
 
     removeIntroBackground(): void {
         this.metadata.introBgName = '';
         this.metadata.introBgPreview = '';
+        this.$emit('backgroundRemoved');
     }
 }
 </script>

--- a/src/components/image-editor.vue
+++ b/src/components/image-editor.vue
@@ -153,6 +153,7 @@ import { ConfigFileStructure, ImageFile, ImagePanel, PanelType, SlideshowPanel, 
 import draggable from 'vuedraggable';
 import ImagePreviewV from './helpers/image-preview.vue';
 import JSZip from 'jszip';
+import Message from 'vue-m-message';
 
 @Options({
     components: {
@@ -255,7 +256,7 @@ export default class ImageEditorV extends Vue {
     }
 
     // TODO: move method into a plugin. That way it isn't repeated in the metadata/video editors
-    // Converts a file into a promise that resolves to its has, as an array of 8-bit integers
+    // Converts a file into a promise that resolves to its hash, as an array of 8-bit integers
     obtainHashData(file: File): Promise<Uint8Array> {
         return this.readBinaryData(file)
             .then((res) => {
@@ -379,6 +380,12 @@ export default class ImageEditorV extends Vue {
                         uploadSource = `${this.configFileStructure.uuid}/assets/shared/${newAssetName}`;
                         this.configFileStructure.assets['shared'].file(newAssetName, file);
                         inSharedAsset = true;
+                        Message.info(
+                            this.$t('editor.slides.movedToShared', {
+                                assetName: newAssetName,
+                                oppositeFolder: `assets/${oppositeLang}`
+                            })
+                        );
                     }
                     this.$emit('shared-asset', oppositeFileSource, uploadSource, oppositeLang); // must be emitted for each duplicate asset
                 }
@@ -414,6 +421,11 @@ export default class ImageEditorV extends Vue {
             }
             uploadSource = `${this.configFileStructure.uuid}/assets/${this.lang}/${newAssetName}`;
             this.configFileStructure.assets[this.lang].file(newAssetName, file);
+        }
+
+        // Notify user of the change in the name of their uploaded asset, to avoid any confusion
+        if (file.name !== newAssetName) {
+            Message.info(this.$t('editor.slides.assetNameChange', { oldName: file.name, newName: newAssetName }));
         }
 
         if (this.sourceCounts[uploadSource]) {
@@ -472,6 +484,13 @@ export default class ImageEditorV extends Vue {
             if (this.sourceCounts[assetSource] === 0) {
                 this.configFileStructure.assets[assetFolder].remove(assetRelativePath);
                 URL.revokeObjectURL(this.imagePreviews[idx].src);
+                Message.info(
+                    this.$t('editor.slides.assetRemoved', {
+                        assetType: 'Image',
+                        assetName: assetRelativePath,
+                        folder: `assets/${assetFolder}`
+                    })
+                );
             }
             this.imagePreviews.splice(idx, 1);
         }

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -527,6 +527,12 @@ export default class SlideTocV extends Vue {
                         this.sourceCounts[sharedFileSource] = this.sourceCounts[oppositeFileSource] ?? 0;
                         this.sourceCounts[oppositeFileSource] = 0;
                         this.$emit('shared-asset', oppositeFileSource, sharedFileSource, oppositeLang);
+                        Message.info(
+                            this.$t('editor.slides.movedToShared', {
+                                assetName: sharedAssetName,
+                                oppositeFolder: `assets/${oppositeLang}`
+                            })
+                        );
                     });
                 }
                 this.sourceCounts[sharedFileSource] += 1;

--- a/src/components/video-editor.vue
+++ b/src/components/video-editor.vue
@@ -334,6 +334,12 @@ export default class VideoEditorV extends Vue {
                         uploadSource = `${this.configFileStructure.uuid}/assets/shared/${newAssetName}`;
                         this.configFileStructure.assets['shared'].file(newAssetName, file);
                         inSharedAsset = true;
+                        Message.info(
+                            this.$t('editor.slides.movedToShared', {
+                                assetName: newAssetName,
+                                oppositeFolder: `assets/${oppositeLang}`
+                            })
+                        );
                     }
                     this.$emit('shared-asset', oppositeFileSource, uploadSource, oppositeLang); // must be emitted for each duplicate asset
                 }
@@ -368,6 +374,11 @@ export default class VideoEditorV extends Vue {
             }
             uploadSource = `${this.configFileStructure.uuid}/assets/${this.lang}/${newAssetName}`;
             this.configFileStructure.assets[this.lang].file(newAssetName, file);
+        }
+
+        // Notify user of the change in the name of their uploaded asset, to avoid any confusion
+        if (file.name !== newAssetName) {
+            Message.info(this.$t('editor.slides.assetNameChange', { oldName: file.name, newName: newAssetName }));
         }
 
         if (this.sourceCounts[uploadSource]) {
@@ -485,6 +496,13 @@ export default class VideoEditorV extends Vue {
             if (this.sourceCounts[videoSource] === 0) {
                 this.configFileStructure.assets[videoFolder].remove(videoRelativePath);
                 URL.revokeObjectURL(this.videoPreview.src);
+                Message.info(
+                    this.$t('editor.slides.assetRemoved', {
+                        assetType: 'Video',
+                        assetName: videoRelativePath,
+                        folder: `assets/${videoFolder}`
+                    })
+                );
             }
         }
         (this.$refs.videoFileInput as HTMLInputElement).value = '';

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -273,6 +273,9 @@ editor.slides.advanced.details,Click here for more details.,1,Cliquez ici pour p
 editor.slides.advanced.error,This configuration contains one or more errors. Leaving it as-is may cause unexpected behaviour in the editor and published product.,1,Cette configuration contient une ou plusieurs erreurs. La laisser telle quelle peut entraîner un comportement inattendu dans l'éditeur et dans le produit publié.,0
 editor.slides.contentType,Content type,1,Type de contenu,1
 editor.slides.content,Content,1,Contenu,1
+editor.slides.assetNameChange,Asset {oldName} has been uploaded with name {newName},1,L'actif {oldName} a été téléchargé avec le nom {newName},0
+editor.slides.movedToShared,"Asset {assetName} has been moved to the shared folder, and subsequently deleted from the {oppositeFolder} folder",1,"L'actif {assetName} a été déplacé vers le dossier partagé, puis supprimé du dossier {oppositeFolder}",0
+editor.slides.assetRemoved,{assetType} {assetName} no longer exists in the product. Saving changes will delete this file from the {folder} folder (if it exists),1,{assetType} {assetName} n'existe plus dans le produit. L'enregistrement des modifications supprimera ce fichier du dossier {folder} (si ça existe),0
 editor.slides.select,Please select a slide to edit,1,Veuillez sélectionner une diapositive à modifier,1
 editor.slides.panel.body,Panel body,1,Corps du panneau,1
 editor.slides.panel.title,Panel title,1,Titre du panneau,1


### PR DESCRIPTION
### Related Item(s)
#572

### Changes
-  Display a toast message when an asset uploaded by a user experiences a name change, due to another asset with the same name (but different content) already exists in the target asset folder
- Display a toast message when an asset is moved to the shared folder
- Display a toast message when the last instance of an asset or chart is deleted from the product

### Notes
- Instead of providing the user with the ability to set their own name for an asset with a duplicated name, I decided to instead just inform the user of the name change to their asset, in order to avoid any confusion the user might experience
- I don't think the ability for a user to set their own name is really necessary now that I think about it. It will just add more complexity to the codebase
- However let me know if you believe it's worth having this feature

### Testing
Steps:
1. Open a product and create an image panel
2. Upload an asset
3. Upload another asset with the same name but different content
4. Notice the toast message, which indicates the new name for the uploaded asset
5. Try the same thing in the metadata editor and video panel, and ensure the same behavior
6. Upload an asset into the en config
7. Upload the same asset (same name and content) into the fr config
8. Notice the toast message, indicating that the asset is now in the shared folder
9. Upload an asset/chart that doesn't yet exist in the product
10. Now delete that asset/chart
11. Notice the toast message, indicating that this was the last instance of the asset/chart in the product
12. Try the same things with the logo and background image in the metadata
