### PR TITLE
Made storyline text layout match text preview layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "nouislider": "^15.5.0",
                 "ramp-config-editor_editeur-config-pcar": "^3.6.0",
                 "ramp-pcar": "^4.10.2",
-                "ramp-storylines_demo-scenarios-pcar": "^3.4.1",
+                "ramp-storylines_demo-scenarios-pcar": "^3.5.1",
                 "throttle-debounce": "^5.0.0",
                 "url": "^0.11.3",
                 "uuid": "^9.0.0",
@@ -8381,9 +8381,9 @@
             }
         },
         "node_modules/ramp-storylines_demo-scenarios-pcar": {
-            "version": "3.4.1",
-            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.4.1.tgz",
-            "integrity": "sha512-OQMEbYp28pyS/DmTj8JTuR8K0rmSRPnbXCqiVfugj0H3IztTNw7lhMznSbHIO+dW1ATOVKvQPiMvUCvo5ck8Pg==",
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.5.1.tgz",
+            "integrity": "sha512-euS1vQTTMwKFeXNIp/oGppM/7Kyv2htJxWUua+q+QVj0aiOf6kevgR5hsCtE8FUaZOEi92nK6bVKwdACmIataQ==",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "nouislider": "^15.5.0",
         "ramp-config-editor_editeur-config-pcar": "^3.6.0",
         "ramp-pcar": "^4.10.2",
-        "ramp-storylines_demo-scenarios-pcar": "^3.4.1",
+        "ramp-storylines_demo-scenarios-pcar": "^3.5.1",
         "throttle-debounce": "^5.0.0",
         "url": "^0.11.3",
         "uuid": "^9.0.0",

--- a/src/style.css
+++ b/src/style.css
@@ -10,3 +10,7 @@
 .tippy-box[data-animation='chapter-menu'][data-placement^='right'] > .tippy-backdrop {
     transform-origin: 50% 0 !important;
 }
+
+#wb-cont code {
+    color: #c7254e !important;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -60,6 +60,20 @@ module.exports = {
                             '&:active': {
                                 color: 'blue'
                             }
+                        },
+                        code: {
+                            margin: '0',
+                            padding: '0.2em 0.4em',
+                            borderRadius: '3px',
+                            fontWeight: '100',
+                            fontSize: '85%',
+                            backgroundColor: '#edeff0'
+                        },
+                        'code::before': {
+                            content: '""'
+                        },
+                        'code::after': {
+                            content: '""'
                         }
                     }
                 },


### PR DESCRIPTION
### Related Item(s)
Issue #548  

### Changes
- Updated storyline layout to properly handle whitespace (respects single line breaks while rendering multiple spaces and line breaks consistently).
- Removed markdown backticks from showing on storyline preview. 

### Testing
Steps:
1. In the main editor, create a new slide with the text content type.
2. Enter multiline text and include some text using backticks (e.g., \`text`).
4. Open the storyline preview.
5. The text pane preview and storyline preview should now have the same format/convention.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/633)
<!-- Reviewable:end -->
