### PR TITLE
fix gray screen error +small dependancy change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
                 "nouislider": "^15.5.0",
                 "ramp-config-editor_editeur-config-pcar": "^3.6.0",
                 "ramp-pcar": "^4.10.2",
-                "ramp-storylines_demo-scenarios-pcar": "^3.2.13",
+                "ramp-storylines_demo-scenarios-pcar": "^3.4.0",
                 "throttle-debounce": "^5.0.0",
                 "url": "^0.11.3",
                 "uuid": "^9.0.0",
@@ -8357,9 +8357,9 @@
             }
         },
         "node_modules/ramp-storylines_demo-scenarios-pcar": {
-            "version": "3.2.13",
-            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.2.13.tgz",
-            "integrity": "sha512-FItHsXZO6wxE7gto5lSHCekeZ7mhMRLuqg73bhICqijSe+CK0tOqcxRIzK3MT8FUwfkc8SabrL8H+MNaw1pXYg==",
+            "version": "3.4.0",
+            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.4.0.tgz",
+            "integrity": "sha512-O17RCbkssEtDSyCDltt2GhYLqHNZ7RePug0sMiQGAH2+XraHSQix1KavIuWImIiFQMEye8GBiW5z2VtH0Ma53Q==",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "nouislider": "^15.5.0",
         "ramp-config-editor_editeur-config-pcar": "^3.6.0",
         "ramp-pcar": "^4.10.2",
-        "ramp-storylines_demo-scenarios-pcar": "^3.2.13",
+        "ramp-storylines_demo-scenarios-pcar": "^3.4.0",
         "throttle-debounce": "^5.0.0",
         "url": "^0.11.3",
         "uuid": "^9.0.0",

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -688,6 +688,25 @@ export default class SlideTocV extends Vue {
     getSlideId(slide: MultiLanguageSlide): string {
         return 'slide' + this.slides.indexOf(slide);
     }
+
+    resizeMobile(): void {
+        let overlayElement = document.getElementById('overlay');
+        let sidebarElement = document.getElementById('sidebar-mobile');
+        
+        if (overlayElement.style.display != 'none' && window.innerWidth >= 768) {
+            overlayElement.style.display = 'none';
+        } else if (sidebarElement.style.width === '20rem' && window.innerWidth < 768) {
+            overlayElement.style.display = 'block';
+        }
+    }
+    mounted() {
+        window.addEventListener('resize', this.resizeMobile);
+    }
+
+    beforeDestroy() {
+        window.removeEventListener('resize', this.resizeMobile);
+    }
+    
 }
 
 // More accurate page height for mobile
@@ -748,6 +767,7 @@ window.addEventListener('resize', () => {
     border-radius: 3px;
     padding: 2px;
 }
+
 .slide-toc-button:hover {
     background-color: rgb(209, 213, 219);
 }
@@ -760,6 +780,7 @@ window.addEventListener('resize', () => {
     border-radius: 3px;
     padding: 2px;
 }
+
 .slide-toc-button:hover {
     background-color: rgb(209, 213, 219);
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ app.use(pinia)
         directive: 'tippy',
         component: 'tippy'
     })
-    .use(HighchartsVue, { tagName: 'charts' })
+    .use(HighchartsVue, { tagName: 'highchart' })
     .use(Message)
     .use(StorylinesViewer)
     .use(VueMarkdownEditor)


### PR DESCRIPTION
### Related Item(s)
Issue #583 

### Changes
- When screen is resized to large enough to display the sidebar constantly, the mobile sidebar is closed
- Bumped Storylines dependency to 3.4.0 and updated Highcharts tag 

### Testing
Steps:
1. Go to main editor
2. F12 to resize screen
3. Go to a mobile view, press sidebar button to display sidebar
4. Resize back to regular size
5. Notice sidebar integrating back and gray overlay disappears

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/612)
<!-- Reviewable:end -->
