### PR TITLE
make cursor drag icon

### DIFF
--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -84,7 +84,7 @@
             >
                 <template #item="{ element, index }">
                     <li
-                        class="toc-slide select-none border-t flex px-3 py-2 cursor-pointer hover:bg-gray-50"
+                        class="toc-slide select-none border-t flex px-3 py-2 hover:bg-gray-50"
                         :class="slideIndex === index ? 'bg-gray-100 border-gray-300' : ''"
                         :id="(isMobileSidebar ? 'mobile' : '') + 'slide' + index"
                         :key="'slide' + index"
@@ -719,6 +719,10 @@ window.addEventListener('resize', () => {
     grid-area: slide-list;
     flex: 1 1 0%;
     overflow: auto;
+}
+
+.toc-slide {
+  cursor: grab;
 }
 
 .toc-slide-button {


### PR DESCRIPTION
### Related Item(s)
Enhancement #544 
### Changes
- on parts of the slides where it is draggable, make the mouse icon the drag icon

### Testing
Steps:
1. Create or load a product
2. create or use an existing slide
3. hover over different parts of the slide on the sidebar
4. notice the change in cursor when over buttons versus draggable area

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/608)
<!-- Reviewable:end -->
