### PR TITLE
Ensure currentSlide exists before setting slide options

### DIFF
--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -586,17 +586,19 @@ export default class SlideEditorV extends Vue {
 
     @Watch('currentSlide', { deep: true })
     onSlideChange(): void {
-        this.onePanelOnly = this.currentSlide?.panel.length === 1;
-        this.langTranslate = this.$t(`editor.lang.${this.lang}`);
-        this.centerPanel = this.currentSlide.panel[0]?.cssClasses?.includes('centerPanel') ?? false;
-        this.centerSlide =
-            (this.onePanelOnly
-                ? this.determineEditorType(this.currentSlide.panel[0]) === 'dynamic'
-                    ? this.currentSlide.panel[0]?.cssClasses?.includes('centerSlideRight')
-                    : this.currentSlide.panel[0]?.cssClasses?.includes('centerSlideFull')
-                : this.currentSlide.panel[0]?.cssClasses?.includes('centerSlideRight') &&
-                  this.currentSlide.panel[1]?.cssClasses?.includes('centerSlideLeft')) ?? false;
-        this.includeInToc = this.currentSlide.includeInToc ?? true;
+        if (this.currentSlide) {
+            this.onePanelOnly = this.currentSlide.panel.length === 1;
+            this.langTranslate = this.$t(`editor.lang.${this.lang}`);
+            this.centerPanel = this.currentSlide.panel[0]?.cssClasses?.includes('centerPanel') ?? false;
+            this.centerSlide =
+                (this.onePanelOnly
+                    ? this.determineEditorType(this.currentSlide.panel[0]) === 'dynamic'
+                        ? this.currentSlide.panel[0]?.cssClasses?.includes('centerSlideRight')
+                        : this.currentSlide.panel[0]?.cssClasses?.includes('centerSlideFull')
+                    : this.currentSlide.panel[0]?.cssClasses?.includes('centerSlideRight') &&
+                      this.currentSlide.panel[1]?.cssClasses?.includes('centerSlideLeft')) ?? false;
+            this.includeInToc = this.currentSlide.includeInToc ?? true;
+        }
     }
 
     /**

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -692,7 +692,7 @@ export default class SlideTocV extends Vue {
     resizeMobile(): void {
         let overlayElement = document.getElementById('overlay');
         let sidebarElement = document.getElementById('sidebar-mobile');
-        
+
         if (overlayElement.style.display != 'none' && window.innerWidth >= 768) {
             overlayElement.style.display = 'none';
         } else if (sidebarElement.style.width === '20rem' && window.innerWidth < 768) {
@@ -706,7 +706,6 @@ export default class SlideTocV extends Vue {
     beforeDestroy() {
         window.removeEventListener('resize', this.resizeMobile);
     }
-    
 }
 
 // More accurate page height for mobile
@@ -720,7 +719,6 @@ window.addEventListener('resize', () => {
     let vh = window.innerHeight * 0.01;
     document.documentElement.style.setProperty('--vh', `${vh}px`);
 });
-
 </script>
 
 <style lang="scss" scoped>
@@ -742,7 +740,7 @@ window.addEventListener('resize', () => {
 }
 
 .toc-slide {
-  cursor: grab;
+    cursor: grab;
 }
 
 .toc-slide-button {


### PR DESCRIPTION
### Related Item(s)
#631

### Changes
- Ensure that `currentSlide` exists before attempting to set slide/panel options
  - Upon deleting the current slide, `currentSlide` is set to `''`, so we need to ensure we don't attempt to access anything within `currentSlide`

### Testing
Steps:
1. Load product into `editor-main`
2. Create a new slide 
3. Access one of its panels
4. Now delete that slide
5. Ensure that there are no console errors, and that the 'Please select a slide to edit' text appears where the slide editor would be

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/636)
<!-- Reviewable:end -->
