### PR TITLE
Prevent fullscreen panel toggle causing fatal error

### DIFF
--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -476,7 +476,7 @@
             :title="$t('editor.slides.changeToOnePanel.title')"
             :message="$t('editor.slides.changeToOnePanel.message')"
             @ok="toggleOnePanelOnly()"
-            @Cancel="onePanelOnly = !onePanelOnly"
+            @Cancel="onePanelOnly = false"
         />
         <multi-option-modal
             :name="`one-to-two-panels-${slideIndex}`"
@@ -486,7 +486,7 @@
                 { label: $t('editor.slides.addBlankPanel.left'), action: () => toggleOnePanelOnly('left') },
                 { label: $t('editor.slides.addBlankPanel.right'), action: () => toggleOnePanelOnly('right') }
             ]"
-            @cancel="onePanelOnly = !onePanelOnly"
+            @cancel="onePanelOnly = true"
             :cancelAllowed="true"
         />
     </div>


### PR DESCRIPTION
### Related Item(s)
Issue #625 

### Changes
- Fixes an error where selecting `Make this panel the full slide`, then selecting `cancel` in the pop-up, causes a fatal error and/or data loss.

### Notes
I was unable to reproduce the exact problem in the issue (clicking `continue` causes the fatal error), but this fix _should_ theoretically work for it. @spencerwahl please let me know if the issue is fixed on your end.

### Testing
Steps:
1. Create a new slide.
2. Change the panel type to video. Upload a YouTube link.
3. Press  `Make this panel the full slide`, then either `Continue` or `Cancel`. 
4. Your choice should be respected; the `Make this panel the full slide` checkbox should show the option you chose and your video should remain as it was.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/638)
<!-- Reviewable:end -->
