### PR TITLE
Made edit/remove buttons tabbable in dynamic editor

### DIFF
--- a/src/components/dynamic-editor.vue
+++ b/src/components/dynamic-editor.vue
@@ -38,8 +38,8 @@
                     <td>{{ item.id }}</td>
                     <td>{{ determineEditorType(item.panel) }}</td>
                     <td>
-                        <span @click="() => switchSlide(idx)">{{ $t('editor.chart.label.edit') }}</span> |
-                        <span @click="$vfm.open(`delete-item-${idx}`)">{{ $t('editor.remove') }}</span>
+                        <button @click="() => switchSlide(idx)">{{ $t('editor.chart.label.edit') }}</button> |
+                        <button @click="$vfm.open(`delete-item-${idx}`)">{{ $t('editor.remove') }}</button>
                     </td>
 
                     <confirmation-modal


### PR DESCRIPTION
### Related Item(s)
Issue #524 

### Changes
- The `Edit|Remove` button in the `Panel Collection` tab is now accessible from keyboard. 

### Testing
Steps:
1. Create a dynamic slide.
2. In the `Panel Collection` tab, add a new panel.
3. Should now be able to access the Edit|Remove buttons by tabbing. 
