### PR TITLE
Add mobile menu to preview

### DIFF
--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -11,13 +11,25 @@
             <div class="storyramp-app bg-white" v-if="config !== undefined">
                 <header
                     id="story-header"
-                    class="story-header sticky top-0 flex border-b border-black bg-gray-200 py-2 px-2 justify-between"
+                    class="story-header sticky top-0 flex border-b border-black bg-gray-200 py-2 justify-between h-16"
                 >
+                    <storylines-mobile-toc
+                        class="mobile-menu"
+                        :active-chapter-index="activeChapterIndex"
+                        :return-to-top="config.returnTop ?? true"
+                        :plugin="true"
+                        :customToc="config.tableOfContents"
+                        :lang="lang"
+                        :slides="config.slides"
+                    />
                     <div class="w-mobile-full truncate">
-                        <span class="font-semibold text-lg m-1">{{ config.title }}</span>
+                        <span class="font-semibold text-lg m-1 ml-2">{{ config.title }}</span>
                     </div>
 
-                    <button @click="changeLang" class="respected-standard-button respected-black-bg-button">
+                    <button
+                        @click="changeLang"
+                        class="respected-standard-button respected-black-bg-button max-h-[40px] mr-2"
+                    >
                         <span class="inline-block">{{
                             lang === 'en' ? $t('editor.lang.fr') : $t('editor.lang.en')
                         }}</span>
@@ -383,6 +395,12 @@ $font-list: 'Segoe UI', system-ui, ui-sans-serif, Tahoma, Geneva, Verdana, sans-
 @media screen and (max-width: 640px) {
     .w-mobile-full {
         width: 100% !important;
+    }
+}
+
+@media screen and (min-width: 641px) {
+    .mobile-menu {
+        display: none !important;
     }
 }
 </style>


### PR DESCRIPTION
### Related Item(s)
#626

### Changes
- Add mobile toc to the preview 

### Testing
Steps:
1. Load in a product
2. Open the preview
3. Decrease screen width to 640px
4. Ensure that the mobile toc button appears in top left
5. Click it and ensure that the mobile toc opens and works correctly
6. Increase screen width and ensure that the mobile toc closes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/634)
<!-- Reviewable:end -->
