### PR TITLE
Fixed so that ToC orientation and return to top changes for both langs

### DIFF
--- a/src/components/helpers/metadata-content.vue
+++ b/src/components/helpers/metadata-content.vue
@@ -20,49 +20,84 @@
             </div>
             <p v-if="!editing">{{ metadata.title || $t('editor.metadataForm.na') }}</p>
         </div>
-        <!-- ToC orientation -->
-        <div class="metadata-item">
-            <label class="respected-standard-label" for="toc">{{ $t('editor.tocOrientation') }}</label>
-            <div v-show="editing">
-                <select
-                    class="respected-standard-select"
-                    name="tocOrientation"
-                    id="toc"
-                    @change="metadataChanged"
-                    v-model="metadata.tocOrientation"
+        <!-- Layout and Navigation Section -->
+        <section class="border mt-5 rounded-md px-4 md:px-5 py-3">
+            <h2 class="text-xl font-bold">{{ $t('editor.metadataForm.layoutAndNav.heading') }}</h2>
+            <!-- Same TOC orientation and return-to-top values across both ENG/FR configs -->
+            <div class="metadata-item">
+                <div
+                    class="inline-flex gap-2 pt-2"
+                    v-tippy="{
+                        delay: '200',
+                        placement: 'bottom',
+                        content: createNew ? $t('editor.sameConfig.tooltip') : null,
+                        animateFill: true,
+                        touch: ['hold', 500],
+                        offset: [10, 2]
+                    }"
                 >
-                    <option value="vertical">{{ $t('editor.tocOrientation.vertical') }}</option>
-                    <option value="horizontal">{{ $t('editor.tocOrientation.horizontal') }}</option>
-                </select>
-                <p class="metadata-subcaption">
-                    {{ $t('editor.metadataForm.caption.tocOrientation') }}
+                    <input
+                        v-show="editing"
+                        type="checkbox"
+                        id="sameConfig"
+                        class="self-center rounded-none cursor-pointer w-4 h-4"
+                        v-model="metadata.sameConfig"
+                        :disabled="createNew"
+                        @change="metadataChanged"
+                    />
+                    <label class="respected-standard-label" for="sameConfig">{{ $t('editor.sameConfig') }}</label>
+                </div>
+                <p v-show="editing" class="metadata-subcaption">
+                    {{ $t('editor.sameConfig.info') }}
+                </p>
+                <p v-if="!editing">
+                    {{ metadata.sameConfig ? $t('editor.metadataForm.enabled') : $t('editor.metadataForm.disabled') }}
                 </p>
             </div>
-            <p v-if="!editing">{{ metadata.tocOrientation || $t('editor.metadataForm.na') }}</p>
-        </div>
-        <!-- Include return to top navigation -->
-        <div class="metadata-item">
-            <div class="flex gap-2">
-                <input
-                    v-show="editing"
-                    type="checkbox"
-                    id="returnToTop"
-                    class="self-center rounded-none cursor-pointer w-4 h-4"
-                    v-model="metadata.returnTop"
-                    @change="metadataChanged"
-                />
-                <label class="respected-standard-label" for="returnToTop">{{ $t('editor.returnTop') }}</label>
+            <!-- ToC orientation -->
+            <div class="metadata-item">
+                <label class="respected-standard-label" for="toc">{{ $t('editor.tocOrientation') }}</label>
+                <div v-show="editing">
+                    <select
+                        class="respected-standard-select"
+                        name="tocOrientation"
+                        id="toc"
+                        @change="metadataChanged"
+                        v-model="metadata.tocOrientation"
+                    >
+                        <option value="vertical">{{ $t('editor.tocOrientation.vertical') }}</option>
+                        <option value="horizontal">{{ $t('editor.tocOrientation.horizontal') }}</option>
+                    </select>
+                    <p class="metadata-subcaption">
+                        {{ $t('editor.metadataForm.caption.tocOrientation') }}
+                    </p>
+                </div>
+                <p v-if="!editing">{{ metadata.tocOrientation || $t('editor.metadataForm.na') }}</p>
             </div>
-            <p v-show="editing" class="metadata-subcaption">
-                {{ $t('editor.tocOrientation.info') }}
-            </p>
-            <p v-if="!editing">
-                {{ metadata.returnTop ? $t('editor.metadataForm.enabled') : $t('editor.metadataForm.disabled') }}
-            </p>
-        </div>
+            <!-- Include return to top navigation -->
+            <div class="metadata-item">
+                <div class="flex gap-2">
+                    <input
+                        v-show="editing"
+                        type="checkbox"
+                        id="returnToTop"
+                        class="self-center rounded-none cursor-pointer w-4 h-4"
+                        v-model="metadata.returnTop"
+                        @change="metadataChanged"
+                    />
+                    <label class="respected-standard-label" for="returnToTop">{{ $t('editor.returnTop') }}</label>
+                </div>
+                <p v-show="editing" class="metadata-subcaption">
+                    {{ $t('editor.tocOrientation.info') }}
+                </p>
+                <p v-if="!editing">
+                    {{ metadata.returnTop ? $t('editor.metadataForm.enabled') : $t('editor.metadataForm.disabled') }}
+                </p>
+            </div>
+        </section>
     </section>
     <!-- Section: Introduction page details -->
-    <section class="border rounded-md px-4 md:px-5 py-3">
+    <section class="border mt-5 rounded-md px-4 md:px-5 py-3">
         <h2 class="text-xl font-bold">{{ $t('editor.metadataForm.introPage.heading') }}</h2>
         <p class="mb-5">
             {{ $t('editor.metadataForm.introPage.explanation') }}
@@ -375,6 +410,7 @@ import ColourPickerInput from './colour-picker-input.vue';
 export default class MetadataEditorV extends Vue {
     @Prop() metadata!: MetadataContent;
     @Prop({ default: true }) editing!: boolean;
+    @Prop({ default: true }) createNew!: boolean;
 
     openFileSelector(where: string = 'logoUpload'): void {
         document.getElementById(where)?.click();

--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -455,6 +455,7 @@
                                     <!-- New projects can only be in edit mode; existing projects can be in both -->
                                     <metadata-content
                                         :metadata="metadata"
+                                        :createNew="true && !editExisting"
                                         :editing="editingMetadata"
                                         @metadata-changed="updateMetadata"
                                         @image-changed="onFileChange"
@@ -666,6 +667,7 @@
                             <div class="mx-4">
                                 <metadata-content
                                     :metadata="metadata"
+                                    :createNew="false"
                                     @metadata-changed="updateMetadata"
                                     @image-changed="onFileChange"
                                     @image-source-changed="onImageSourceInput"
@@ -847,6 +849,7 @@ export default class MetadataEditorV extends Vue {
         contextLabel: '',
         tocOrientation: '',
         returnTop: true,
+        sameConfig: true,
         dateModified: '',
         schemaVersion: ''
     };
@@ -868,6 +871,7 @@ export default class MetadataEditorV extends Vue {
         contextLabel: '',
         tocOrientation: '',
         returnTop: true,
+        sameConfig: true,
         dateModified: '',
         schemaVersion: ''
     };
@@ -953,6 +957,7 @@ export default class MetadataEditorV extends Vue {
             // set vertical as the default table of contents orientation
             this.metadata.tocOrientation = 'vertical';
             this.metadata.returnTop = true;
+            this.metadata.sameConfig = true;
         }
         // Find which view to render based on route
         if (this.$route.name === 'editor') {
@@ -1242,6 +1247,7 @@ export default class MetadataEditorV extends Vue {
             contextLink: this.metadata.contextLink,
             tocOrientation: this.metadata.tocOrientation,
             returnTop: this.metadata.returnTop,
+            sameConfig: this.metadata.sameConfig,
             dateModified: this.metadata.dateModified
         };
     }
@@ -2149,6 +2155,7 @@ export default class MetadataEditorV extends Vue {
         this.metadata.contextLabel = config.contextLabel;
         this.metadata.tocOrientation = config.tocOrientation;
         this.metadata.returnTop = config.returnTop ?? true;
+        this.metadata.sameConfig = config.sameConfig ?? true;
         this.metadata.dateModified = config.dateModified;
         this.metadata.schemaVersion = config.schemaVersion;
 
@@ -2416,7 +2423,7 @@ export default class MetadataEditorV extends Vue {
      * `Done` is pressed in the metadata editor within editor-main. Save metadata content fields to config file. If
      * `publish` is set to true, publish to server as well.
      */
-    async saveMetadata(publish = false): Promise<void> {
+    async saveMetadata(publish = false, swapLang = false): Promise<void> {
         // update metadata content to existing config only if it has been successfully loaded
         const config = this.configs[this.configLang];
         if (config !== undefined) {
@@ -2430,7 +2437,21 @@ export default class MetadataEditorV extends Vue {
             config.contextLabel = this.metadata.contextLabel;
             config.tocOrientation = this.metadata.tocOrientation;
             config.returnTop = this.metadata.returnTop;
+            config.sameConfig = this.metadata.sameConfig;
             config.dateModified = this.metadata.dateModified;
+
+            // Changing TOC orientation and return-to-top navigation for one language also changes for other language.
+            // Changes only if the 'Same across configurations' toggle is true.
+            const otherLang = this.configLang === 'en' ? 'fr' : 'en';
+            const otherConfig = this.configs[otherLang];
+            if (otherConfig) {
+                otherConfig.sameConfig = this.metadata.sameConfig;
+
+                if (this.metadata.sameConfig) {
+                    otherConfig.tocOrientation = this.metadata.tocOrientation;
+                    otherConfig.returnTop = this.metadata.returnTop;
+                }
+            }
 
             // If the logo section is missing, create it here before overwriting values.
             if (config.introSlide.logo === undefined) {
@@ -2463,12 +2484,16 @@ export default class MetadataEditorV extends Vue {
                 this.editingMetadata = false;
             }
 
-            const userStore = useUserStore();
-            userStore.fetchUserProfile();
+            if (!swapLang) {
+                const userStore = useUserStore();
+                userStore.fetchUserProfile();
+            }
 
             this.updateSaveStatus(true, 'Save metadata');
         }
-        this.$vfm.close('metadata-edit-modal');
+        if (!swapLang) {
+            this.$vfm.close('metadata-edit-modal');
+        }
     }
 
     /**
@@ -2490,7 +2515,8 @@ export default class MetadataEditorV extends Vue {
             logoName: '',
             logoAltText: '',
             tocOrientation: '',
-            returnTop: true
+            returnTop: true,
+            sameConfig: true
         };
         this.temporaryMetadataCopy = JSON.parse(JSON.stringify(this.metadata));
         this.configs = { en: undefined, fr: undefined };
@@ -2501,6 +2527,7 @@ export default class MetadataEditorV extends Vue {
      * Language toggle.
      */
     swapLang(): void {
+        this.saveMetadata(false, true);
         this.configLang = this.configLang === 'en' ? 'fr' : 'en';
         if (!this.configs[this.configLang]) {
             return;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -11,6 +11,7 @@ export interface StoryRampConfig {
     contextLabel: string;
     tocOrientation: string;
     returnTop: boolean;
+    sameConfig: boolean;
     stylesheets?: string[];
     dateModified: string;
 }
@@ -48,6 +49,7 @@ export interface MetadataContent {
     contextLabel: string;
     tocOrientation: string;
     returnTop: boolean;
+    sameConfig: boolean;
     dateModified: string;
     schemaVersion: string;
 }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -88,6 +88,7 @@ editor.metadataForm.caption.logoAltText,"For accessibility purposes, provide des
 editor.metadataForm.caption.introBackground,"The background image is displayed on the first slide of the storyline product, behind the intro title and subtitle.",1,"L'image d'arrière-plan est affichée sur la première diapositive du produit scénarisé, derrière le titre et le sous-titre de l'introduction.",1
 editor.metadataForm.caption.contextLink,"Context link shows up at the bottom of the page to provide additional resources for interested users.",1,"Le lien contextuel apparaît au bas de la page pour fournir des ressources supplémentaires aux utilisateurs intéressés.",0
 editor.metadataForm.caption.contextLabel,"Context label shows up as text. When users click the context link, the linked site appears in a new tab for the user.",1,"L'étiquette de contexte s'affiche sous forme de texte. Lorsque les utilisateurs cliquent sur le lien contextuel, le site lié apparaît dans un nouvel onglet pour l'utilisateur.",0
+editor.metadataForm.layoutAndNav.heading,Layout and Navigation,1,Mise en page et Navigation,0
 editor.metadataForm.introPage.heading,Introduction page details,1,Détails de la page d'introduction,0
 editor.metadataForm.introPage.explanation,"The introduction page of the storylines product is displayed to users at the beginning of the storyline product, before any content slides.",1,"La page d'introduction du produit Storylines est affichée aux utilisateurs au début du produit Storylines, avant toute diapositive de contenu.",0
 editor.metadataForm.endOfPage.heading,End of page information,1,Informations de fin de page,0
@@ -322,6 +323,9 @@ editor.tocOrientation.info,The table of contents orientation will be set to vert
 editor.tocOrientation.vertical,Vertical,1,Verticale,0
 editor.tocOrientation.horizontal,Horizontal,1,Horizontale,0
 editor.returnTop,Include return to top navigation,1,Inclure le retour en haut de la navigation,0
+editor.sameConfig,Same across configurations,1,Idem dans toutes les configurations,0
+editor.sameConfig.info,Determines whether the table of contents orientation and return-to-top navigation are shared across English and French configurations.,1,Détermine si l'orientation de la table des matières et la navigation de retour en haut sont partagées entre les configurations anglaise et française.,0
+editor.sameConfig.tooltip,Navigation and layout settings are currently synchronized. They can be customized per language on the next page in the metadata editor.,1,Les paramètres de navigation et de mise en page sont actuellement synchronisés. Ils peuvent être personnalisés par langue sur la page suivante de l'éditeur de métadonnées.,0
 editor.landing.greeting,Hello,1,Bonjour,1
 editor.month.january,January,1,Janvier,0
 editor.month.february,February,1,Février,0


### PR DESCRIPTION
### Related Item(s)
Issue #448 

### Changes
- Changing ToC orientation or return to top navigation choice after creating a storyline changes for both language configs. 

### Testing
Steps:
1. Create a new storyline and proceed to main editor. 
2. Click on `Edit project metadata` and switch the ToC orientation or check/uncheck return to top checkbox in one language config.
3. Click `Done` to save and return to main editor.
4. Open preview for both languages and notice the changes in orientation and return to top apply to both.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/614)
<!-- Reviewable:end -->
