### PR TITLE
Ensure only one preview gets BroadcastChannel

### DIFF
--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -111,12 +111,23 @@ export default class StoryPreviewV extends Vue {
     lockStore = useLockStore();
     confirmationTimeout: NodeJS.Timeout | undefined = undefined; // the timer to show the session extension confirmation modal
     totalTime = import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_END) : 30;
+    localStorageKey = 'preview-broadcast-channel';
 
     extendSession(showPopup?: boolean): void {
         // Only send message to other BroadcastChannel if preview is connected to editor
         if (!this.savedProduct) {
             this.broadcast?.postMessage({ action: 'extend', showPopup });
         }
+    }
+
+    removeLocalStorageKey() {
+        localStorage.removeItem(this.localStorageKey);
+    }
+
+    beforeCreate() {
+        // When new tab is created, and another preview tab already has a BC, this will trigger its event listener, which
+        // closes its BC. If no other preview with a BC exists, this will do nothing
+        localStorage.removeItem(this.localStorageKey);
     }
 
     async mounted() {
@@ -131,6 +142,8 @@ export default class StoryPreviewV extends Vue {
             this.configFileStructure = window.props.configFileStructure;
             // This broadcast channel will be used to communicate regarding sessions with the main editor tab
             this.broadcast = new BroadcastChannel(window.props.secret);
+            localStorage.setItem(this.localStorageKey, true);
+
             this.broadcast.onmessage = (e) => {
                 const msg = e.data;
                 if (msg.action === 'confirm') {
@@ -191,6 +204,14 @@ export default class StoryPreviewV extends Vue {
                 this.addStylesheets(this.config.stylesheets);
             }
             this.loadStatus = 'loaded';
+            window.addEventListener('beforeunload', this.removeLocalStorageKey);
+            window.addEventListener('storage', (event) => {
+                if (event.key === this.localStorageKey) {
+                    this.broadcast?.close();
+                    document.onmousemove = () => undefined;
+                    document.onkeydown = () => undefined;
+                }
+            });
         } else {
             this.savedProduct = true;
             const userStore = useUserStore();
@@ -283,6 +304,10 @@ export default class StoryPreviewV extends Vue {
         const html = document.documentElement;
         html.setAttribute('lang', this.lang);
         this.$i18n.locale = this.lang;
+    }
+
+    beforeDestroy() {
+        window.removeEventListener('beforeunload', this.removeLocalStorageKey);
     }
 
     addStylesheets(paths: string[]): void {


### PR DESCRIPTION
### Related Item(s)
#622

### Changes
- Ensure that only the first preview tab opened gets a BroadcastChannel, and any additional previews are treated as independent from the editor

### Testing
Steps:
1. Load in a product
2. Open its preview tab
3. Within the preview tab, open dev tools and notice that a BroadcastChannel has been create
4. Move the mouse around the screen a bit
5. Within the editor tab, open dev tools and notice that the messages are received by the lock stores BroadcastChannel
6. Now open a new preview tab 
7. Within the second preview tab, open dev tools and notice a BroadcastChannel was not created
8. Move the mouse around the screen a bit
9. Within the editor tab, notice that no new messages were received
10. Within the first preview tab, notice there are no session extended toast messages

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/635)
<!-- Reviewable:end -->
