### PR TITLE
Fix non-highcharts WAVE errors

### DIFF
--- a/src/components/helpers/custom-editor.vue
+++ b/src/components/helpers/custom-editor.vue
@@ -94,6 +94,14 @@ export default class CustomEditorV extends Vue {
             this.updatedConfig = this.config;
             this.validate();
         });
+
+        // selects the <textarea> inside json-editor and add label attribute dynamically
+        this.$nextTick(() => {
+            const textarea = this.$el.querySelector('textarea.jsoneditor-text');
+            if (textarea) {
+                textarea.setAttribute('aria-label', this.$t('editor.slides.advanced.editor'));
+            }
+        });
     }
 
     // returns true if no validation errors, false if errors
@@ -137,5 +145,22 @@ export default class CustomEditorV extends Vue {
 <style lang="scss" scoped>
 :deep(.jsoneditor-vue) {
     height: 100vh;
+}
+
+:deep(div.jsoneditor) {
+    border-color: #0657db;
+}
+
+:deep(.jsoneditor-menu) {
+    background-color: #0657db;
+}
+
+:deep(div.jsoneditor-contextmenu ul li button) {
+    color: #cdddf8;
+}
+
+:deep(button.jsoneditor-selected) {
+    color: #383838 !important;
+    background-color: #ffffff !important;
 }
 </style>

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -30,6 +30,7 @@
             <!-- Close ToC sidebar button -->
             <button
                 v-if="isMobileSidebar"
+                :aria-label="$t(`editor.slides.toc.closeToC`)"
                 class="respected-standard-button respected-gray-border-button"
                 @click="$emit('close-sidebar')"
             >

--- a/src/components/text-editor.vue
+++ b/src/components/text-editor.vue
@@ -407,6 +407,14 @@ export default class TextEditorV extends Vue {
         });
 
         this.makeTextEditorElementsTabbable();
+
+        // selects the <textarea> and adds label attribute dynamically
+        this.$nextTick(() => {
+            const textarea = this.$el.querySelector('.CodeMirror textarea');
+            if (textarea) {
+                textarea.setAttribute('aria-label', this.$t('editor.slides.panel.textEntry'));
+            }
+        });
     }
 
     unmounted(): void {
@@ -478,5 +486,13 @@ label {
 
 :deep(.v-md-editor-preview) {
     position: relative;
+}
+
+:deep(.CodeMirror-linenumber) {
+    color: #383838;
+}
+
+:deep(.cm-header) {
+    color: blue !important;
 }
 </style>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -255,6 +255,7 @@ editor.slides.copyAll,Copy all,1,Copier tout,1
 editor.slides.copyAll.confirm,Are you sure you want to copy all slides?,1,Êtes-vous sûr de vouloir copier toutes les diapositives ?,0
 editor.slides.copy,Copy,1,Copier,1
 editor.slides.slide,Slide,1,Diapositive,1
+editor.slides.toc.closeToC,Close table of content sidebar,1,Fermer la barre latérale de la table des matières,0
 editor.slides.toc.noSlides,No Slides,1,Pas de diapositives,0
 editor.slides.toc.selectNewSlideMessage,Select 'New Blank Slide' to add your first slide.,1,Sélectionnez « Nouvelle diapositive vierge » pour ajouter votre première diapositive.,0
 editor.slides.toc.dropdownTooltip,Options,1,Options,0
@@ -288,6 +289,7 @@ editor.slides.fullscreenPanel,Fullscreen panel,1,Panneau plein écran,1
 editor.slides.slideTitle,Slide title,1,Titre de la diapositive,0
 editor.slides.addSlideTitle,Add a title,1,Ajoutez un titre,0
 editor.slides.advanced,Advanced,1,Avancé,0
+editor.slides.advanced.editor,JSON configuration editor,1,Éditeur de configuration JSON,0
 editor.slides.advanced.good,Configuration adheres to Storylines schema.,1,La configuration adhère au schéma Storylines.,0
 editor.slides.advanced.broken,This configuration violates the Storylines schema.,1,Cette configuration viole le schéma Storylines.,0
 editor.slides.advanced.details,Click here for more details.,1,Cliquez ici pour plus de détails.,0
@@ -300,6 +302,7 @@ editor.slides.select,Please select a slide to edit,1,Veuillez sélectionner une 
 editor.slides.panelNumber,Panel {num},1,Panneau {num},0
 editor.slides.panel.body,Panel body,1,Corps du panneau,1
 editor.slides.panel.title,Panel title,1,Titre du panneau,1
+editor.slides.panel.textEntry,Panel text entry,1,Saisie de texte du panneau,0
 editor.slide.panel.type.text,Text,1,Texte,1
 editor.slide.panel.type.image,Image,1,Image,1
 editor.slide.panel.type.slideshow,Slideshow,1,Diaporama,1


### PR DESCRIPTION
### Related Item(s)
Issue #567 

### Changes
- Added an accessible label to the button next to the `Edit Project Metadata` button.
- Adjusted header shade in the `Advanced` slide editor to fix colour contrast error.
- Added labels to `<textarea>` elements in both the text panel editor and the `Advanced` slide editor.

### Testing
Steps:
1. In main editor, add a slide.
2. WAVE the page, and non-highcharts WAVE errors should be resolved.
3. Reload and navigate to the `Advanced` tab.
4. WAVE the page again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/651)
<!-- Reviewable:end -->
