### PR TITLE
Added hour and minute to last modified timestamp

### DIFF
--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -285,7 +285,11 @@
                     >
                         <div class="m-2 mt-4 ml-3">{{ $t('editor.uuid') }}: {{ storyline.uuid }}</div>
                         <div class="m-2 mb-4 ml-3">
-                            {{ $t('editor.previousProducts.productInfo.title') + ': ' + storyline.titleEN }}
+                            {{
+                                $t('editor.previousProducts.productInfo.title') +
+                                ': ' +
+                                (currLang === 'en' ? storyline.titleEN : storyline.titleFR)
+                            }}
                         </div>
                     </td>
                     <td
@@ -426,10 +430,13 @@ export default class HomeV extends Vue {
                 this.$t('editor.month.november'),
                 this.$t('editor.month.december')
             ];
+            const hour = d.getHours().toString().padStart(2, '0');
+            const minute = d.getMinutes().toString().padStart(2, '0');
+
             if (this.currLang === 'en') {
-                return months[d.getMonth()] + ' ' + d.getDate() + ', ' + d.getFullYear();
+                return months[d.getMonth()] + ' ' + d.getDate() + ', ' + d.getFullYear() + ' ' + hour + ':' + minute;
             } else {
-                return d.getDate() + ' ' + months[d.getMonth()] + ' ' + d.getFullYear();
+                return d.getDate() + ' ' + months[d.getMonth()] + ' ' + d.getFullYear() + ' ' + hour + ':' + minute;
             }
         }
     }


### PR DESCRIPTION
### Related Item(s)
Issue #547 

### Changes
- Added the hour and minute details to the last modified timestamp for `Previously Edited Products` on the dashboard.
- Also noticed that storyline titles on dashboard weren't updating when switching language to French, so I added a check in `home.vue`. 

### Notes
- Since testing is done while signed in as a guest without access to the API database, I mocked the storyline data in `userStore` to simulate the API response.

### Testing
Steps:
1. On homepage, the dashboard should contain two mock storylines with dates and timestamps.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/640)
<!-- Reviewable:end -->
