### PR TITLE
Fixed disappearing scrollbar in WET template

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -2755,7 +2755,7 @@ $font-list: 'Segoe UI', system-ui, ui-sans-serif, Tahoma, Geneva, Verdana, sans-
 
 .editor-mode {
     height: 100%;
-    overflow: hidden;
+    overflow: auto;
 }
 
 .storyramp-app,


### PR DESCRIPTION
### Related Item(s)
Issue #588 

### Changes
- Changed overflow from hidden to auto for `editor-mode`. Now when using the WET template, page scrollbar is visible when proceeding to the main editor page. 

### Testing
Steps:
1. Open editor with the WET template.
2. Load or create a new product.
3. Proceed to the main editor.
4. The scrollbar should be visible, and should be able to scroll down to footer.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/610)
<!-- Reviewable:end -->
