### PR TITLE
Include source counts for new panel types

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -693,6 +693,8 @@ import {
     MultiLanguageSlide,
     PanelType,
     Slide,
+    SlideshowChart,
+    SlideshowImage,
     SlideshowPanel,
     SourceCounts,
     StoryRampConfig,
@@ -1599,6 +1601,17 @@ export default class MetadataEditorV extends Vue {
                     this.panelSourceHelper(item);
                 });
                 break;
+            case PanelType.SlideshowImage:
+                (panel as SlideshowImage).items.forEach((item: ImagePanel) => {
+                    this.panelSourceHelper(item);
+                });
+                break;
+            case PanelType.SlideshowChart:
+                (panel as SlideshowChart).items.forEach((item: ChartPanel) => {
+                    this.panelSourceHelper(item);
+                });
+                break;
+
             case PanelType.Chart:
                 this.incrementSourceCount((panel as ChartPanel).src);
                 break;
@@ -2034,6 +2047,8 @@ export default class MetadataEditorV extends Vue {
         if (this.configs[this.configLang]) {
             this.useConfig(this.configs[this.configLang] as StoryRampConfig);
             this.findSources(this.configs); // increments source counts for all panels
+            console.log('source counts upon loading in project data');
+            console.log(JSON.parse(JSON.stringify(this.sourceCounts)));
             // Update router path
             if (this.reloadExisting) {
                 this.loadEditor = true;
@@ -2132,6 +2147,8 @@ export default class MetadataEditorV extends Vue {
      * with the new changes, and if `publish` is set to true, generates and submits the product file to the server.
      */
     generateConfig(publish = true): ConfigFileStructure {
+        console.log('source counts upon saving');
+        console.log(JSON.parse(JSON.stringify(this.sourceCounts)));
         this.lockStore.broadcast?.postMessage({ action: 'saving' });
         this.saving = true;
 


### PR DESCRIPTION
### Changes
- When determining a product's source counts upon loading it in, the new panel types that were recently introduced, `slideshowImage` and `slideshowChart`, will now be considered

### Testing
Steps:
1. Load in a product
2. In the console, ensure that all assets that are within a panel of type `slideshowImage` or `slideshowChart` are included in the `sourceCounts` object
3. Load the product into `editor-main` 
4. Create an image panel and add 2/more images that are not already in the product's assets folder
5. Save changes
6. Reload the page
7. Check the console to ensure that these new images are included in the `sourceCounts` object
