### PR TITLE
Fix lang change for Canada.ca template

### DIFF
--- a/index-ca-en.html
+++ b/index-ca-en.html
@@ -31,6 +31,7 @@
         <!-- template top and no-script fallback -->
         <div id="def-top"></div>
 
+        <!-- TODO: Storylines editor app is in here. Put into shadow dom or wrap with iframe -->
         <div id="wb-cont">
             <div id="app"></div>
         </div>
@@ -39,59 +40,93 @@
         <div id="def-footer"></div>
 
         <script type="text/javascript">
-            // URL Parsing for Language Switch
-            var url = new URL(window.location.href);
-            var hashParams = url.hash.split('/');
 
-            // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-            if (hashParams.at(-1).length === 0) {
-                hashParams.pop();
+            const getUrlRoute = (strUrl = window.location.href) => {
+                // URL Parsing for Language Switch
+                var url = new URL(strUrl);
+                var hashParams = url.hash.split('/');
+
+                // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
+                if (hashParams.at(-1).length === 0) {
+                    hashParams.pop();
+                }
+
+                // If content after the last slash in the URL is an anchor, clear it.
+                if (hashParams.at(-1).startsWith('#')) {
+                    hashParams.pop();
+                }
+
+                // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
+                var latestParam = hashParams.pop();
+                var newURLRoute = '';
+                var productID = '';
+
+                // In this case there is no product id in the url. The url param before this one will be the lang, 
+                // which we should not include
+                if (latestParam === 'editor' || latestParam === 'editor-metadata') {
+                    newURLRoute = latestParam;
+                } else {
+                    productID = latestParam;
+
+                    if (productID.includes('#')) {
+                        productID = productID.split('#')[0];
+                    }
+                    
+                    // Check to see if the 'editor' route is included in the URL. If so, keep it.
+                    var location = hashParams.pop();
+                    
+                    // Build new URL route.
+                    newURLRoute = location + '/' + productID;
+
+                }
+                return newURLRoute;
             }
 
-            // If content after the last slash in the URL is an anchor, clear it.
-            if (hashParams.at(-1).startsWith('#')) {
-                hashParams.pop();
+            const setAttributes = () => {
+                var url = new URL(window.location.href);
+                
+                document.querySelectorAll('.wb-sl').forEach(function (skipLink) {
+                    skipLink.setAttribute('href', url.href.split(/#[^\/]/)[0] + '#' + skipLink.href.split('#')[1]);
+                });
+                var interval = setInterval(function () {
+                    var links = document.querySelectorAll('.wb-sl');
+                    if (links.length === 3) {
+                        clearInterval(interval);
+                        links[2].setAttribute('href', url.href.split(/#[^\/]/)[0] + '?' + links[2].href.split('?')[1]);
+                    }
+                }, 200);
             }
 
-            // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
-            var productID = hashParams.pop();
-
-            if (productID.includes('#')) {
-                productID = productID.split('#')[0];
-            }
-
-            // Check to see if the 'editor' route is included in the URL. If so, keep it.
-            var hasEditor = hashParams.pop() === 'editor';
-
-            // Build new URL route.
-            var newURLRoute = hasEditor ? 'editor/' + productID : productID;
-
+            let urlRoute = getUrlRoute();
             var defTop = document.getElementById('def-top');
             defTop.outerHTML = wet.builder.top({
                 lngLinks: [
                     {
-                        lang: 'fr',
-                        href: 'index-ca-fr#/fr/' + newURLRoute,
+                        lang: 'en',
+                        id: 'test',
+                        href: 'index-ca-fr#/fr/' + urlRoute,
                         text: 'Français'
                     }
                 ],
                 breadcrumbs: [
                     {
-                        title: 'Environment and natural resources',
-                        href: 'https://www.canada.ca/en/services/environment.html'
+                        title: 'Environnement et ressources naturelles',
+                        href: 'https://www.canada.ca/fr/services/environnement/meteo.html'
                     }
                 ]
             });
-            document.querySelectorAll('.wb-sl').forEach(function (skipLink) {
-                skipLink.setAttribute('href', url.href.split(/#[^\/]/)[0] + '#' + skipLink.href.split('#')[1]);
+
+            setAttributes();
+
+            var langChangeContainer = document.querySelector('#wb-lng');
+            var langChange = langChangeContainer.querySelector('a');
+
+            // Ignores the href in the a tag, and instead navigates to the fr equivalent of the current page
+            langChange.addEventListener('click', (e) => {
+                e.preventDefault();
+                const urlRoute = getUrlRoute();
+                window.location.href = 'index-ca-fr#/fr/' + urlRoute;
             });
-            var interval = setInterval(function () {
-                var links = document.querySelectorAll('.wb-sl');
-                if (links.length === 3) {
-                    clearInterval(interval);
-                    links[2].setAttribute('href', url.href.split(/#[^\/]/)[0] + '?' + links[2].href.split('?')[1]);
-                }
-            }, 200);
         </script>
 
         <script>

--- a/index-ca-fr.html
+++ b/index-ca-fr.html
@@ -39,39 +39,70 @@
         <div id="def-footer"></div>
 
         <script type="text/javascript">
-            // URL Parsing for Language Switch
-            var url = new URL(window.location.href);
-            var hashParams = url.hash.split('/');
 
-            // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
-            if (hashParams.at(-1).length === 0) {
-                hashParams.pop();
+            const getUrlRoute = (strUrl = window.location.href) => {
+                // URL Parsing for Language Switch
+                var url = new URL(strUrl);
+                var hashParams = url.hash.split('/');
+
+                // If there's an empty item at the end of the paramater list (occurs if there's a trailing slash in the URL), clear it.
+                if (hashParams.at(-1).length === 0) {
+                    hashParams.pop();
+                }
+
+                // If content after the last slash in the URL is an anchor, clear it.
+                if (hashParams.at(-1).startsWith('#')) {
+                    hashParams.pop();
+                }
+
+                // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
+                var latestParam = hashParams.pop();
+                var newURLRoute = '';
+                var productID = '';
+
+                // In this case there is no product id in the url. The url param before this one will be the lang, 
+                // which we should not include
+                if (latestParam === 'editor' || latestParam === 'editor-metadata') {
+                    newURLRoute = latestParam;
+                } else {
+                    productID = latestParam;
+
+                    if (productID.includes('#')) {
+                        productID = productID.split('#')[0];
+                    }
+                    
+                    // Check to see if the 'editor' route is included in the URL. If so, keep it.
+                    var location = hashParams.pop();
+
+                    // Build new URL route.
+                    newURLRoute = location + '/' + productID;
+
+                }
+                return newURLRoute;
             }
 
-            // If content after the last slash in the URL is an anchor, clear it.
-            if (hashParams.at(-1).startsWith('#')) {
-                hashParams.pop();
+            const setAttributes = () => {
+                var url = new URL(window.location.href);
+                
+                document.querySelectorAll('.wb-sl').forEach(function (skipLink) {
+                    skipLink.setAttribute('href', url.href.split(/#[^\/]/)[0] + '#' + skipLink.href.split('#')[1]);
+                });
+                var interval = setInterval(function () {
+                    var links = document.querySelectorAll('.wb-sl');
+                    if (links.length === 3) {
+                        clearInterval(interval);
+                        links[2].setAttribute('href', url.href.split(/#[^\/]/)[0] + '?' + links[2].href.split('?')[1]);
+                    }
+                }, 200);
             }
-
-            // Finally, extract the StoryRAMP ID from the URL. If it has an anchor tag in it, remove it since it's not useful on the new page.
-            var productID = hashParams.pop();
-
-            if (productID.includes('#')) {
-                productID = productID.split('#')[0];
-            }
-
-            // Check to see if the 'editor' route is included in the URL. If so, keep it.
-            var hasEditor = hashParams.pop() === 'editor';
-
-            // Build new URL route.
-            var newURLRoute = hasEditor ? 'editor/' + productID : productID;
-
+            
+            let urlRoute = getUrlRoute();
             var defTop = document.getElementById('def-top');
             defTop.outerHTML = wet.builder.top({
                 lngLinks: [
                     {
                         lang: 'en',
-                        href: 'index-ca-en#/en/' + newURLRoute,
+                        href: 'index-ca-en#/en/' + urlRoute,
                         text: 'English'
                     }
                 ],
@@ -82,16 +113,18 @@
                     }
                 ]
             });
-            document.querySelectorAll('.wb-sl').forEach(function (skipLink) {
-                skipLink.setAttribute('href', url.href.split(/#[^\/]/)[0] + '#' + skipLink.href.split('#')[1]);
+
+            setAttributes();
+            
+            var langChangeContainer = document.querySelector('#wb-lng');
+            var langChange = langChangeContainer.querySelector('a');
+
+            // Ignores the href in the a tag, and instead navigates to the en equivalent of the current page
+            langChange.addEventListener('click', (e) => {
+                e.preventDefault();
+                const urlRoute = getUrlRoute();
+                window.location.href = 'index-ca-en#/en/' + urlRoute;
             });
-            var interval = setInterval(function () {
-                var links = document.querySelectorAll('.wb-sl');
-                if (links.length === 3) {
-                    clearInterval(interval);
-                    links[2].setAttribute('href', url.href.split(/#[^\/]/)[0] + '?' + links[2].href.split('?')[1]);
-                }
-            }, 200);
         </script>
 
         <script>


### PR DESCRIPTION
### Related Item(s)
#561

### Changes
- Modify the `href` attribute of the lang change link upon a URL change, within the Canada.ca template

### Notes
- When initially loading a product into `editor-main`, the editor appears to load twice, due to the modification of the DOM. Not sure how to work around this. 

### Testing
Steps:
1. Load in the Canada.ca template and enter dashboard
2. Press the 'load existing product' button
4. Perform lang change
5. Ensure that you remain on the same page
6. Load a product into editor-main
7. Perform lang change
8. Ensure that you remain on the same page
9. Go back to the dashboard
10. Perform lang change
11. Ensure that you remain on the same page

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/580)
<!-- Reviewable:end -->
