### PR TITLE
Fixed overlap between modal header and colour pickers

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -621,7 +621,7 @@
                         class="flex justify-center items-center"
                     >
                         <div @click.stop class="flex flex-col space-y-2">
-                            <div class="sticky top-0 bg-white pt-5 pb-2 mb-2 border-b border-gray-300">
+                            <div class="sticky top-0 bg-white pt-5 pb-2 mb-2 border-b border-gray-300 z-50">
                                 <div class="flex justify-between items-center flex-wrap gap-y-1.5 gap-x-5 mb-2">
                                     <h2 slot="header" class="text-2xl font-bold">{{ $t('editor.editMetadata') }}</h2>
                                     <div class="flex flex-row gap-2">


### PR DESCRIPTION
### Related Item(s)
Issue #582 

### Changes
-  Adjusted z-index of modal header so colour pickers are now hidden behind the header when scrolling past. 

### Testing
Steps:
1. Create or load a product 
2. Open edit project metadata 
3. Decrease screen width to about 900px
4. Scroll down through the editor, and notice that the colour pickers are hidden behind the modal's header when they are scrolled past.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/607)
<!-- Reviewable:end -->
