### PR TITLE
Handle dev errors

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -1074,6 +1074,8 @@ export default class MetadataEditorV extends Vue {
                                 external: true // indicates that this is an external asset
                             });
                         });
+                    } else {
+                        res(); // resolve on 404 error, so that loadStatus gets set to loaded
                     }
                 });
             }
@@ -1242,14 +1244,25 @@ export default class MetadataEditorV extends Vue {
                         const configZip = new JSZip();
                         // Files retrieved. Convert them into a JSZip object.
                         res.blob().then((file: Blob) => {
-                            configZip.loadAsync(file).then(() => {
-                                this.configFileStructureHelper(configZip);
-                                // Extend the session on load
-                                this.extendSession();
-                                this.error = false;
-                                this.warning = 'none';
-                                this.loadStatus = 'loaded';
-                            });
+                            configZip
+                                .loadAsync(file)
+                                .then(() => {
+                                    this.configFileStructureHelper(configZip);
+                                    // Extend the session on load
+                                    this.extendSession();
+                                    this.error = false;
+                                    this.warning = 'none';
+                                    this.loadStatus = 'loaded';
+                                })
+                                // Need to ensure we fail gracefully
+                                .catch((error) => {
+                                    Message.error(this.$t('editor.warning.retrievalFailed'));
+                                    console.log(error.response || error);
+                                    this.error = true;
+                                    this.loadStatus = 'waiting';
+                                    this.lockStore.unlockStoryline();
+                                    reject();
+                                });
                         });
                     }
 


### PR DESCRIPTION
### Changes
- Handle errors that were breaking the dev site
  - Within `processAsset()`, when a logo/background image cannot be found, as either a local or remote file, ensure that the editor can still load in
  - Within `loadEditor()`, if the `/retrieve` endpoint throws an iisnode error, ensure that the error is handled appropriately

### Testing
Steps:
1. Open dev site
2. Load in product `BugTest1`
3. Ensure that the metadata editor and next button loads in
4. Click the next button and ensure you are redirected to editor-main
5. Go back and load in product `1d11d1c0-8d99-404d-9e13-3135a4c8a196`
6. Ensure that an error toast appears, and that the loading spinner does not load forever
7. Now load a valid product (ex. TCEI) and ensure that works fine
