### PR TITLE
Fix Canada.ca lang change

### DIFF
--- a/index-ca-en.html
+++ b/index-ca-en.html
@@ -102,16 +102,15 @@
             defTop.outerHTML = wet.builder.top({
                 lngLinks: [
                     {
-                        lang: 'en',
-                        id: 'test',
-                        href: 'index-ca-fr#/fr/' + urlRoute,
+                        lang: 'fr',
+                        href: 'index-ca-fr.html#/fr/' + urlRoute,
                         text: 'Français'
                     }
                 ],
                 breadcrumbs: [
                     {
-                        title: 'Environnement et ressources naturelles',
-                        href: 'https://www.canada.ca/fr/services/environnement/meteo.html'
+                        title: 'Environment and natural resources',
+                        href: 'https://www.canada.ca/en/services/environment.html'
                     }
                 ]
             });
@@ -125,7 +124,7 @@
             langChange.addEventListener('click', (e) => {
                 e.preventDefault();
                 const urlRoute = getUrlRoute();
-                window.location.href = 'index-ca-fr#/fr/' + urlRoute;
+                window.location.href = 'index-ca-fr.html#/fr/' + urlRoute;
             });
         </script>
 

--- a/index-ca-fr.html
+++ b/index-ca-fr.html
@@ -102,7 +102,7 @@
                 lngLinks: [
                     {
                         lang: 'en',
-                        href: 'index-ca-en#/en/' + urlRoute,
+                        href: 'index-ca-en.html#/en/' + urlRoute,
                         text: 'English'
                     }
                 ],
@@ -123,7 +123,7 @@
             langChange.addEventListener('click', (e) => {
                 e.preventDefault();
                 const urlRoute = getUrlRoute();
-                window.location.href = 'index-ca-en#/en/' + urlRoute;
+                window.location.href = 'index-ca-en.html#/en/' + urlRoute;
             });
         </script>
 


### PR DESCRIPTION
### Related Item(s)
#580

### Changes
- Ensure that the lang change toggle routes to `index-ca-en.html`, rather than just `index-ca-en.html` (and same for `index-ca-fr`)

### Testing
Steps:
1. Follow steps in #580 to ensure lang change is working properly
