### PR TITLE
Increment chart source count on slide copy

### DIFF
--- a/src/components/metadata-editor.vue
+++ b/src/components/metadata-editor.vue
@@ -1675,7 +1675,11 @@ export default class MetadataEditorV extends Vue {
      * @param callback The callback function that is called on each ImagePanel/VideoPanel in the provided BasePanel
      * @param callbackArgs The additional argument(s) for the callback function (can be empty)
      */
-    panelHelper(panel: BasePanel, callback: (panel: ImagePanel | VideoPanel, ...args) => void, ...callbackArgs): void {
+    panelHelper(
+        panel: BasePanel,
+        callback: (panel: ImagePanel | VideoPanel | ChartPanel, ...args) => void,
+        ...callbackArgs
+    ): void {
         switch (panel.type) {
             case 'slideshow':
                 panel.items.forEach((item) => this.panelHelper(item, callback, ...callbackArgs));
@@ -1685,6 +1689,7 @@ export default class MetadataEditorV extends Vue {
                 break;
             case 'image':
             case 'video':
+            case 'chart':
                 callback(panel, ...callbackArgs);
         }
     }


### PR DESCRIPTION
### Related Item(s)
#620

### Changes
- Upon copying a slide containing a chart, that chart will now have it's source count incremented

### Testing
Steps:
1. Load a product into editor-main
2. Create a chart panel and add a chart to it
3. Save changes
4. Copy that slide
5. Now delete that slide
6. Go back to the original slide and ensure that the chart is still there

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/632)
<!-- Reviewable:end -->
