### PR TITLE
Reroute to Dashboard when using Canada.ca template

### DIFF
--- a/src/components/landing.vue
+++ b/src/components/landing.vue
@@ -35,6 +35,18 @@ import { useUserStore } from '../stores/userStore';
 
 export default class LandingV extends Vue {
     title = document.title;
+    url = window.location.href;
+
+    beforeCreate(): void {
+        // Automatically choose lang and re-route when the user is using Canada.ca template
+        if (this.url.includes('index-ca')) {
+            const lang = this.url.includes('index-ca-en') ? 'en' : 'fr';
+            this.$router.push({
+                name: 'home',
+                params: { lang }
+            });
+        }
+    }
 
     get userName(): string {
         const userStore = useUserStore();


### PR DESCRIPTION
### Related Item(s)
#581

### Changes
- Within the `landing` component, reroute to the dashboard if the Canada.ca template is being used, since the lang selection is unnecessary for the Canada.ca template

### Testing
Steps:
1. Load the editor normally, so that the lang selection page appears
2. Switch to the Canada.ca template
3. Notice that you will be rerouted to the Dashboard component with the appropriate page lang already selection

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/585)
<!-- Reviewable:end -->
