### PR TITLE
Fix preview lang change upon reload

### DIFF
--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -301,13 +301,15 @@ export default class StoryPreviewV extends Vue {
     // reload preview page with FR config
     changeLang(): void {
         this.broadcast?.close();
+        document.onmousemove = () => undefined;
+        document.onkeydown = () => undefined;
         const newLang = this.lang === 'en' ? 'fr' : 'en';
         const routeData = this.$router.resolve({
             name: 'preview',
             params: { lang: newLang, uid: this.uid }
         });
-        const secret = window.props.secret;
-        const timeRemaining = window.props.timeRemaining;
+        const secret = window.props?.secret;
+        const timeRemaining = window.props?.timeRemaining;
 
         // update window props on refresh (to prevent having to fetch from server again)
         const refreshTab = window.open(routeData.href, '_self');


### PR DESCRIPTION
### Related Item(s)
#623

### Changes
- Ensure that `window.props` exists before trying to access `secret` and `timeRemaining`

### Testing
Steps:
1. Load in a product
2. Open its preview
3. Reload the tab
4. Attempt a lang change, and ensure it's successful

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/630)
<!-- Reviewable:end -->
