### PR TITLE
Correct uuid with incorrect letter case

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -1990,7 +1990,26 @@ export default class MetadataEditorV extends Vue {
                 }
             });
         }
+        this.correctUuid();
         return this.loadConfig();
+    }
+
+    /**
+     * Ensure that `uuid` is a case-sensitive match with the product's uuid on the server
+     */
+    correctUuid(): void {
+        const configFileNames = Object.keys(this.configFileStructure.zip.files).filter(
+            (key) => key.includes('.json') && !key.includes('/')
+        );
+        if (configFileNames.length > 0) {
+            const productUuid = configFileNames[0].split('_')[0]; // Case-sensitive UUID of product on server
+
+            // Only update uuid if its the same as on the server, just with incorrect letter case
+            if (productUuid.toLowerCase() === this.uuid.toLowerCase()) {
+                this.uuid = productUuid;
+                this.configFileStructure.uuid = productUuid;
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
### Related Item(s)
#616

### Changes
- When a uuid is entered with the incorrect letter case, ensure that it is correct prior to attempting to read the config files within `configFileStructure`


### Notes
- Here I'm assuming that the names of the files within `configFileStructure` are file paths relative to the product folder on the server. So, the json files that are sitting directly in the product folder (and not in a sub folder) would be the config files
- This is the case locally, but let me now if this is not the case on the dev server 

### Testing
Steps:
1. Load in a product by entering its uuid manually, but with incorrect letter case (lowercase instead of uppercase, or vice versa)
2. Ensure that the metadata editor and Next button loads in
3. Click Next and ensure that the product is loaded into editor-main
4. Make some changes and save
5. Ensure that changes are saved successfully
