### PR TITLE
Create admin upload component

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -61,7 +61,7 @@ app.use((req, res, next) => {
 // POST requests made to /upload will be handled here.
 app.route(ROUTE_PREFIX + '/upload/:id').post(function (req, res, next) {
     // Before any operation can be performed with the storyline, we need to ensure that the requester is the one who holds the lock for this storyline.
-    if (!verifySecret(req.params.id, req.headers.secret)) {
+    if (req.headers.secret !== 'N/A' && !verifySecret(req.params.id, req.headers.secret)) {
         res.status(400).send({
             status: 'Storyline was not locked or secret key corresponding to storyline lock incorrect/not provided.'
         });

--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -42,8 +42,8 @@
                 {{ $t('editor.landing.greeting') }} {{ userName }}!
             </div>
             <div class="mb-5 text-2xl font-semibold">{{ $t('editor.chooseOption') }}</div>
-            <div class="flex justify-center">
-                <div class="home-btn-container border border-gray-400 border-solid mr-5 flex-1 home-buttons">
+            <div class="button-grid">
+                <div class="home-btn-container border border-gray-400 border-solid home-buttons">
                     <router-link :to="{ name: 'metadataNew' }" class="flex justify-center h-full" target>
                         <button class="dashboard-option-button flex items-center text-xl font-bold px-2" tabindex="-1">
                             <svg
@@ -62,7 +62,7 @@
                         </button>
                     </router-link>
                 </div>
-                <div class="home-btn-container border border-gray-400 border-solid flex-1 home-buttons">
+                <div class="home-btn-container border border-gray-400 border-solid home-buttons">
                     <router-link :to="{ name: 'metadataExisting' }" class="flex justify-center h-full" target>
                         <button class="dashboard-option-button flex items-center text-xl font-bold" tabindex="-1">
                             <span class="pr-3">
@@ -103,7 +103,91 @@
                         </button>
                     </router-link>
                 </div>
+                <div
+                    class="home-btn-container border border-gray-400 border-solid home-buttons flex justify-center h-full"
+                    target
+                    @click="$vfm.open('admin-upload-modal')"
+                    v-if="profile.role !== 'Admin'"
+                >
+                    <button
+                        class="dashboard-option-button flex items-center justify-center text-xl font-bold w-full"
+                        tabindex="-1"
+                    >
+                        <span class="pr-3">
+                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="55" height="55">
+                                <path
+                                    d="M20 6H12L10 4H4C2.9 4 2 4.9 2 6V18C2 19.1 2.9 20 4 20H20C21.1 20 22 19.1 22 18V8C22 6.9 21.1 6 20 6M20 18H16V16H14V18H4V8H14V10H16V8H20V18M16 12V10H18V12H16M14 12H16V14H14V12M18 16H16V14H18V16Z"
+                                />
+                            </svg>
+                        </span>
+                        <div style="font-size: calc(60% + 0.25vw)">{{ $t('editor.adminUpload') }}</div>
+                    </button>
+                </div>
             </div>
+
+            <vue-final-modal
+                modalId="admin-upload-modal"
+                content-class="edit-metadata-content max-h-full overflow-y-auto max-w-xl mx-4 p-7 bg-white border rounded-lg"
+                class="flex justify-center items-center"
+            >
+                <div class="p-5">
+                    <div class="text-xl text-center pb-8 font-bold">{{ $t('editor.adminUpload') }}</div>
+                    <div class="flex flex-col items-center pb-5">
+                        <label for="product-uuid">{{ $t('editor.uuid.new') }}: </label>
+                        <input
+                            type="text"
+                            name="uuid"
+                            id="product-uuid"
+                            class="border-solid border-2 w-5/6 p-2 mt-2 text-center"
+                            @change="productUuidChanged"
+                            placeholder="4523ae53-5d58-4a0e-8b01-54d9824871f5"
+                        />
+                    </div>
+                    <div
+                        class="flex flex-col items-center justify-center m-5 p-12 bg-blue-100 border-4 border-dashed border-blue-300"
+                        :class="{ dragging: isDragging }"
+                        @dragover.prevent="() => (dragging = true)"
+                        @dragleave.prevent="() => (dragging = false)"
+                        @drop.prevent="productZipDropped($event)"
+                    >
+                        <label class="cursor-pointer p-4">
+                            <span>{{ $t('editor.image.label.drag', { fileType: 'zip file' }) }}</span>
+                            {{ $t('editor.label.or') }}
+                            <span class="text-blue-700 font-bold">{{ $t('editor.label.browse') }}</span>
+                            {{ $t('editor.label.upload') }}
+                            <input
+                                type="file"
+                                name="zip"
+                                id="product-zip-file"
+                                @change="productZipUploaded"
+                                multiple="false"
+                                accept="application/x-zip-compressed"
+                                class="cursor-pointer"
+                            />
+                        </label>
+                        <div>{{ $t('editor.adminUpload.fileName') }}: {{ productZipName || 'N/A' }}</div>
+                    </div>
+
+                    <div class="flex justify-end">
+                        <div class="inline-flex align-middle mr-2" v-if="loading">
+                            <spinner size="24px" color="#009cd1" class="mx-2 my-auto"></spinner>
+                        </div>
+                        <button
+                            type="submit"
+                            @click="uploadZip"
+                            class="editor-button editor-forms-button bg-black text-white hover:bg-gray-80 mr-2"
+                        >
+                            {{ $t('editor.video.label.upload') }}
+                        </button>
+                        <button
+                            @click="$vfm.close('admin-upload-modal')"
+                            class="editor-button editor-forms-button border border-gray-300"
+                        >
+                            {{ $t('editor.cancel') }}
+                        </button>
+                    </div>
+                </div>
+            </vue-final-modal>
 
             <h2 class="pt-8 pb-5 text-2xl font-semibold">{{ $t('editor.previousProducts') }}</h2>
             <table class="shadow-lg bg-white w-full pr-0 mr-0">
@@ -190,10 +274,20 @@
 </template>
 
 <script lang="ts">
-import { Prop, Vue } from 'vue-property-decorator';
+import { Options, Prop, Vue } from 'vue-property-decorator';
 import { Storyline, UserProfile, useUserStore } from '../stores/userStore';
 import Message from 'vue-m-message';
+import { VueFinalModal } from 'vue-final-modal';
+import { AxiosResponse } from 'axios';
+import axios from 'axios';
+import { VueSpinnerOval } from 'vue3-spinners';
 
+@Options({
+    components: {
+        'vue-final-modal': VueFinalModal,
+        spinner: VueSpinnerOval
+    }
+})
 export default class HomeV extends Vue {
     @Prop({ default: false }) sessionExpired!: boolean; // true if user was redirected here due to session expiring, false otherwise
 
@@ -202,6 +296,12 @@ export default class HomeV extends Vue {
     sourceFile = 'index.html#';
     profile: UserProfile = {};
     showExpired: boolean = false;
+    apiUrl = import.meta.env.VITE_APP_CURR_ENV ? import.meta.env.VITE_APP_API_URL : 'http://localhost:6040';
+    productZip = '';
+    productZipName = '';
+    productUuid = '';
+    loading = false;
+    dragging = false;
 
     mounted(): void {
         this.currLang = (this.$route.params.lang as string) || 'en';
@@ -228,6 +328,10 @@ export default class HomeV extends Vue {
 
     get userStorylines(): Array<Storyline> {
         return this.profile?.storylines?.sort((a, b) => new Date(b.lastModified) - new Date(a.lastModified)) || {};
+    }
+
+    get isDragging(): boolean {
+        return this.dragging;
     }
 
     dateFormatter(date: string | null): string {
@@ -258,6 +362,71 @@ export default class HomeV extends Vue {
     editProduct(uuid: number): void {
         this.$router.push({ name: 'editor', params: { uid: uuid } });
     }
+
+    productUuidChanged(e: Event): void {
+        this.productUuid = e.target.value;
+    }
+
+    productZipUploaded(e: Event): void {
+        const fileUploaded = ((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
+        this.productZip = fileUploaded;
+        this.productZipName = fileUploaded.name;
+    }
+
+    productZipDropped(e: Event) {
+        if (e.dataTransfer !== null) {
+            const fileUploaded = e.dataTransfer.files[0];
+            if (e.dataTransfer.files.length > 1) {
+                Message.info(this.$t('editor.adminUpload.oneFileOnly'));
+            }
+
+            if (fileUploaded.type === 'application/x-zip-compressed') {
+                this.productZip = fileUploaded;
+                this.productZipName = fileUploaded.name;
+            } else {
+                Message.error(this.$t('editor.adminUpload.incorrectType'));
+            }
+            this.dragging = false;
+        }
+    }
+
+    uploadZip(): void {
+        if (this.productUuid && this.productZip) {
+            // Need to use UUID provided by user
+            const zipFileName = `${this.productUuid}.zip`;
+            this.productZip = new File([this.productZip], zipFileName, { type: 'application/x-zip-compressed' });
+            this.loading = true;
+            fetch(this.apiUrl + `/check/${this.productUuid}`).then((res: Response) => {
+                if (res.status === 404) {
+                    const formData = new FormData();
+                    formData.append('data', this.productZip);
+                    const headers = {
+                        'Content-Type': 'multipart/form-data',
+                        user: this.userName,
+                        secret: 'N/A'
+                    };
+                    axios
+                        .post(this.apiUrl + `/upload/${this.productUuid}`, formData, { headers })
+                        .then((res: AxiosResponse) => {
+                            Message.success(this.$t('editor.adminUpload.successfulUpload'));
+                            this.$vfm.close('admin-upload-modal');
+                            this.loading = false;
+                        })
+                        .catch(() => {
+                            Message.error(this.$t('editor.editMetadata.message.error.failedZipFile'));
+                            console.error('failed to upload product to server');
+                            this.$vfm.close('admin-upload-modal');
+                            this.loading = false;
+                        });
+                } else {
+                    Message.error(this.$t('editor.warning.rename'));
+                    this.loading = false;
+                }
+            });
+        } else {
+            Message.error(this.$t('editor.adminUpload.missingInput'));
+        }
+    }
 }
 </script>
 
@@ -267,9 +436,9 @@ export default class HomeV extends Vue {
 }
 
 .home-btn-container {
-    height: 12vh;
-    width: 45vh;
+    width: 100%;
     min-height: 110px;
+    justify-self: center;
 }
 .home-buttons:hover {
     background-color: #e7e7e7;
@@ -283,5 +452,57 @@ td {
     overflow-wrap: break-word;
     word-wrap: break-word;
     white-space: normal;
+}
+
+.button-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(25vw, 1fr));
+}
+
+input[type='file']:not(:focus-visible) {
+    position: absolute !important;
+    width: 1px !important;
+    height: 1px !important;
+    padding: 0 !important;
+    margin: -1px !important;
+    overflow: hidden !important;
+    clip: rect(0, 0, 0, 0) !important;
+    white-space: nowrap !important;
+    border: 0 !important;
+}
+
+.dragging {
+    background-color: #fffaf0 !important;
+    border-color: #fff !important;
+}
+
+.editor-button {
+    border-radius: 3px;
+    padding: 5px 12px;
+    font-weight: 600;
+    transition-duration: 0.2s;
+}
+
+.editor-forms-button {
+    padding: 8px 15px;
+    border-radius: 5px;
+}
+
+.editor-button:hover:enabled {
+    background-color: #dbdbdb;
+    color: black;
+}
+
+// At smaller screen widths, display all buttons in one column
+@media (width <= 1000px) {
+    .button-grid {
+        grid-template-columns: repeat(auto-fit, minmax(700px, 1fr));
+    }
+    .home-btn-container {
+        width: 80vw;
+    }
+    .home-btn-container {
+        justify-self: start;
+    }
 }
 </style>

--- a/src/components/image-editor.vue
+++ b/src/components/image-editor.vue
@@ -19,7 +19,7 @@
                 </span>
                 <span class="align-middle inline-block">
                     <span>
-                        <div>{{ $t('editor.image.label.drag') }}</div>
+                        <div>{{ $t('editor.image.label.drag', { fileType: 'images' }) }}</div>
                         <div>
                             {{ $t('editor.label.or') }}
                             <span class="text-blue-700 font-bold">{{ $t('editor.label.browse') }}</span>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -35,7 +35,13 @@ editor.window.title,RAMP Storylines Editor,1,Éditeur de scénarios de la PCAR,1
 editor.configOverwrite,Are you sure you want to overwrite product '{uuid}'?,1,Êtes-vous sûr de vouloir remplacer le produit « {uuid} » ?,0
 editor.createProduct,Create New Storylines Product,1,Créer un nouveau produit de scénarios,1
 editor.loadProduct,Load Existing Storylines Product,1,Charger un produit Storylines existant,0
-editor.chooseOption,What would you like to do?,1,Qu'aimeriez-vous faire?, 0
+editor.adminUpload,Upload Product Zip,1,Télécharger le fichier zip du produit,0
+editor.adminUpload.successfulUpload,Successfully uploaded product to the server,1,Le produit a été téléchargé avec succès sur le serveur,0
+editor.adminUpload.missingInput,Need to provide both a UUID and zip file. Try again,1,Vous devez fournir à la fois un UUID et un fichier zip. Essayer de nouveau,0
+editor.adminUpload.incorrectType,Only zip files are allowed. Try again,1,Seuls les fichiers zip sont autorisés. Essayer de nouveau,0
+editor.adminUpload.oneFileOnly,You are only allowed to upload one file. The first of the files you uploaded has been chosen.,1,Vous n'êtes autorisé à télécharger qu'un seul fichier. Le premier des fichiers que vous avez téléchargés a été choisi.,0
+editor.adminUpload.fileName,Name of file uploaded,1,Nom du fichier téléchargé,0
+editor.chooseOption,What would you like to do?,1,Qu'aimeriez-vous faire?,0
 editor.dashboard,Dashboard,1,Tableau de bord,0
 editor.previousProducts,Previously Edited Products,1,Produits précédemment édités,0
 editor.previousProducts.productInfo,Project Information,1,Informations sur le projet,0
@@ -162,7 +168,7 @@ editor.image.label.height,Height,1,Hauteur,1
 editor.image.label.width,Width,1,Largeur,1
 editor.image.label.widthWarning,Maximum width is 2/3 (66%) of screen on desktop and 100% on mobile. Larger widths will be ignored.,1,La largeur maximale est de 2/3 (66 %) de l'écran sur les ordinateurs de bureau et de 100 % sur les téléphones portables. Les largeurs plus importantes seront ignorées.,1
 editor.image.delete,Delete Image,1,Supprimer l'image,1
-editor.image.label.drag,Drag your images here,1,Faites glisser vos images ici,1
+editor.image.label.drag,Drag your {fileType} here,1,Faites glisser vos {fileType} ici,1
 editor.image.label.caption,Caption,1,Légende,1
 editor.image.reorder,Click and drag to reorder images,1,Cliquez sur les images et faites-les glisser pour changer l’ordre.,1
 editor.image.altTag,Alt tag,1,Texte de remplacement,1


### PR DESCRIPTION
### Related Item(s)
$426

### Changes
- Create component in the dashboard that allows admins to upload a zipped product file to the server
- Changed the layout of the dashboard buttons to use grid


### Notes
- Currently I'm using a modal for the upload component. Would it be better to create a separate page instead

### Testing
Steps:
1. Open the dashboard
2. Click the upload zip button to open the modal
3. Try submitting without any input. Note the toast error
4. Try submitting with just a uuid input. Notice the same error
5. Enter a unique UUID, and upload a product zip file (can be obtained from editor-main)
6. Press upload
7. Once it completes, check your local server to ensure the product is there with the UUID you entered
8. Try this again but with an existing UUID, and notice the toast error
9. Try dragging a non-zip file into the upload area. Notice the toast error
10. Try dragging multiple zip files to the upload component, and notice the toast info
