### PR TITLE
Reduced help search input padding

### DIFF
--- a/src/components/help-panel.vue
+++ b/src/components/help-panel.vue
@@ -11,7 +11,7 @@
             <div class="h-26 mb-8 mx-8">
                 <input
                     type="search"
-                    class="rv-help-search-bar border-b w-full text-base py-8 outline-none focus:shadow-outline border-gray-600 h-full min-w-0"
+                    class="rv-help-search-bar border-b w-full text-base py-2 outline-none focus:shadow-outline border-gray-600 h-full min-w-0"
                     :placeholder="$t('help.search')"
                     v-model="searchTerm"
                     :aria-label="$t('help.search')"


### PR DESCRIPTION
### Related Item(s)
Issue #543 

### Changes
- Reduced help search input padding in help panel. 

### Testing
Steps:
1. Go to the main editor.
2. Click on the help button.
3. Padding around help search input textbox should now appear better fitted for the text size.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/611)
<!-- Reviewable:end -->
