### PR TITLE
Fix loading spinner

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -130,6 +130,7 @@ app.route(ROUTE_PREFIX + '/upload/:id').post(function (req, res, next) {
             const config_fr = JSON.stringify(
                 JSON.parse(files.find((file) => file.path === `${req.params.id}_fr.json`).data)
             );
+
             // Retrieve the existing files in the directory and change the path. Ignore all files within the
             // .git folder
             const existingFiles = recursiveRead(fileName).then((existing) => {

--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -240,7 +240,7 @@
             </vue-final-modal>
 
             <h2 class="pt-8 pb-5 text-2xl font-semibold">{{ $t('editor.previousProducts') }}</h2>
-            <table class="shadow-lg bg-white w-full pr-0 mr-0">
+            <table class="shadow-lg bg-white w-full pr-0 mr-0 mb-10">
                 <colgroup>
                     <col class="w-3/5" />
                     <col span="2" />


### PR DESCRIPTION
### Related Item(s)
#565

### Changes
- Use the `loadStatus` prop when determining whether to display the loading spinner or not. 
- Added padding to loading spinner
- Added margin to previous products table

### Testing
Steps:
Changes have been pushed to the dev site, so testing should be done there

1. Try loading products into editor-main, and ensure that the loading spinner persists until the editor is actually loaded in

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/593)
<!-- Reviewable:end -->
