### PR TITLE
Enhance admin upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "deep-object-diff": "^1.1.9",
                 "dompurify": "^3.2.6",
                 "file-saver": "^2.0.5",
+                "file-selector": "^2.1.2",
                 "highcharts": "^9.3.2",
                 "highcharts-accessible-configuration-kit": "^1.15.0",
                 "highcharts-vue": "^1.4.3",
@@ -5907,6 +5908,24 @@
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.5.tgz",
             "integrity": "sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA=="
+        },
+        "node_modules/file-selector": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+            "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+            "license": "MIT",
+            "dependencies": {
+                "tslib": "^2.7.0"
+            },
+            "engines": {
+                "node": ">= 12"
+            }
+        },
+        "node_modules/file-selector/node_modules/tslib": {
+            "version": "2.8.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+            "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+            "license": "0BSD"
         },
         "node_modules/fill-range": {
             "version": "7.1.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "deep-object-diff": "^1.1.9",
         "dompurify": "^3.2.6",
         "file-saver": "^2.0.5",
+        "file-selector": "^2.1.2",
         "highcharts": "^9.3.2",
         "highcharts-accessible-configuration-kit": "^1.15.0",
         "highcharts-vue": "^1.4.3",

--- a/server/index.js
+++ b/server/index.js
@@ -546,15 +546,15 @@ app.route(ROUTE_PREFIX + '/admin-rename').post(function (req, res) {
                     let configEn = JSON.stringify(JSON.parse(data), null, 4);
                     configEn = configEn.replaceAll(`${configUuid}/`, `${newUuid}/`);
 
-                    // Create the new en config file
-                    fs.writeFile(PRODUCT_PATH + `/${newUuid}_en.json`, configEn, 'utf8', async (err) => {
+                    // Remove the old en config from the product
+                    fs.unlink(PRODUCT_PATH + `/${configUuid}_en.json`, (err) => {
                         if (err) {
                             res.status(500).send({ status: 'Internal Server Error' });
                             logger('WARNING', 'Error occured while renaming a Storylines product.' + err);
                             return;
                         }
-                        // Remove the old en config from the product
-                        fs.unlink(PRODUCT_PATH + `/${configUuid}_en.json`, (err) => {
+                        // Create the new en config file
+                        fs.writeFile(PRODUCT_PATH + `/${newUuid}_en.json`, configEn, 'utf8', async (err) => {
                             if (err) {
                                 res.status(500).send({ status: 'Internal Server Error' });
                                 logger('WARNING', 'Error occured while renaming a Storylines product.' + err);
@@ -571,31 +571,36 @@ app.route(ROUTE_PREFIX + '/admin-rename').post(function (req, res) {
                                 let configFr = JSON.stringify(JSON.parse(data), null, 4);
                                 configFr = configFr.replaceAll(`${configUuid}/`, `${newUuid}/`);
 
-                                // Create the new fr config file
-                                fs.writeFile(PRODUCT_PATH + `/${newUuid}_fr.json`, configFr, 'utf8', async (err) => {
+                                // Remove the old fr config from the product
+                                fs.unlink(PRODUCT_PATH + `/${configUuid}_fr.json`, (err) => {
                                     if (err) {
                                         res.status(500).send({ status: 'Internal Server Error' });
                                         logger('WARNING', 'Error occured while renaming a Storylines product.' + err);
                                         return;
                                     }
 
-                                    // Remove the old fr config from the product
-                                    fs.unlink(PRODUCT_PATH + `/${configUuid}_fr.json`, (err) => {
-                                        if (err) {
-                                            res.status(500).send({ status: 'Internal Server Error' });
+                                    // Create the new fr config file
+                                    fs.writeFile(
+                                        PRODUCT_PATH + `/${newUuid}_fr.json`,
+                                        configFr,
+                                        'utf8',
+                                        async (err) => {
+                                            if (err) {
+                                                res.status(500).send({ status: 'Internal Server Error' });
+                                                logger(
+                                                    'WARNING',
+                                                    'Error occured while renaming a Storylines product.' + err
+                                                );
+                                                return;
+                                            }
+                                            res.status(200).send({ status: 'OK' });
                                             logger(
-                                                'WARNING',
-                                                'Error occured while renaming a Storylines product.' + err
+                                                'INFO',
+                                                `Product successfully renamed product from ${configUuid} to ${newUuid}`
                                             );
                                             return;
                                         }
-                                        res.status(200).send({ status: 'OK' });
-                                        logger(
-                                            'INFO',
-                                            `Product successfully renamed product from ${configUuid} to ${newUuid}`
-                                        );
-                                        return;
-                                    });
+                                    );
                                 });
                             });
                         });

--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -152,15 +152,15 @@
                 content-class="edit-metadata-content max-h-full overflow-y-auto max-w-xl mx-4 p-7 bg-white border rounded-lg"
                 class="flex justify-center items-center"
             >
-                <div class="p-5">
+                <div class="modal-contents">
                     <div class="text-xl text-center pb-8 font-bold">{{ $t('editor.adminUpload') }}</div>
-                    <div class="flex flex-col items-center pb-5">
-                        <label for="product-uuid">{{ $t('editor.uuid.new') }}: </label>
+                    <div class="flex flex-col items-center pb-2">
+                        <label class="pb-1" for="product-uuid">{{ $t('editor.uuid.new') }}: </label>
                         <input
                             type="text"
                             name="uuid"
                             id="product-uuid"
-                            class="respected-standard-input w-5/6 text-center"
+                            class="respected-standard-input text-center"
                             v-model="productUuid"
                             @input="checkUuid"
                             placeholder="4523ae53-5d58-4a0e-8b01-54d9824871f5"
@@ -168,12 +168,11 @@
                                 'input-error': error
                             }"
                         />
-                        <!-- TODO: try to keep this fixed in size, so the modal doesn't resize when rendered -->
-                        <div class="w-5/6 h-1/6">
+                        <div class="warning-container">
                             <!-- Display a warning if there is one. -->
                             <span
                                 v-if="warning !== 'none'"
-                                class="flex flex-row items-center text-accent-dark-orange rounded p-1"
+                                class="flex flex-row items-center justify-center text-accent-dark-orange rounded p-1"
                             >
                                 <span class="align-middle inline-block mr-1 fill-current">
                                     <svg
@@ -201,33 +200,65 @@
                         </div>
                     </div>
                     <div
-                        class="flex flex-col items-center justify-center m-5 bg-blue-100 border-4 border-dashed border-blue-300"
+                        class="file-upload flex flex-col items-center justify-center bg-blue-100 border-4 border-dashed border-blue-300"
                         :class="{ dragging: isDragging }"
                         @dragover.prevent="() => (dragging = true)"
                         @dragleave.prevent="() => (dragging = false)"
-                        @drop.prevent="productZipDropped($event)"
+                        @drop.prevent="productDropped($event)"
                     >
-                        <div class="self-end p-0">
-                            <button
-                                class="info-button w-min cursor-default"
-                                :content="$t('editor.adminUpload.zipFileInfo')"
+                        <div class="self-end p-2">
+                            <span
+                                :content="`${$t('editor.adminUpload.zipFileInfo')}<br/><br/>${$t(
+                                    'editor.adminUpload.folderUploadInfo'
+                                )}`"
                                 v-tippy="{
-                                    theme: 'left-align',
-                                    delay: '200',
                                     placement: 'bottom-start',
+                                    theme: 'left-align',
+                                    hideOnClick: false,
+                                    animateFill: true,
                                     touch: ['hold', 500],
                                     allowHTML: true
                                 }"
+                                tabindex="0"
                             >
-                                i
-                            </button>
+                                <svg
+                                    class="fill-current"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                                    width="20"
+                                    height="20"
+                                    viewBox="0 0 416.979 416.979"
+                                    xml:space="preserve"
+                                >
+                                    <g>
+                                        <path
+                                            d="M356.004,61.156c-81.37-81.47-213.377-81.551-294.848-0.182c-81.47,81.371-81.552,213.379-0.181,294.85   c81.369,81.47,213.378,81.551,294.849,0.181C437.293,274.636,437.375,142.626,356.004,61.156z M237.6,340.786   c0,3.217-2.607,5.822-5.822,5.822h-46.576c-3.215,0-5.822-2.605-5.822-5.822V167.885c0-3.217,2.607-5.822,5.822-5.822h46.576   c3.215,0,5.822,2.604,5.822,5.822V340.786z M208.49,137.901c-18.618,0-33.766-15.146-33.766-33.765   c0-18.617,15.147-33.766,33.766-33.766c18.619,0,33.766,15.148,33.766,33.766C242.256,122.755,227.107,137.901,208.49,137.901z"
+                                        />
+                                    </g>
+                                </svg>
+                            </span>
                         </div>
-                        <div class="flex flex-col items-center justify-center p-12 pt-4">
-                            <label class="cursor-pointer p-4">
-                                <span>{{ $t('editor.image.label.drag', { fileType: 'zip file' }) }}</span>
-                                {{ $t('editor.label.or') }}
-                                <span class="text-blue-700 font-bold">{{ $t('editor.label.browse') }}</span>
-                                {{ $t('editor.label.upload') }}
+                        <div class="flex gap-3 flex-col items-center justify-center p-6 pt-0">
+                            <span>{{ $t('editor.adminUpload.drag') }}</span>
+                            {{ $t('editor.label.or')[0].toUpperCase() + $t('editor.label.or').slice(1) }}
+
+                            <label
+                                class="cursor-pointer"
+                                :content="$t('editor.adminUpload.zipFileInfo')"
+                                v-tippy="{
+                                    placement: 'bottom-start',
+                                    theme: 'left-align',
+                                    hideOnClick: false,
+                                    animateFill: true,
+                                    touch: ['hold', 500]
+                                }"
+                                @keydown.enter="clickZipUpload"
+                                tabindex="0"
+                            >
+                                <span class="text-blue-700 font-bold">{{
+                                    $t('editor.label.browse')[0].toUpperCase() + $t('editor.label.browse').slice(1)
+                                }}</span>
+                                {{ $t('editor.label.upload.zip') }}
                                 <input
                                     type="file"
                                     name="zip"
@@ -236,20 +267,54 @@
                                     multiple="false"
                                     accept="application/x-zip-compressed"
                                     class="cursor-pointer"
+                                    ref="productZipInput"
+                                    tabindex="-1"
                                 />
                             </label>
-                            <div>{{ $t('editor.adminUpload.fileName') }}: {{ productZipName || 'N/A' }}</div>
+                            <label
+                                class="cursor-pointer pt-4"
+                                :content="$t('editor.adminUpload.folderUploadInfo')"
+                                v-tippy="{
+                                    placement: 'bottom-start',
+                                    theme: 'left-align',
+                                    hideOnClick: false,
+                                    animateFill: true,
+                                    touch: ['hold', 500]
+                                }"
+                                @keydown.enter="clickFolderUpload"
+                                tabindex="0"
+                            >
+                                <span class="text-blue-700 font-bold">{{
+                                    $t('editor.label.browse')[0].toUpperCase() + $t('editor.label.browse').slice(1)
+                                }}</span>
+                                {{ $t('editor.label.upload.folder') }}
+                                <input
+                                    type="file"
+                                    name="folder"
+                                    @change="productFolderUploaded"
+                                    multiple="false"
+                                    webkitdirectory
+                                    directory
+                                    class="cursor-pointer"
+                                    ref="productFolderInput"
+                                    tabindex="-1"
+                                />
+                            </label>
+
+                            <div class="pt-4">
+                                {{ $t('editor.adminUpload.fileName') }}: {{ productUploadName || 'N/A' }}
+                            </div>
                         </div>
                     </div>
+                    <br />
 
-                    <div class="flex justify-end">
-                        <div class="inline-flex align-middle mr-2" v-if="loading">
+                    <div class="modal-footer">
+                        <div class="inline-flex align-middle self-center" v-if="loading">
                             <spinner size="24px" color="#009cd1" class="mx-2 my-auto"></spinner>
                         </div>
                         <button
                             type="submit"
                             @click="uploadZip"
-                            style="margin-right: 0.5rem"
                             class="respected-standard-button respected-black-bg-button"
                             :disabled="error"
                         >
@@ -288,6 +353,11 @@
                     </tr>
                 </thead>
                 <tbody>
+                    <tr v-if="userStorylines.length === 0">
+                        <td style="background-color: #f9f9f9" class="border-b border-solid text-center p-2" colspan="3">
+                            {{ $t('editor.previousProducts.noProducts') }}
+                        </td>
+                    </tr>
                     <tr v-for="(storyline, idx) in userStorylines" :key="idx">
                         <td
                             style="background-color: #f9f9f9; padding-right: 1vw"
@@ -316,7 +386,7 @@
                             :class="idx === userStorylines.length - 1 ? 'border-black' : 'border-gray-200'"
                         >
                             <button
-                                class="flex items-center font-semibold rounded-sm py-2 border border-solid border-black home-buttons"
+                                class="flex items-center justify-center font-semibold rounded-sm py-2 border border-solid border-black home-buttons"
                                 style="
                                     padding-right: 1vw;
                                     padding-left: 1vw;
@@ -362,6 +432,8 @@ import { VueFinalModal } from 'vue-final-modal';
 import { AxiosResponse } from 'axios';
 import { VueSpinnerOval } from 'vue3-spinners';
 import { throttle } from 'throttle-debounce';
+import JSZip from 'jszip';
+import { fromEvent } from 'file-selector';
 
 import axios from 'axios';
 import Message from 'vue-m-message';
@@ -383,7 +455,7 @@ export default class HomeV extends Vue {
     showExpired = false;
     apiUrl = import.meta.env.VITE_APP_CURR_ENV ? import.meta.env.VITE_APP_API_URL : 'http://localhost:6040';
     productZip: string | File = '';
-    productZipName = '';
+    productUploadName = '';
     productUuid = '';
     loading = false;
     dragging = false;
@@ -464,7 +536,6 @@ export default class HomeV extends Vue {
     }
 
     productZipUploaded(e: Event): void {
-        // TODO: If a product folder was uploaded instead of a zip, zip it
         const uploadedFiles = (e.target as HTMLInputElement).files as ArrayLike<File>;
         if (uploadedFiles.length > 0) {
             if (uploadedFiles.length > 1) {
@@ -473,18 +544,34 @@ export default class HomeV extends Vue {
             const fileUploaded = uploadedFiles[0];
             if (fileUploaded.type === 'application/x-zip-compressed') {
                 this.productZip = fileUploaded;
-                this.productZipName = fileUploaded.name;
+                this.productUploadName = fileUploaded.name;
             } else {
                 Message.error(this.$t('editor.adminUpload.incorrectType'));
             }
         } else {
             this.productZip = '';
-            this.productZipName = '';
+            this.productUploadName = '';
         }
     }
 
-    productZipDropped(e: DragEvent) {
-        // TODO: If a product folder was uploaded instead of a zip, zip it
+    clickZipUpload() {
+        this.$refs['productZipInput'].click();
+    }
+
+    clickFolderUpload() {
+        this.$refs['productFolderInput'].click();
+    }
+
+    productFolderUploaded(e: Event): void {
+        const uploadedFiles = (e.target as HTMLInputElement).files as ArrayLike<File>;
+        uploadedFiles.forEach((file) => {
+            // Add filePath property to each file
+            file.filePath = file.webkitRelativePath;
+        });
+        this.uploadFolderHelper(uploadedFiles);
+    }
+
+    productDropped(e: Event): void {
         if (e.dataTransfer !== null) {
             const fileUploaded = e.dataTransfer.files[0];
             if (e.dataTransfer.files.length > 1) {
@@ -493,11 +580,87 @@ export default class HomeV extends Vue {
 
             if (fileUploaded.type === 'application/x-zip-compressed') {
                 this.productZip = fileUploaded;
-                this.productZipName = fileUploaded.name;
+                this.productUploadName = fileUploaded.name;
             } else {
-                Message.error(this.$t('editor.adminUpload.incorrectType'));
+                fromEvent(e).then((files) => {
+                    files.forEach((file) => {
+                        // Remove initial slash. Creating new property because others are read only
+                        file.filePath = file.relativePath.split('/').slice(1).join('/');
+                    });
+                    this.uploadFolderHelper(files);
+                });
             }
             this.dragging = false;
+        }
+    }
+
+    uploadFolderHelper(uploadedFiles: Array<File>): void {
+        if (uploadedFiles.length > 0) {
+            const configZip = new JSZip();
+            let containsEnConfig = false;
+            let containsFrConfig = false;
+            let folderUuidEn = '';
+            let folderUuidFr = '';
+            configZip.folder('ramp-config');
+            configZip.folder('assets/en');
+            configZip.folder('assets/fr');
+            configZip.folder('charts');
+            configZip.folder('styles');
+
+            uploadedFiles.forEach((file) => {
+                if (file.name.includes('_en.json')) {
+                    containsEnConfig = true;
+                    folderUuidEn = file.name.split('_en.json')[0];
+                }
+
+                if (file.name.includes('_fr.json')) {
+                    containsFrConfig = true;
+                    folderUuidFr = file.name.split('_fr.json')[0];
+                }
+            });
+
+            // Ensure that there exists a json config for each lang
+            if (!(containsEnConfig && containsFrConfig && folderUuidEn === folderUuidFr)) {
+                Message.error(this.$t('editor.adminUpload.folder.invalidStructure'));
+                return;
+            }
+
+            for (const file of uploadedFiles) {
+                // Ignore git files
+                if (!file.filePath.includes('.git')) {
+                    // If this file is not within a valid subfolder, the folder is not valid strcture
+                    if (
+                        ['ramp-config', 'styles', 'assets', 'charts'].every(
+                            (str) => file.filePath.split('/')[1] !== str
+                        )
+                    ) {
+                        if (
+                            file.filePath.split('/')[1] !== `${folderUuidEn}_en.json` &&
+                            file.filePath.split('/')[1] !== `${folderUuidEn}_fr.json`
+                        ) {
+                            Message.error(this.$t('editor.adminUpload.folder.invalidStructure'));
+                            return;
+                        }
+                    }
+
+                    // If this files highest parent is not the same as the names of the config files, the folder is not
+                    // valid structure
+                    if (file.filePath.split('/')[0] !== folderUuidEn) {
+                        Message.error(this.$t('editor.adminUpload.folder.invalidStructure'));
+                        return;
+                    }
+
+                    configZip.file(file.filePath.split('/').slice(1).join('/'), file);
+                }
+            }
+
+            configZip.generateAsync({ type: 'blob' }).then((content: Blob) => {
+                this.productZip = content;
+                this.productUploadName = folderUuidEn;
+            });
+        } else {
+            this.productZip = '';
+            this.productUploadName = '';
         }
     }
 
@@ -673,6 +836,11 @@ td {
     grid-template-columns: repeat(auto-fit, minmax(25vw, 1fr));
 }
 
+.warning-container {
+    width: 30vw;
+    height: 20px;
+}
+
 input[type='file']:not(:focus-visible) {
     position: absolute !important;
     width: 1px !important;
@@ -688,6 +856,41 @@ input[type='file']:not(:focus-visible) {
 .dragging {
     background-color: #fffaf0 !important;
     border-color: #fff !important;
+}
+
+.modal-contents {
+    padding: 1.25em;
+}
+
+.file-upload {
+    margin: 1.25rem;
+}
+
+.modal-footer {
+    display: flex;
+    justify-content: end;
+    gap: 5px;
+}
+
+.editor-button {
+    border-radius: 3px;
+    padding: 5px 12px;
+    font-weight: 600;
+    transition-duration: 0.2s;
+}
+
+.editor-input {
+    width: 85%;
+}
+
+.editor-forms-button {
+    padding: 8px 15px;
+    border-radius: 5px;
+}
+
+.editor-button:hover:enabled {
+    background-color: #dbdbdb;
+    color: black;
 }
 
 .input-error {
@@ -712,6 +915,35 @@ input[type='file']:not(:focus-visible) {
     }
     .home-btn-container {
         justify-self: start;
+    }
+    .warning-container {
+        width: 60vw;
+        height: 25px;
+    }
+}
+
+@media (width <= 400px) {
+    .modal-contents {
+        padding: 5px;
+        padding-top: 15px;
+    }
+
+    .file-upload {
+        margin: 2px;
+        margin-bottom: 10px;
+    }
+
+    .modal-footer {
+        flex-direction: column;
+    }
+
+    .editor-input {
+        width: 100%;
+    }
+
+    .warning-container {
+        width: 70vw;
+        height: 10%;
     }
 }
 </style>

--- a/src/components/panel-editors/image-editor.vue
+++ b/src/components/panel-editors/image-editor.vue
@@ -19,7 +19,7 @@
                 </span>
                 <span class="align-middle inline-block">
                     <span>
-                        <div>{{ $t('editor.image.label.drag', { fileType: 'images' }) }}</div>
+                        <div>{{ $t('editor.image.label.drag') }}</div>
                         <div>
                             {{ $t('editor.label.or') }}
                             <span class="text-blue-700 font-bold">{{ $t('editor.label.browse') }}</span>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -39,13 +39,19 @@ editor.window.title,RAMP Storylines Editor,1,Éditeur de scénarios de la PCAR,1
 editor.configOverwrite,Are you sure you want to overwrite product '{uuid}'?,1,Êtes-vous sûr de vouloir remplacer le produit « {uuid} » ?,0
 editor.createProduct,Create New Storylines Product,1,Créer un nouveau produit de scénarios,1
 editor.loadProduct,Load Existing Storylines Product,1,Charger un produit Storylines existant,0
-editor.adminUpload,Upload Product Zip,1,Télécharger le produit,0
+editor.adminUpload,Upload Product,1,Télécharger le produit,0
 editor.adminUpload.successfulUpload,Successfully uploaded product to the server,1,Le produit a été téléchargé avec succès sur le serveur,0
 editor.adminUpload.missingInput,Need to provide both a UUID and zip file. Try again,1,Vous devez fournir à la fois un UUID et un fichier zip. Essayer de nouveau,0
 editor.adminUpload.incorrectType,Only zip files are allowed. Try again,1,Le dossier téléchargé ne correspond pas à la structure du produit.,0
 editor.adminUpload.oneFileOnly,You are only allowed to upload one file. The first of the files you uploaded has been chosen.,1,Vous n'êtes autorisé à télécharger qu'un seul fichier. Le premier des fichiers que vous avez téléchargés a été choisi.,0
-editor.adminUpload.fileName,Name of file uploaded,1,Nom du dossier téléchargé,0
+editor.adminUpload.fileName,Name of product upload,1,Nom du produit téléchargé,0
 editor.adminUpload.zipFileInfo,"A zipped product folder can be obtained by navigating to a product folder, highlighting all of it's contents, right clicking and then compressing to a zip file.",0,"Un dossier de produit zippé peut être obtenu en naviguant vers un dossier de produit, en mettant en surbrillance tout son contenu, en cliquant avec le bouton droit de la souris, puis en le compressant dans un fichier zip.",0
+editor.adminUpload.drag,Drag your product here,1,Faites glisser votre produit ici,0
+editor.adminUpload,Upload Product,1,Télécharger le produit,1
+editor.adminUpload.folderUpload,"""Or, upload a product folder as is, without zipping""",1,"« Ou téléchargez un dossier produit tel quel, sans le compresser. »",1
+editor.adminUpload.folderUploadError,Uploaded folder doesnt match product structure,1,Le dossier téléchargé ne correspond pas à la structure du produit.,1
+editor.adminUpload.folderUploadInfo,"""The product folder uploaded must adhere to the structure of a storylines product, otherwise it will not be accepted""",1,"« Le dossier produit téléchargé doit respecter la structure d'un produit Storylines, sinon il ne sera pas accepté. »",1
+editor.adminUpload.folder.invalidStructure,Uploaded folder doesn't match product structure,1,Le dossier téléchargé ne correspond pas à la structure du produit.,1
 editor.chooseOption,What would you like to do?,1,Qu'aimeriez-vous faire?,0
 editor.dashboard,Dashboard,1,Tableau de bord,0
 editor.previousProducts,Previously Edited Products,1,Produits précédemment édités,0
@@ -53,6 +59,7 @@ editor.previousProducts.productInfo,Project Information,1,Informations sur le pr
 editor.previousProducts.productInfo.title,Title,1,Titre,0
 editor.previousProducts.lastModified,Last Modified,1,Dernière modification,0
 editor.previousProducts.actions,Actions,1,Actes,0
+editor.previousProducts.noProducts,No previously edited products,1,Aucun produit précédemment modifié,1
 editor.editMetadata.load.cancel,Cancel load,1,Annuler le chargement,0
 editor.editMetadata.editExistingHeader,Choose Storylines Product,1,Choisissez le produit Storylines,0
 editor.editMetadata.input.tooltip,Press Esc to erase field.,1,Appuyez sur Esc pour effacer le champ.,0
@@ -121,7 +128,7 @@ editor.warning.renameFailed,Failed to rename product.,1,Échec du renommage du p
 editor.warning.badChar,"Illegal character entered. You cannot use these characters in your UUID: {': / # ? & @ % +'}",1,"Caractère illégal saisi. Vous ne pouvez pas utiliser ces caractères dans votre UUID: {': / # ? & @ % +'}",0
 editor.changeUuid,Click here to change UUID,1,Cliquez ici pour changer,0
 editor.title,Title,1,Titre,1
-editor.respectTitle,RAMP - Enhanced Storylines Product Editor & Creation Tool,1,PCAR - Outil de création et d'édition de scénarios amélioré,1
+editor.respectTitle,RAMP-Enhanced Storylines Product Editor & Creation Tool,1,RAMP - Outil de création et d'édition de scénarios amélioré,1
 editor.logo,Logo,1,Logo,1
 editor.logoPreview,Logo preview,1,Aperçu du logo,1
 editor.logoPreviewAltText,Preview of product logo,1,Aperçu du logo du produit,0
@@ -163,13 +170,15 @@ editor.discardChanges,Discard changes,1,Annuler,0
 editor.label.or,or,1,ou,1
 editor.label.browse,browse,1,parcourir,1
 editor.label.upload,to upload,1,téléverser,1
+editor.label.upload.zip,to upload zip,1,pour télécharger le zip,0
+editor.label.upload.folder,to upload product folder,1,pour télécharger le dossier produit,0
 editor.savingChanges,Saving...,1,Enregistrement...,1
 editor.confirmOverwrite,Are you sure you want to overwrite product '{uuid}'?,1,Are you sure you want to overwrite product '{uuid}'?,0
 editor.resetChanges,Reset Changes,1,Annuler,1
 editor.refreshChanges.modal,"Are you sure you want to reload the product? All unsaved changes will be lost.",1,"Voulez-vous vraiment recharger ce produit? Toute modification non enregistrée sera perdue.",1
 editor.changeLang.modal,"Are you sure you want to switch languages? Unsaved changes may be lost.",1,"Voulez-vous vraiment changer de langue? Toute modification non enregistrée sera perdue.",1
-editor.wetDashboard.title,WET Component Dashboard,1,Tableau de board de l'expérience des composantes web (BOEW),1
-editor.wetDashboard.info,"Please check the <a class='font-bold alert-link' target='_NEW' href='https://wet-boew.github.io/wet-boew-styleguide/index-en.html'>WET design documentation</a> to ensure that you are following the specified accessibility guidelines.",1,"« Veuillez consulter la <a class='font-bold alert-link' target='_NEW' href='https://wet-boew.github.io/wet-boew-styleguide/index-fr.html'>la documentation relative à la conception BOEW</a> afin de vous assurer que vous respectez les directives d'accessibilité spécifiées. »",1
+editor.wetDashboard.title,WET Component Dashboard,1,Tableau de bord des composants humides,1
+editor.wetDashboard.info,"Please check the WET design documentation to ensure that you are following the specified accessibility guidelines.",1,« Veuillez consulter la documentation relative à la conception WET afin de vous assurer que vous respectez les directives d'accessibilité spécifiées. »,1
 editor.enterText,Enter Text,1,Entrer le texte,1
 editor.frenchConfig,View French Config,1,Afficher la configuration en français,1
 editor.englishConfig,View English Config,1,Afficher la configuration en anglais,1
@@ -178,7 +187,7 @@ editor.image.label.height,Height,1,Hauteur,1
 editor.image.label.width,Width,1,Largeur,1
 editor.image.label.widthWarning,Maximum width is 2/3 (66%) of screen on desktop and 100% on mobile. Larger widths will be ignored.,1,La largeur maximale est de 2/3 (66 %) de l'écran sur les ordinateurs de bureau et de 100 % sur les téléphones portables. Les largeurs plus importantes seront ignorées.,1
 editor.image.delete,Delete Image,1,Supprimer l'image,1
-editor.image.label.drag,Drag your {fileType} here,1,Faites glisser vos {fileType} ici,1
+editor.image.label.drag,Drag your images here,1,Faites glisser vos images ici,1
 editor.image.label.caption,Caption,1,Légende,1
 editor.image.reorder,Click and drag to reorder images,1,Cliquez sur les images et faites-les glisser pour changer l’ordre.,1
 editor.image.altTag,Alt tag,1,Texte de remplacement,1
@@ -328,9 +337,9 @@ editor.tocOrientation.vertical,Vertical,1,Verticale,0
 editor.tocOrientation.horizontal,Horizontal,1,Horizontale,0
 editor.returnTop,Include return to top navigation,1,Inclure le retour en haut de la navigation,0
 editor.sameConfig,Same across configurations,1,Identique dans toutes les configurations,1
-editor.sameConfig.info,Determines whether the table of contents orientation and return-to-top navigation are shared across English and French configurations.,1,Détermine si l'orientation de la table des matières et la navigation de retour en haut de page sont communes aux configurations anglaise 
-et française.,1
-editor.sameConfig.tooltip,Navigation and layout settings are currently synchronized. They can be customized per language on the next page in the metadata editor.,1,Les paramètres de navigation et de mise en page sont actuellement synchronisés. Ils peuvent être personnalisés par langue à la page suivante dans l'éditeur de métadonnées.,1
+editor.sameConfig.info,"Determines whether the table of contents orientation and return-to-top navigation are shared across English and French configurations.",1,"Détermine si l'orientation de la table des matières et la navigation de retour en haut de page sont communes aux configurations anglaise 
+et française.",1
+editor.sameConfig.tooltip,"Navigation and layout settings are currently synchronized. They can be customized per language on the next page in the metadata editor.",1,Les paramètres de navigation et de mise en page sont actuellement synchronisés. Ils peuvent être personnalisés par langue à la page suivante dans l'éditeur de métadonnées.,1
 editor.landing.greeting,Hello,1,Bonjour,1
 editor.month.january,January,1,Janvier,0
 editor.month.february,February,1,Février,0
@@ -349,3 +358,25 @@ help.search,Search Help,1,Aide à la recherche,1
 help.section.expand,Expand section,1,Développer une section,1
 help.section.collapse,Collapse section,1,Réduire une section,1
 help.noResults,Nothing is found. Please try a different search.,1,Aucun résultat. Veuillez essayer une autre recherche.,1
+mapnav.openMenu,Open navigation,1,Ouvrir la navigation,1
+mapnav.closeMenu,Close navigation,1,Fermer la navigation,1
+ramp.reload,Reload RAMP,1,Recharger RAMP,1
+legend.layer.features.count,{count} features,1,{count} fonctionnalités,1
+legend.layer.type.ESRIFeature,ESRI Feature Layer,1,Couche d'entités ESRI,1
+legend.layer.type.ESRIMapImage,ESRI Map Image Layer,1,Couche d'image cartographique ESRI,1
+legend.layer.type.ESRITile,ESRI Tile Layer,1,Couche de tuiles ESRI,1
+legend.layer.type.ESRIImagery,ESRI Image Service,1,Service d'images ESRI,1
+legend.layer.type.ESRIGraphic,ESRI Graphic Layer,1,Couche graphique ESRI,1
+legend.layer.type.wfs,OGC WFS 3.0 Layer,1,Couche OGC WFS 3.0,1
+legend.layer.type.wms,OGC WMS Layer,1,Couche WMS OGC,1
+legend.layer.type.geoJson,GeoJSON Layer,1,Couche GeoJSON,1
+legend.layer.type.csv,CSV File Layer,1,Couche de fichier CSV,1
+legend.layer.type.shapefile,Shapefile Layer,1,Couche Shapefile,1
+legend.layer.type.osm,OpenStreetMap Tile Layer,1,Couche de tuiles OpenStreetMap,1
+legend.layer.type.datatable,ESRI Table Layer,1,Couche de table ESRI,1
+legend.layer.type.dataCsv,Non-Spatial CSV File Layer,1,Couche de fichier CSV non spatiale,1
+legend.layer.type.dataJson,Compact JSON File Layer,1,Couche de fichiers JSON compacte,1
+legend.layer.type.sublayer,Sublayer,1,Sous-couche,1
+legend.layer.type.unknown,Unknown Layer Type,1,Type de couche inconnu,1
+editor.undo,Undo,1,Annuler,1
+editor.redo,Redo,1,Refaire,1


### PR DESCRIPTION
### Related Item(s)
#426

### Changes
- Allow for the uploading of product folders as is, without having to zip them
   - Works for both file selection and drag/drop
   - Had to use the `file-selector` 3rd party library for drag/drop
- Improved modal formatting/layout for smaller screen sizes
- Other styling improvements in dashboard

### Notes
- Assuming the folder upload is working correctly, should we still include the zip upload?

### Testing
Steps:
1. Ensure you have the server changes locally
2. Open the admin upload modal
3. Upload a product folder using the second input box
4. Provide a UUID and upload. Ensure that the product is correctly uploaded into your local server
5. Load the product into the editor and ensure that there are no issues
6. Go back to the admin upload modal and repeat steps 2-4 by dragging/dropping a product folder
7. Try uploading a random folder (one that doesn't adhere to the storylines product structure), and observe an appropriate error message
8. Try dragging/dropping a regular file, and observe an appropriate error message

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/595)
<!-- Reviewable:end -->
