### PR TITLE
refactor: centralize commonly used variables, methods in Pinia store

### DIFF
--- a/src/components/dynamic-editor.vue
+++ b/src/components/dynamic-editor.vue
@@ -19,13 +19,7 @@
         </div>
         <!-- Text Section -->
         <div v-if="editingStatus === 'text'">
-            <component
-                :is="'text-editor'"
-                key="text"
-                :panel="panel"
-                :configFileStructure="configFileStructure"
-                :lang="lang"
-            ></component>
+            <component :is="'text-editor'" key="text" :panel="panel" :lang="lang"></component>
         </div>
         <div v-if="editingStatus === 'panels'">
             <table class="w-2/3 mt-5">
@@ -45,7 +39,7 @@
                     <confirmation-modal
                         :name="`delete-item-${idx}`"
                         :message="$t('dynamic.panel.remove')"
-                        @ok="() => removeSlide(item as any, idx)"
+                        @ok="() => removeSlide(item.panel as any, idx)"
                     />
                 </tr>
                 <tr class="table-add-row">
@@ -86,15 +80,10 @@
                     :is="editors[determineEditorType(panel.children[editingSlide].panel)]"
                     :key="editingSlide + determineEditorType(panel.children[editingSlide].panel)"
                     :panel="panel.children[editingSlide].panel"
-                    :configFileStructure="configFileStructure"
                     :lang="lang"
-                    :sourceCounts="sourceCounts"
                     :centerSlide="centerSlide"
                     :dynamicSelected="dynamicSelected"
                     @slide-edit="$emit('slide-edit', 'Dynamic editor')"
-                    @shared-asset="(oppositeAssetPath: string, sharedAssetPath: string, oppositeLang: string) => {
-                        $emit('shared-asset', oppositeAssetPath, sharedAssetPath, oppositeLang);
-                    }"
                 ></component>
             </div>
         </div>
@@ -106,18 +95,10 @@ import { Options, Prop, Vue } from 'vue-property-decorator';
 import {
     BasePanel,
     BaseStartingConfig,
-    ChartPanel,
-    ConfigFileStructure,
     DefaultConfigs,
     DynamicChildItem,
     DynamicPanel,
-    ImagePanel,
-    MapPanel,
-    PanelType,
-    SlideshowPanel,
-    SourceCounts,
-    TextPanel,
-    VideoPanel
+    PanelType
 } from '@/definitions';
 
 import ChartEditorV from './chart-editor.vue';
@@ -127,6 +108,7 @@ import MapEditorV from './map-editor.vue';
 import VideoEditorV from './video-editor.vue';
 import SlideshowEditorV from './slideshow-editor.vue';
 import ConfirmationModalV from './helpers/confirmation-modal.vue';
+import { useProductStore } from '@/stores/productStore';
 
 @Options({
     components: {
@@ -142,11 +124,11 @@ import ConfirmationModalV from './helpers/confirmation-modal.vue';
 })
 export default class DynamicEditorV extends Vue {
     @Prop() panel!: DynamicPanel;
-    @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
-    @Prop() sourceCounts!: SourceCounts;
     @Prop() centerSlide!: boolean;
     @Prop() dynamicSelected!: boolean;
+
+    productStore = useProductStore();
 
     editors: Record<string, string> = {
         text: 'text-editor',
@@ -184,58 +166,7 @@ export default class DynamicEditorV extends Vue {
 
     removeSlide(panel: BasePanel, index?: number): void {
         // Update source counts based on which panel is removed.
-        switch (panel?.type) {
-            case 'map': {
-                const mapPanel = panel as MapPanel;
-                this.sourceCounts[mapPanel.config] -= 1;
-                if (this.sourceCounts[mapPanel.config] === 0) {
-                    this.configFileStructure.zip.remove(
-                        `${mapPanel.config.substring(mapPanel.config.indexOf('/') + 1)}`
-                    );
-                }
-                break;
-            }
-
-            case 'chart': {
-                const chartPanel = panel as ChartPanel;
-                this.sourceCounts[chartPanel.src] -= 1;
-                if (this.sourceCounts[chartPanel.src] === 0) {
-                    this.configFileStructure.zip.remove(`${chartPanel.src.substring(chartPanel.src.indexOf('/') + 1)}`);
-                }
-                break;
-            }
-
-            case 'image': {
-                const imagePanel = panel as ImagePanel;
-
-                this.sourceCounts[imagePanel.src] -= 1;
-                if (this.sourceCounts[imagePanel.src] === 0) {
-                    this.configFileStructure.zip.remove(`${imagePanel.src.substring(imagePanel.src.indexOf('/') + 1)}`);
-                }
-                break;
-            }
-
-            case 'slideshow': {
-                const slideshowPanel = panel as SlideshowPanel;
-                slideshowPanel.items.forEach((item: TextPanel | ImagePanel | MapPanel | ChartPanel) => {
-                    this.removeSlide(item);
-                });
-                break;
-            }
-
-            case 'video': {
-                const videoPanel = panel as VideoPanel;
-                if (videoPanel.videoType === 'local') {
-                    this.sourceCounts[videoPanel.src] -= 1;
-                    if (this.sourceCounts[videoPanel.src] === 0) {
-                        this.configFileStructure.zip.remove(
-                            `${videoPanel.src.substring(videoPanel.src.indexOf('/') + 1)}`
-                        );
-                    }
-                }
-                break;
-            }
-        }
+        this.productStore.removeSourceCounts(panel);
 
         if (index !== undefined) {
             // Remove the panel itself.

--- a/src/components/helpers/chart-preview.vue
+++ b/src/components/helpers/chart-preview.vue
@@ -30,7 +30,7 @@
                 class="w-full h-full"
                 :config="chartConfig"
                 :key="chartIdx"
-                :configFileStructure="configFileStructure"
+                :configFileStructure="productStore.configFileStructure"
                 @loaded="loadChart"
                 v-if="!loading"
             ></storylines-chart>
@@ -78,15 +78,9 @@
 
 <script lang="ts">
 import { Prop, Vue } from 'vue-property-decorator';
-import {
-    ChartConfig,
-    ConfigFileStructure,
-    DQVChartConfig,
-    LineSeriesData,
-    PieDataRow,
-    PieSeriesData,
-    SourceCounts
-} from '@/definitions';
+import { ChartConfig, DQVChartConfig, LineSeriesData, PieDataRow, PieSeriesData } from '@/definitions';
+
+import { useProductStore } from '@/stores/productStore';
 
 import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
@@ -99,10 +93,10 @@ exportData(Highcharts);
 
 export default class ChartPreviewV extends Vue {
     @Prop() chart!: ChartConfig;
-    @Prop() configFileStructure!: ConfigFileStructure;
-    @Prop() sourceCounts!: SourceCounts;
     @Prop() lang!: string;
     @Prop() index!: number;
+
+    productStore = useProductStore();
 
     loading = true;
     chartIdx = 0;
@@ -137,10 +131,10 @@ export default class ChartPreviewV extends Vue {
             },
             (newChart: string) => {
                 const chart = JSON.parse(newChart);
-                const newName = `${this.configFileStructure.uuid}/charts/${this.lang}/${chart.title.text}.json`;
+                const newName = `${this.productStore.configFileStructure.uuid}/charts/${this.lang}/${chart.title.text}.json`;
 
                 // Check to see if a chart already exists with the provided name. If so, alert the user and re-prompt.
-                if (this.sourceCounts[newName] > 0 && chart.title.text != this.chart.name) {
+                if (this.productStore.sourceExists(newName) && chart.title.text != this.chart.name) {
                     alert(
                         this.$t('editor.chart.label.nameExists', {
                             name: chart.title.text

--- a/src/components/image-editor.vue
+++ b/src/components/image-editor.vue
@@ -148,20 +148,11 @@
 </template>
 
 <script lang="ts">
-import {
-    BaseStartingConfig,
-    ConfigFileStructure,
-    ImageFile,
-    ImagePanel,
-    PanelType,
-    SlideshowPanel,
-    SourceCounts
-} from '@/definitions';
 import { Options, Prop, Vue } from 'vue-property-decorator';
+import { ImageFile, ImagePanel, PanelType } from '@/definitions';
 import draggable from 'vuedraggable';
 import ImagePreviewV from './helpers/image-preview.vue';
-import JSZip from 'jszip';
-import Message from 'vue-m-message';
+import { useProductStore } from '@/stores/productStore';
 
 @Options({
     components: {
@@ -171,12 +162,12 @@ import Message from 'vue-m-message';
 })
 export default class ImageEditorV extends Vue {
     @Prop() panel!: ImagePanel | SlideshowImagePanel;
-    @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
-    @Prop() sourceCounts!: SourceCounts;
     @Prop({ default: true }) allowMany!: boolean;
     @Prop({ default: false }) centerSlide!: boolean;
     @Prop({ default: false }) dynamicSelected!: boolean;
+
+    productStore = useProductStore();
 
     dragging = false;
     edited = false;
@@ -218,7 +209,7 @@ export default class ImageEditorV extends Vue {
                 // Check if the config file exists in the ZIP folder first.
                 const assetSrc = `${image.src.substring(image.src.indexOf('/') + 1)}`;
                 const filename = image.src.replace(/^.*[\\/]/, '');
-                const compressedAssetFile = this.configFileStructure.zip.file(assetSrc);
+                const compressedAssetFile = this.productStore.configFileStructure.zip.file(assetSrc);
                 const assetType = assetSrc.split('.').at(-1);
 
                 if (compressedAssetFile) {
@@ -248,193 +239,8 @@ export default class ImageEditorV extends Vue {
         }
     }
 
-    // TODO: move method into a plugin. That way it isn't repeated in the metadata/video editors
-    // Converts a file into a promise that resolves to an ArrayBuffer containing the files data
-    readBinaryData(file: File): Promise<ArrayBuffer> {
-        return new Promise((resolve, reject) => {
-            const fileReader = new FileReader();
-            fileReader.onload = () => {
-                resolve(fileReader.result);
-            };
-            fileReader.onerror = () => {
-                reject(new Error('Could not load file reader'));
-            };
-            fileReader.readAsArrayBuffer(file);
-        });
-    }
-
-    // TODO: move method into a plugin. That way it isn't repeated in the metadata/video editors
-    // Converts a file into a promise that resolves to its hash, as an array of 8-bit integers
-    obtainHashData(file: File): Promise<Uint8Array> {
-        return this.readBinaryData(file)
-            .then((res) => {
-                res = new Uint8Array(res);
-                return window.crypto.subtle.digest('SHA-256', res);
-            })
-            .then((res) => {
-                res = new Uint8Array(res);
-                return res;
-            });
-    }
-
-    // TODO: move method into a plugin. That way it isn't repeated in the metadata/video editors
-    /**
-     * Helper used to find all instances of the specified file in the specified asset folder
-     * @param file File that was uploaded
-     * @param folder The asset folder withinn which we should be searching
-     * @param checkNested Flag that indicates whether we should consider assets with nested subfolders
-     */
-    filesInAssetFolder(file: File, folder: string, checkNested = true): Array<Promise<string>> {
-        // Here, if a file in the specified folder has the same name and hash as the file uploaded, then we consider the
-        // two to be the same. Otherwise, we consider them to be different. We even consider if the asset is within a
-        // subfolder of the specified folder, so long as the name and hash of the file is the same. There may be more than one
-        // instance of the specified asset in the specified folder, albeit in seperate subfolders, hence why we collect
-        // an array of duplicate asset promises
-        const sharedAssetPromises = [];
-        this.configFileStructure.assets[folder].forEach((relativePath, compressedBinary) => {
-            const assetName = checkNested ? relativePath.split('/').at(-1) : relativePath;
-
-            // Only compare the hashes of two files when they have the exact same name
-            if (assetName === file.name) {
-                sharedAssetPromises.push(
-                    this.compareFiles(file, compressedBinary, assetName).then((fileSame) =>
-                        fileSame ? relativePath : 'N/A'
-                    )
-                );
-            }
-        });
-
-        return sharedAssetPromises;
-    }
-
-    // TODO: move method into a plugin. That way it isn't repeated in the metadata/video editors
-    /**
-     * Compares the hashes of two files
-     * @param file File that was uploaded
-     * @param compressedBinary Compressed binary file from configFileStructure
-     * @param compressedName The name of the compressed binary file
-     */
-    async compareFiles(file: File, compressedBinary: JSZip.JSZipObject, compressedName: string): Promise<boolean> {
-        const fileHash = await this.obtainHashData(file);
-        const compressedType = compressedName.split('.').at(-1);
-
-        return compressedBinary
-            .async(compressedType !== 'svg' ? 'blob' : 'text')
-            .then((assetFile) => {
-                if (compressedType === 'svg') {
-                    assetFile = new File([assetFile], compressedName, {
-                        type: 'image/svg+xml'
-                    });
-                }
-                return this.obtainHashData(assetFile);
-            })
-            .then((hash) => {
-                return hash.join() === fileHash.join();
-            });
-    }
-
-    // TODO: move method into a plugin. That way it isn't repeated in the metadata/video editors
-    // Helper for onFileChange and dropImages. Maps a File object to an ImageFile object
     async addUploadedFile(file: File): Promise<ImageFile> {
-        const oppositeLang = this.lang === 'en' ? 'fr' : 'en';
-        const sharedAssetPaths = await Promise.all(this.filesInAssetFolder(file, 'shared', false));
-        let inSharedAsset = false;
-        let oppositeSourceCount = 0;
-        let newAssetName = file.name;
-        let uploadSource = `${this.configFileStructure.uuid}/assets/shared/${file.name}`;
-
-        // Should contain either 0 or 1 promise.
-        sharedAssetPaths.forEach((sharedAssetPath) => {
-            inSharedAsset = sharedAssetPath !== 'N/A';
-        });
-
-        // If the asset is already in the shared asset folder, we do not need to do anything. We can assume that it
-        // does not exist in the opposite lang's asset folder (i.e. we assume shared asset system is working correctly)
-        if (!inSharedAsset) {
-            const oppositeAssetPaths = await Promise.all(this.filesInAssetFolder(file, oppositeLang));
-            // If the current promise contains 'N/A', then the current path refers to an asset in the opposite asset
-            // folder that has the same name, but different contents, as the asset uploaded. In this case we do
-            // nothing, as this asset is not a valid duplicate.
-            for (const oppositeAssetPath of oppositeAssetPaths) {
-                if (oppositeAssetPath !== 'N/A') {
-                    const oppositeFileSource = `${this.configFileStructure.uuid}/assets/${oppositeLang}/${oppositeAssetPath}`;
-                    oppositeSourceCount += this.sourceCounts[oppositeFileSource] ?? 0;
-                    this.sourceCounts[oppositeFileSource] = 0;
-                    this.configFileStructure.assets[oppositeLang].remove(oppositeAssetPath);
-
-                    // Add asset to shared folder if asset is yet to be moved to the shared folder. If an asset with the
-                    // same name, but different content, is already in the shared folder, we must give the asset we are
-                    // uploading a unique name. Otherwise the existing asset will be overwritten
-                    if (!inSharedAsset) {
-                        let i = 2;
-                        while (this.configFileStructure.assets['shared'].file(newAssetName)) {
-                            // If the updated name is the same as a file that already exists in the shared asset folder,
-                            // we must compare that file with the uploaded file, since they wouldnt have been compared
-                            // on the first run due to having different names (Such an asset COULD also be in the shared
-                            // or opposite lang asset folder, since a new name is now being used. However we shouldn't
-                            // execute this entire method again just for an edge case like a name change, so we can
-                            // leave this as is for now)
-                            if (i > 2) {
-                                const filesEqual = await this.compareFiles(
-                                    file,
-                                    this.configFileStructure.assets['shared'].file(newAssetName),
-                                    newAssetName
-                                );
-                                if (filesEqual) break;
-                            }
-                            newAssetName = `${file.name.split('.').at(0)}(${i}).${file.name.split('.').at(-1)}`;
-                            i++;
-                        }
-                        uploadSource = `${this.configFileStructure.uuid}/assets/shared/${newAssetName}`;
-                        this.configFileStructure.assets['shared'].file(newAssetName, file);
-                        inSharedAsset = true;
-                    }
-                    this.$emit('shared-asset', oppositeFileSource, uploadSource, oppositeLang); // must be emitted for each duplicate asset
-                }
-            }
-        }
-
-        // If the asset uploaded is in the shared asset folder, then no need to upload to the current langs assets folder
-        if (!inSharedAsset) {
-            const currAssetPaths = await Promise.all(this.filesInAssetFolder(file, this.lang, false));
-            // Should contain either 0 or 1 promise.
-            // Need to use await here
-            for (const currAssetPath of currAssetPaths) {
-                // If asset w/ same name but different contents is in curr lang asset folder, set name in curr lang
-                // asset folder to a unique name, to avoid overwriting an existing file.
-                if (currAssetPath === 'N/A') {
-                    let i = 2;
-                    while (this.configFileStructure.assets[this.lang].file(newAssetName)) {
-                        // If the updated name is the same as a file that already exists in the current langs asset folder,
-                        // we must compare that file with the uploaded file, since they wouldnt have been compared
-                        // on the first run due to having different names
-                        if (i > 2) {
-                            const filesEqual = await this.compareFiles(
-                                file,
-                                this.configFileStructure.assets[this.lang].file(newAssetName),
-                                newAssetName
-                            );
-                            if (filesEqual) break;
-                        }
-                        newAssetName = `${file.name.split('.').at(0)}(${i}).${file.name.split('.').at(-1)}`;
-                        i++;
-                    }
-                }
-            }
-            uploadSource = `${this.configFileStructure.uuid}/assets/${this.lang}/${newAssetName}`;
-            this.configFileStructure.assets[this.lang].file(newAssetName, file);
-        }
-
-        // Notify user of the change in the name of their uploaded asset, to avoid any confusion
-        if (file.name !== newAssetName) {
-            Message.info(this.$t('editor.slides.assetNameChange', { oldName: file.name, newName: newAssetName }));
-        }
-
-        if (this.sourceCounts[uploadSource]) {
-            this.sourceCounts[uploadSource] += 1 + oppositeSourceCount;
-        } else {
-            this.sourceCounts[uploadSource] = 1 + oppositeSourceCount;
-        }
+        const { inSharedAsset, newAssetName, uploadSource } = await this.productStore.addUploadedFile(file);
 
         let imageSrc = URL.createObjectURL(file);
         return {
@@ -484,9 +290,9 @@ export default class ImageEditorV extends Vue {
             const assetRelativePath = this.imagePreviews[idx].id.split('/').slice(3).join('/');
 
             // Remove the image from the product ZIP file.
-            this.sourceCounts[assetSource] -= 1;
-            if (this.sourceCounts[assetSource] === 0) {
-                this.configFileStructure.assets[assetFolder].remove(assetRelativePath);
+            this.productStore.decrementSourceCount(assetSource);
+            if (!this.productStore.sourceExists(assetSource)) {
+                // Revote the object URL if the image has been fully removed.
                 URL.revokeObjectURL(this.imagePreviews[idx].src);
             }
             this.imagePreviews.splice(idx, 1);

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -423,9 +423,6 @@
                     @config-edited="(slideConfig: Slide, save?: boolean = false) => {
                         $emit('custom-slide-updated', slideConfig, save, lang)
                     }"
-                    @shared-asset="(oppositeAssetPath: string, sharedAssetPath: string, oppositeLang: string) => {
-                        $emit('shared-asset', oppositeAssetPath, sharedAssetPath, oppositeLang);
-                    }"
                     v-if="advancedEditorView"
                 ></custom-editor>
                 <component
@@ -433,15 +430,10 @@
                     :is="editors[determineEditorType(currentSlide.panel[panelIndex])]"
                     :key="panelIndex + determineEditorType(currentSlide.panel[panelIndex])"
                     :panel="currentSlide.panel[panelIndex]"
-                    :configFileStructure="configFileStructure"
                     :lang="lang"
                     :uid="uid"
-                    :sourceCounts="sourceCounts"
                     :centerSlide="centerSlide"
                     :dynamicSelected="dynamicSelected"
-                    @shared-asset="(oppositeAssetPath: string, sharedAssetPath: string, oppositeLang: string) => {
-                        $emit('shared-asset', oppositeAssetPath, sharedAssetPath, oppositeLang);
-                    }"
                     @slide-edit="$emit('slide-edit')"
                     v-else
                 ></component>
@@ -499,23 +491,13 @@ import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
 import {
     BasePanel,
     BaseStartingConfig,
-    ChartPanel,
-    ConfigFileStructure,
     DefaultConfigs,
-    DynamicChildItem,
-    DynamicPanel,
-    ImagePanel,
     MapPanel,
     PanelType,
     Slide,
-    SlideshowChartPanel,
-    SlideshowImagePanel,
-    SlideshowPanel,
-    SourceCounts,
     StoryRampConfig,
     SupportedLanguages,
-    TextPanel,
-    VideoPanel
+    TextPanel
 } from '@/definitions';
 
 import ChartEditorV from './chart-editor.vue';
@@ -529,6 +511,8 @@ import LoadingPageV from './helpers/loading-page.vue';
 import DynamicEditorV from './dynamic-editor.vue';
 import ConfirmationModalV from './helpers/confirmation-modal.vue';
 import { toRaw } from 'vue';
+
+import { useProductStore } from '@/stores/productStore';
 
 @Options({
     components: {
@@ -549,13 +533,13 @@ import { toRaw } from 'vue';
 export default class SlideEditorV extends Vue {
     config: StoryRampConfig | undefined = undefined;
     @Prop() currentSlide!: Slide;
-    @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
     @Prop() uid!: string;
     @Prop() slideIndex!: number;
     @Prop() isLast!: boolean;
-    @Prop() sourceCounts!: SourceCounts;
     @Prop() otherLangSlide!: Slide;
+
+    productStore = useProductStore();
 
     panelIndex = 0;
     advancedEditorView = false;
@@ -609,6 +593,7 @@ export default class SlideEditorV extends Vue {
     panelModified(panel: BasePanel): boolean {
         this.saveChanges(); // Used to capture unsaved changes before comparing with the corresponding default config
         const prevType = this.currentSlide.panel[this.panelIndex].type;
+        const uuid = this.productStore.configFileStructure.uuid;
 
         let startingConfig = {
             ...JSON.parse(JSON.stringify(BaseStartingConfig)),
@@ -627,9 +612,7 @@ export default class SlideEditorV extends Vue {
             },
             map: {
                 type: PanelType.Map,
-                config: `${this.configFileStructure.uuid}/ramp-config/${
-                    this.configFileStructure.uuid
-                }-map-${this.getNumberOfMaps()}.json`,
+                config: `${uuid}/ramp-config/${uuid}-map-${this.getNumberOfMaps()}.json`,
                 title: '',
                 scrollguard: false
             }
@@ -662,87 +645,16 @@ export default class SlideEditorV extends Vue {
         // When switching to a dynamic panel, remove the secondary panel.
         if (newType === 'dynamic') {
             // Remove source content of both panels
-            this.currentSlide.panel.forEach((panel: BasePanel) => this.removeSourceCounts(panel));
+            this.currentSlide.panel.forEach((panel: BasePanel) => this.productStore.removeSourceCounts(panel));
             this.panelIndex = 0;
             this.currentSlide['panel'] = [startingConfig[newType as keyof DefaultConfigs]];
             this.dynamicSelected = true;
         } else {
             // Remove source content of panel having its type swapped
-            this.removeSourceCounts(this.currentSlide.panel[this.panelIndex]);
+            this.productStore.removeSourceCounts(this.currentSlide.panel[this.panelIndex]);
 
             // Switching panel type when dynamic panels are not involved.
             this.currentSlide.panel[this.panelIndex] = startingConfig[newType as keyof DefaultConfigs];
-        }
-    }
-
-    removeSourceCounts(panel: BasePanel): void {
-        // The provided panel is being removed. Update source counts accordingly.
-        switch (panel.type) {
-            case 'map': {
-                const mapPanel = panel as MapPanel;
-                this.sourceCounts[mapPanel.config] -= 1;
-                if (this.sourceCounts[mapPanel.config] === 0) {
-                    this.configFileStructure.zip.remove(
-                        `${mapPanel.config.substring(mapPanel.config.indexOf('/') + 1)}`
-                    );
-                }
-                break;
-            }
-
-            case 'image': {
-                const imagePanel = panel as ImagePanel;
-                this.sourceCounts[imagePanel.src] -= 1;
-                if (this.sourceCounts[imagePanel.src] === 0) {
-                    this.configFileStructure.zip.remove(`${imagePanel.src.substring(imagePanel.src.indexOf('/') + 1)}`);
-                }
-
-                break;
-            }
-
-            case 'chart': {
-                const chartPanel = panel as ChartPanel;
-                this.sourceCounts[chartPanel.src] -= 1;
-                if (this.sourceCounts[chartPanel.src] === 0) {
-                    this.configFileStructure.zip.remove(`${chartPanel.src.substring(chartPanel.src.indexOf('/') + 1)}`);
-                }
-
-                break;
-            }
-
-            case 'slideshow':
-            case 'slideshowImage':
-            case 'slideshowChart': {
-                const slideshowPanel = panel as SlideshowPanel;
-                slideshowPanel.items.forEach((item: TextPanel | ImagePanel | MapPanel | ChartPanel) => {
-                    this.removeSourceCounts(item);
-                });
-                break;
-            }
-
-            case 'video': {
-                const videoPanel = panel as VideoPanel;
-                if (videoPanel.videoType === 'local') {
-                    this.sourceCounts[videoPanel.src] -= 1;
-                    if (this.sourceCounts[videoPanel.src] === 0) {
-                        this.configFileStructure.zip.remove(
-                            `${videoPanel.src.substring(videoPanel.src.indexOf('/') + 1)}`
-                        );
-                    }
-                }
-                break;
-            }
-
-            case 'dynamic': {
-                const dynamicPanel = panel as DynamicPanel;
-                dynamicPanel.children.forEach((subPanel: DynamicChildItem) => {
-                    this.removeSourceCounts(subPanel.panel);
-                });
-                break;
-            }
-
-            case 'text': {
-                break;
-            }
         }
     }
 
@@ -869,7 +781,7 @@ export default class SlideEditorV extends Vue {
 
     getNumberOfMaps(): number {
         let n = 0;
-        this.configFileStructure.rampConfig.forEach((f) => {
+        this.productStore.configFileStructure.rampConfig.forEach((f) => {
             n += 1;
         });
         return n;

--- a/src/components/slide-toc.vue
+++ b/src/components/slide-toc.vue
@@ -166,7 +166,7 @@
                                     <!-- ENG config for slide -->
                                     <slide-toc-button
                                         :element="element"
-                                        lang="en"
+                                        selectedLang="en"
                                         :currentSlide="currentSlide"
                                         :isMobileSidebar="isMobileSidebar"
                                         :isActiveSlide="slideIndex === index"
@@ -175,7 +175,7 @@
                                         @copyConfig="copyConfigFromOtherLang(index, 'en')"
                                         @copy="
                                             {
-                                                configEmpty(element, 'en')
+                                                configEmpty(index, 'en')
                                                     ? copyConfigFromOtherLang(index, 'en')
                                                     : $vfm.open(`copy-other-slide-${index}-en-config`);
                                             }
@@ -218,7 +218,7 @@
                                     <!-- FR config for slide -->
                                     <slide-toc-button
                                         :element="element"
-                                        lang="fr"
+                                        selectedLang="fr"
                                         :currentSlide="currentSlide"
                                         :isMobileSidebar="isMobileSidebar"
                                         :isActiveSlide="slideIndex === index"
@@ -227,7 +227,7 @@
                                         @copyConfig="copyConfigFromOtherLang(index, 'fr')"
                                         @copy="
                                             {
-                                                configEmpty(element, 'fr')
+                                                configEmpty(index, 'fr')
                                                     ? copyConfigFromOtherLang(index, 'fr')
                                                     : $vfm.open(`copy-other-slide-${index}-fr-config`);
                                             }
@@ -375,21 +375,7 @@
 <script lang="ts">
 import ActionModal from '@/components/helpers/action-modal.vue';
 import SlideTocButton from '@/components/helpers/slide-toc-button.vue';
-import {
-    BasePanel,
-    ChartPanel,
-    ConfigFileStructure,
-    DynamicChildItem,
-    DynamicPanel,
-    ImagePanel,
-    MapPanel,
-    MultiLanguageSlide,
-    Slide,
-    SlideshowPanel,
-    SourceCounts,
-    TextPanel,
-    VideoPanel
-} from '@/definitions';
+import { BasePanel, ImagePanel, MultiLanguageSlide, Slide, TextPanel, VideoPanel } from '@/definitions';
 import cloneDeep from 'clone-deep';
 import { VueFinalModal } from 'vue-final-modal';
 
@@ -399,6 +385,7 @@ import draggable from 'vuedraggable';
 import ConfirmationModalV from './helpers/confirmation-modal.vue';
 
 import SlideEditorV from './slide-editor.vue';
+import { useProductStore } from '@/stores/productStore';
 
 @Options({
     components: {
@@ -414,11 +401,11 @@ export default class SlideTocV extends Vue {
     @Prop() slides!: MultiLanguageSlide[];
     @Prop() currentSlide!: Slide | string;
     @Prop() slideIndex!: number;
-    @Prop() configFileStructure!: ConfigFileStructure;
     @Prop() lang!: string;
-    @Prop() sourceCounts!: SourceCounts;
     @Prop() closeSidebar!: () => void;
     @Prop({ default: false }) isMobileSidebar!: boolean;
+
+    productStore = useProductStore();
 
     defaultBlankSlide: Slide = {
         title: '',
@@ -442,7 +429,8 @@ export default class SlideTocV extends Vue {
      * @param slide Slide object to check.
      * @param lang Specific config in slide to check ('en' or 'fr')
      */
-    configEmpty(slide: MultiLanguageSlide, lang: keyof MultiLanguageSlide): boolean {
+    configEmpty(index: number, lang: keyof MultiLanguageSlide): boolean {
+        const slide: MultiLanguageSlide = this.slides[index];
         return JSON.stringify(slide[lang]) === JSON.stringify(this.defaultBlankSlide);
     }
 
@@ -459,7 +447,6 @@ export default class SlideTocV extends Vue {
      * Adds a new slide at the end of the current list.
      */
     addNewSlide(): void {
-        const lastSlide = this.slides[this.slides.length - 1];
         this.slides.push({
             en: JSON.parse(JSON.stringify(this.defaultBlankSlide)),
             fr: JSON.parse(JSON.stringify(this.defaultBlankSlide))
@@ -475,7 +462,7 @@ export default class SlideTocV extends Vue {
      * @param currLang The config to delete, either 'en' for English of 'fr' for French.
      */
     deleteConfig(slides: MultiLanguageSlide, currLang: 'en' | 'fr'): void {
-        slides[currLang].panels.forEach((panel: BasePanel) => this.removeSourceHelper(panel));
+        slides[currLang].panel.forEach((panel: BasePanel) => this.productStore.removeSourceCounts(panel));
         slides[currLang] = undefined;
         this.$emit('slides-updated', this.slides);
     }
@@ -501,13 +488,13 @@ export default class SlideTocV extends Vue {
         // in the shared folder (in which case we do nothing), and if an asset with the same name and different
         // contents already exists in the shared folder (in which case we give the asset uploaded to the shared
         // asset folder a unique name)
-        const oppositeToSharedFolder = (panel: ImagePanel | VideoPanel, oppositeLang: string): void => {
+        const oppositeToSharedFolder = async (panel: ImagePanel | VideoPanel, oppositeLang: string): void => {
             if (panel.src) {
                 const assetSrc = panel.src.split('/');
                 const fileName = assetSrc.at(-1);
                 const assetType = fileName.split('.').at(-1);
                 let inSharedAssets = assetSrc[2] === 'shared';
-                let sharedFileSource = `${this.configFileStructure.uuid}/assets/shared/${fileName}`;
+                let sharedFileSource = `${this.productStore.configFileStructure.uuid}/assets/shared/${fileName}`;
 
                 // If the asset for this panel refers to the opposite lang's asset folder, we will assume that there
                 // is no asset in the shared asset folder with the same name and contents as this asset. Otherwise
@@ -516,48 +503,51 @@ export default class SlideTocV extends Vue {
                     const oppositeFileSource = panel.src;
                     const oppositeRelativePath = assetSrc.slice(3).join('/');
                     let sharedAssetName = fileName;
-                    let compressedFile = this.configFileStructure.assets[oppositeLang].file(oppositeRelativePath);
+                    let compressedFile =
+                        this.productStore.configFileStructure.assets[oppositeLang].file(oppositeRelativePath);
                     let i = 2;
 
                     // If an asset with the same name, but different content, is already in the shared folder, we must
                     // give the asset we are uploading a unique name. Otherwise the existing asset will be overwritten
-                    while (this.configFileStructure.assets['shared'].file(sharedAssetName)) {
+                    while (this.productStore.configFileStructure.assets['shared'].file(sharedAssetName)) {
                         sharedAssetName = `${compressedFile.name.split('.').at(0)}(${i}).${compressedFile.name
                             .split('.')
                             .at(-1)}`;
                         i++;
                     }
-                    sharedFileSource = `${this.configFileStructure.uuid}/assets/shared/${sharedAssetName}`;
-
-                    compressedFile.async(assetType !== 'svg' ? 'blob' : 'text').then((assetFile) => {
+                    sharedFileSource = `${this.productStore.configFileStructure.uuid}/assets/shared/${sharedAssetName}`;
+                    await compressedFile.async(assetType !== 'svg' ? 'blob' : 'text').then((assetFile) => {
                         if (assetType === 'svg') {
                             assetFile = new File([assetFile], fileName, {
                                 type: 'image/svg+xml'
                             });
                         }
-                        this.configFileStructure.assets[oppositeLang].remove(oppositeRelativePath);
-                        this.configFileStructure.assets['shared'].file(sharedAssetName, assetFile);
-                        this.sourceCounts[sharedFileSource] = this.sourceCounts[oppositeFileSource] ?? 0;
-                        this.sourceCounts[oppositeFileSource] = 0;
-                        this.$emit('shared-asset', oppositeFileSource, sharedFileSource, oppositeLang);
+                        this.productStore.configFileStructure.assets[oppositeLang].remove(oppositeRelativePath);
+                        this.productStore.configFileStructure.assets['shared'].file(sharedAssetName, assetFile);
+                        this.productStore.sourceCounts[sharedFileSource] =
+                            this.productStore.sourceCounts[oppositeFileSource] ?? 0;
+                        this.productStore.sourceCounts[oppositeFileSource] = 0;
+                        this.productStore.updateToSharedAsset(oppositeFileSource, sharedFileSource, oppositeLang);
                     });
                 }
-                this.sourceCounts[sharedFileSource] += 1;
+                this.productStore.sourceCounts[sharedFileSource] += 1;
             }
         };
 
         this.slides[index][oppositeLang].panel.forEach((panel) => {
-            this.$emit('process-panel', panel, oppositeToSharedFolder, oppositeLang);
+            this.productStore.panelHelper(panel, oppositeToSharedFolder, oppositeLang);
         });
 
         // TODO: find better alternative to setTimeout. This code MUST execute after the callback above executes on each
         // panel in the opposite lang's slide. Otherwise it will copy the contents of the opposite config before its
         // src values are updated
         setTimeout(() => {
-            this.slides[index][currLang].panel.forEach((panel) => this.removeSourceHelper(panel));
+            this.slides[index][currLang].panel.forEach((panel) => this.productStore.removeSourceCounts(panel));
             this.slides[index][currLang] = JSON.parse(JSON.stringify(this.slides[index][oppositeLang]));
             this.$emit('slides-updated', this.slides);
             this.$emit('slide-change', index, currLang);
+
+            console.log('slide-toc.vue -> copyConfigFromOtherLang() -> ', this.productStore.sourceCounts);
         }, 300);
     }
 
@@ -567,6 +557,12 @@ export default class SlideTocV extends Vue {
      * @param currLang The language to create a blank config for.
      */
     createNewConfig(index: number, currLang: 'en' | 'fr'): void {
+        // Before wiping the slides, remove source counts as necessary.
+        this.slides[index][currLang]!.panel.forEach((panel: BasePanel) => {
+            // Remove source counts for each panel in the current config
+            this.productStore.removeSourceCounts(panel);
+        });
+
         this.slides[index][currLang] = JSON.parse(JSON.stringify(this.defaultBlankSlide));
 
         this.$emit('slides-updated', this.slides);
@@ -582,17 +578,19 @@ export default class SlideTocV extends Vue {
 
         // increment source count of each asset in this slide
         const incrementSourceCounts = (panel: ImagePanel | VideoPanel) => {
-            if (panel.src) {
-                this.sourceCounts[panel.src] += 1;
+            const source = !!panel.src ? panel.src : !!panel.config ? panel.config : undefined;
+            if (source) {
+                this.productStore.sourceCounts[source] += 1;
             }
         };
-        this.slides[index].en.panel.forEach((panel) => this.$emit('process-panel', panel, incrementSourceCounts));
-        this.slides[index].fr.panel.forEach((panel) => this.$emit('process-panel', panel, incrementSourceCounts));
+        this.slides[index].en.panel.forEach((panel) => this.productStore.panelHelper(panel, incrementSourceCounts));
+        this.slides[index].fr.panel.forEach((panel) => this.productStore.panelHelper(panel, incrementSourceCounts));
 
         this.$emit('slides-updated', this.slides);
         this.selectSlide(index + 1, this.lang);
         Message.success(this.$t('editor.slide.copy.success'));
         this.scrollToElement(index + 1);
+        console.log(`slide-toc.vue -> copySlide(): ${this.productStore.sourceCounts}`);
     }
 
     removeSlide(index: number): void {
@@ -613,77 +611,8 @@ export default class SlideTocV extends Vue {
         let panelEn = this.slides.find((slide: MultiLanguageSlide, idx: number) => idx === deletedIndex)?.en?.panel;
         let panelFr = this.slides.find((slide: MultiLanguageSlide, idx: number) => idx === deletedIndex)?.fr?.panel;
 
-        panelEn?.forEach((p: BasePanel) => this.removeSourceHelper(p));
-        panelFr?.forEach((p: BasePanel) => this.removeSourceHelper(p));
-    }
-
-    removeSourceHelper(panel: BasePanel): void {
-        // The provided panel is being removed. Update source counts accordingly.
-        switch (panel.type) {
-            case 'map': {
-                const mapPanel = panel as MapPanel;
-                this.sourceCounts[mapPanel.config] -= 1;
-                if (this.sourceCounts[mapPanel.config] === 0) {
-                    this.configFileStructure.zip.remove(
-                        `${mapPanel.config.substring(mapPanel.config.indexOf('/') + 1)}`
-                    );
-                }
-                break;
-            }
-
-            case 'image': {
-                const imagePanel = panel as ImagePanel;
-                this.sourceCounts[imagePanel.src] -= 1;
-                if (this.sourceCounts[imagePanel.src] === 0) {
-                    this.configFileStructure.zip.remove(`${imagePanel.src.substring(imagePanel.src.indexOf('/') + 1)}`);
-                }
-
-                break;
-            }
-
-            case 'chart': {
-                const chartPanel = panel as ChartPanel;
-                this.sourceCounts[chartPanel.src] -= 1;
-                if (this.sourceCounts[chartPanel.src] === 0) {
-                    this.configFileStructure.zip.remove(`${chartPanel.src.substring(chartPanel.src.indexOf('/') + 1)}`);
-                }
-
-                break;
-            }
-
-            case 'slideshow': {
-                const slideshowPanel = panel as SlideshowPanel;
-                slideshowPanel.items.forEach((item: TextPanel | MapPanel | ChartPanel | ImagePanel) => {
-                    this.removeSourceHelper(item);
-                });
-                break;
-            }
-
-            case 'video': {
-                const videoPanel = panel as VideoPanel;
-                if (videoPanel.videoType === 'local') {
-                    this.sourceCounts[videoPanel.src] -= 1;
-                    if (this.sourceCounts[videoPanel.src] === 0) {
-                        this.configFileStructure.zip.remove(
-                            `${videoPanel.src.substring(videoPanel.src.indexOf('/') + 1)}`
-                        );
-                    }
-                }
-                break;
-            }
-
-            case 'dynamic': {
-                const dynamicPanel = panel as DynamicPanel;
-                dynamicPanel.children.forEach((subPanel: DynamicChildItem) => {
-                    this.removeSourceHelper(subPanel.panel);
-                });
-                break;
-            }
-
-            case 'text': {
-                break;
-            }
-        }
+        panelEn?.forEach((p: BasePanel) => this.productStore.removeSourceCounts(p));
+        panelFr?.forEach((p: BasePanel) => this.productStore.removeSourceCounts(p));
     }
 
     moveUp(index: number): void {
@@ -703,7 +632,7 @@ export default class SlideTocV extends Vue {
     resizeMobile(): void {
         let overlayElement = document.getElementById('overlay');
         let sidebarElement = document.getElementById('sidebar-mobile');
-        
+
         if (overlayElement.style.display != 'none' && window.innerWidth >= 768) {
             overlayElement.style.display = 'none';
         } else if (sidebarElement.style.width === '20rem' && window.innerWidth < 768) {
@@ -717,7 +646,6 @@ export default class SlideTocV extends Vue {
     beforeDestroy() {
         window.removeEventListener('resize', this.resizeMobile);
     }
-    
 }
 
 // More accurate page height for mobile
@@ -731,7 +659,6 @@ window.addEventListener('resize', () => {
     let vh = window.innerHeight * 0.01;
     document.documentElement.style.setProperty('--vh', `${vh}px`);
 });
-
 </script>
 
 <style lang="scss" scoped>
@@ -753,7 +680,7 @@ window.addEventListener('resize', () => {
 }
 
 .toc-slide {
-  cursor: grab;
+    cursor: grab;
 }
 
 .toc-slide-button {

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -3,6 +3,7 @@ import JSZip from 'jszip';
 export type SupportedLanguages = 'en' | 'fr';
 
 export interface StoryRampConfig {
+    schemaVersion: string;
     title: string;
     lang: string;
     introSlide: Intro;
@@ -142,7 +143,6 @@ export interface Intro {
     title: string;
     subtitle: string;
     blurb?: string;
-    backgroundImage?: string;
     backgroundImage: string;
     titleColour?: string;
     subtitleColour?: string;

--- a/src/stores/productStore.ts
+++ b/src/stores/productStore.ts
@@ -1,0 +1,558 @@
+import { ConfigFileStructure, SourceCounts, StoryRampConfig } from '@/definitions';
+import { defineStore } from 'pinia';
+import JSZip from 'jszip';
+
+import Message from 'vue-m-message';
+
+import type {
+    BasePanel,
+    ChartPanel,
+    DynamicChildItem,
+    DynamicPanel,
+    ImagePanel,
+    MapPanel,
+    SlideshowPanel,
+    TextPanel,
+    VideoPanel,
+    Slide
+} from '@/definitions';
+import { PanelType } from '@/definitions';
+import { useStateStore } from './stateStore';
+
+interface ProductState {
+    configFileStructure: ConfigFileStructure;
+    configs: { [key: string]: StoryRampConfig | undefined };
+    configLang: string;
+    sourceCounts: SourceCounts;
+    debounceTimer: ReturnType<typeof setTimeout> | null;
+}
+
+export const useProductStore = defineStore('product', {
+    state: (): ProductState => ({
+        configFileStructure: {} as ConfigFileStructure,
+        configs: { en: undefined, fr: undefined },
+        configLang: 'en',
+        sourceCounts: {},
+
+        // Debounce timer used for updateSaveStatus only.
+        // IMPORTANT: Avoid using stateStore's handlePotentialChange() directly, this timer may cause issues with change detection and saving to the configs variable.
+        // Instead, ALWAYS call either updateSaveStatus() (if in metadata-editor) or emit the 'save-status' event instead!
+        debounceTimer: null
+    }),
+
+    getters: {
+        /**
+         * If a language is provided, use that. Otherwise use the current configuration language.
+         */
+        oppositeLang: (state) => {
+            return state.configLang === 'en' ? 'fr' : 'en';
+        },
+        folders: (state: ProductState) => {
+            return {
+                assets: state.configFileStructure?.assets,
+                charts: state.configFileStructure?.charts,
+                rampConfig: state.configFileStructure?.rampConfig
+            };
+        }
+    },
+
+    actions: {
+        changeLang(lang: string): void {
+            this.configLang = lang;
+        },
+
+        /**
+         * Update the unsaved changes value to the payload.
+         * Debounced to prevent being called too often.
+         */
+        updateSaveStatus(payload: boolean | undefined, origin?: string): void {
+            const stateStore = useStateStore();
+
+            if (this.debounceTimer) clearTimeout(this.debounceTimer);
+
+            this.debounceTimer = setTimeout(() => {
+                stateStore.handlePotentialChange(
+                    {
+                        en: JSON.parse(JSON.stringify(this.configs.en)),
+                        fr: JSON.parse(JSON.stringify(this.configs.fr))
+                    },
+                    origin
+                );
+            }, 300);
+        },
+
+        /**
+         * =====================
+         * SOURCE COUNT METHODS
+         * =====================
+         */
+
+        // Return true if the source exists in sourceCounts and its count is greater than 0.
+        sourceExists(src: string): boolean {
+            return this.sourceCounts[src] !== undefined && this.sourceCounts[src] > 0;
+        },
+
+        // Incremements the source count for the provided source. If it doesn't exist, the source is also added to the object.
+        incrementSourceCount(src: string): void {
+            this.sourceCounts[src] ? (this.sourceCounts[src] += 1) : (this.sourceCounts[src] = 1);
+            console.log(`productStore -> incrementSourceCount()`, this.sourceCounts, src);
+        },
+
+        // Decrements the source count for the provided source. If the count is 0, the source is removed.
+        decrementSourceCount(src: string | undefined | 'Logo' | 'Background'): void {
+            if (src === 'Logo') {
+                src = this.configs[this.configLang]?.introSlide.logo.src;
+            }
+
+            if (src === 'Background') {
+                src = this.configs[this.configLang]?.introSlide.backgroundImage;
+            }
+
+            if (src) {
+                if (this.sourceCounts[src]) {
+                    this.sourceCounts[src] -= 1;
+                }
+                if (this.sourceCounts[src] <= 0) {
+                    const relativePath = src.split('/').slice(1).join('/');
+                    this.configFileStructure?.zip.remove(relativePath);
+                }
+            }
+            console.log(`productStore -> decrementSourceCount()`, this.sourceCounts);
+        },
+
+        // Recursively calls `decrementSourceCount` on a panel. Will ensure correct source counts for panels with children.
+        removeSourceCounts(panel: BasePanel): void {
+            // The provided panel is being removed. Update source counts accordingly.
+            switch (panel.type) {
+                case 'map': {
+                    const mapPanel = panel as MapPanel;
+                    this.decrementSourceCount(mapPanel.config);
+                    break;
+                }
+
+                case 'image': {
+                    const imagePanel = panel as ImagePanel;
+                    this.decrementSourceCount(imagePanel.src);
+                    break;
+                }
+
+                case 'chart': {
+                    const chartPanel = panel as ChartPanel;
+                    this.decrementSourceCount(chartPanel.src);
+                    break;
+                }
+
+                case 'slideshow':
+                case 'slideshowImage':
+                case 'slideshowChart': {
+                    const slideshowPanel = panel as SlideshowPanel;
+                    slideshowPanel.items.forEach((item: TextPanel | ImagePanel | MapPanel | ChartPanel) => {
+                        this.removeSourceCounts(item);
+                    });
+                    break;
+                }
+
+                case 'video': {
+                    const videoPanel = panel as VideoPanel;
+                    if (videoPanel.videoType === 'local') {
+                        this.decrementSourceCount(videoPanel.src);
+                    }
+                    break;
+                }
+
+                case 'dynamic': {
+                    const dynamicPanel = panel as DynamicPanel;
+                    dynamicPanel.children.forEach((subPanel: DynamicChildItem) => {
+                        this.removeSourceCounts(subPanel.panel);
+                    });
+                    break;
+                }
+
+                case 'text': {
+                    break;
+                }
+            }
+        },
+
+        // Recursively calls `incrementSourceCount` on a panel. Will ensure correct source counts for panels with children.
+        // TODO: this is basically the same as the function above. We should re-visit these functions and maybe combine them in the future.
+        panelSourceHelper(panel: BasePanel): void {
+            switch (panel.type) {
+                case PanelType.Dynamic:
+                    (panel as DynamicPanel).children.forEach((subPanel: DynamicChildItem) => {
+                        this.panelSourceHelper(subPanel.panel);
+                    });
+                    break;
+                case PanelType.Slideshow:
+                case PanelType.SlideshowImage:
+                case PanelType.SlideshowChart:
+                    (panel as SlideshowPanel).items.forEach((item: ChartPanel | TextPanel | ImagePanel | MapPanel) => {
+                        this.panelSourceHelper(item);
+                    });
+                    break;
+                case PanelType.Chart:
+                    this.incrementSourceCount((panel as ChartPanel).src);
+                    break;
+                case PanelType.Image:
+                    this.incrementSourceCount((panel as ImagePanel).src);
+                    break;
+                case PanelType.Video:
+                    if ((panel as VideoPanel).videoType === 'local') {
+                        this.incrementSourceCount((panel as VideoPanel).src);
+                    }
+                    break;
+                case PanelType.Map:
+                    this.incrementSourceCount((panel as MapPanel).config);
+                    break;
+                case PanelType.Text:
+                    break;
+                default:
+                    break;
+            }
+        },
+
+        // Calculates the sourceCounts for all assets used within a product.
+        findSources(): void {
+            this.sourceCounts = {}; // reset source counts first.
+            ['en', 'fr'].forEach((lang) => {
+                if (this.configs[lang]?.introSlide.logo?.src) {
+                    this.incrementSourceCount((this.configs[lang] as StoryRampConfig).introSlide.logo.src);
+                }
+
+                if (this.configs[lang]?.introSlide.backgroundImage) {
+                    this.incrementSourceCount((this.configs[lang] as StoryRampConfig).introSlide.backgroundImage);
+                }
+
+                this.configs[lang]?.slides.forEach((slide) => {
+                    if (Object.keys(slide).length !== 0) {
+                        (slide as Slide).panel.forEach((panel) => {
+                            this.panelSourceHelper(panel);
+                        });
+                    }
+                });
+            });
+            console.log(`productStore.ts -> findSources():`, this.sourceCounts);
+        },
+        // Given a Storylines config, replace instances of the current UUID with a new UUID.
+        renameSources(config: StoryRampConfig, prevUuid: string, changeUuid: string): void {
+            const _renameHelper = (panel: any): any => {
+                switch (panel.type) {
+                    case PanelType.Dynamic:
+                        (panel as DynamicPanel).children.forEach((child) => {
+                            _renameHelper(child.panel);
+                        });
+                        break;
+                    case PanelType.Slideshow:
+                    case PanelType.SlideshowImage:
+                    case PanelType.SlideshowChart:
+                        (panel as SlideshowPanel).items.forEach((child) => {
+                            _renameHelper(child);
+                        });
+                        break;
+                    case PanelType.Map:
+                        if (panel.config && typeof panel.config === 'string') {
+                            // Update the path to the RAMP config in the product config file.
+                            panel.config = panel.config.replace(`/${prevUuid}-map-`, `/${changeUuid}-map-`);
+                        }
+                    // Intentionally no break here so that the folder can also be renamed in the default block.
+                    default:
+                        // Base case. This is a panel that doesn't have any children (i.e., not dynamic, slideshow).
+                        // Rename the source.
+                        if (panel.src) {
+                            panel.src = panel.src.replace(`${prevUuid}/`, `${changeUuid}/`);
+                        }
+                        if (panel.config && typeof panel.config === 'string') {
+                            panel.config = panel.config.replace(`${prevUuid}/`, `${changeUuid}/`);
+                        }
+                }
+            };
+
+            // Rename logo and introduction slide background image, if applicable.
+            if (config?.introSlide.logo?.src) {
+                config.introSlide.logo.src = config.introSlide.logo.src.replace(
+                    `${prevUuid}/assets/`,
+                    `${changeUuid}/assets/`
+                );
+            }
+
+            if (config?.introSlide.backgroundImage) {
+                config.introSlide.backgroundImage = config.introSlide.backgroundImage.replace(
+                    `${prevUuid}/assets/`,
+                    `${changeUuid}/assets/`
+                );
+            }
+
+            config.slides.forEach((slide) => {
+                if (Object.keys(slide).length !== 0) {
+                    if ((slide as Slide).backgroundImage) {
+                        (slide as Slide).backgroundImage = (slide as Slide).backgroundImage.replace(
+                            `${prevUuid}/assets/`,
+                            `${changeUuid}/assets/`
+                        );
+                    }
+
+                    (slide as Slide).panel.forEach((panel) => {
+                        _renameHelper(panel);
+                    });
+                }
+            });
+        },
+
+        /**
+         * =====================
+         * SHARED ASSET METHODS
+         * =====================
+         */
+        // Converts a file into a promise that resolves to an ArrayBuffer containing the files data
+        readBinaryData(file: File): Promise<ArrayBuffer> {
+            return new Promise((resolve, reject) => {
+                const fileReader: FileReader = new FileReader();
+                fileReader.onload = () => {
+                    resolve(fileReader.result as ArrayBuffer);
+                };
+                fileReader.onerror = () => {
+                    reject(new Error('Could not load file reader'));
+                };
+                fileReader.readAsArrayBuffer(file);
+            });
+        },
+
+        // Converts a file into a promise that resolves to its hash, as an array of 8-bit integers
+        obtainHashData(file: File): Promise<Uint8Array> {
+            return this.readBinaryData(file)
+                .then((res) => {
+                    res = new Uint8Array(res);
+                    return window.crypto.subtle.digest('SHA-256', res);
+                })
+                .then((res) => {
+                    res = new Uint8Array(res);
+                    return res;
+                });
+        },
+
+        /**
+         * Compares the hashes of two files
+         * @param file File that was uploaded
+         * @param compressedBinary Compressed binary file from configFileStructure
+         * @param compressedName The name of the compressed binary file
+         */
+        async compareFiles(file: File, compressedBinary: JSZip.JSZipObject, compressedName: string): Promise<boolean> {
+            const fileHash = await this.obtainHashData(file);
+            const compressedType = compressedName.split('.').at(-1);
+
+            return compressedBinary
+                .async(compressedType !== 'svg' ? 'blob' : 'text')
+                .then((assetFile) => {
+                    if (compressedType === 'svg') {
+                        assetFile = new File([assetFile], compressedName, {
+                            type: 'image/svg+xml'
+                        });
+                    }
+                    return this.obtainHashData(assetFile as File);
+                })
+                .then((hash) => {
+                    return hash.join() === fileHash.join();
+                });
+        },
+
+        /**
+         * Helper used to find all instances of the specified file in the specified asset folder
+         * @param file File that was uploaded
+         * @param folder The asset folder withinn which we should be searching
+         * @param checkNested Flag that indicates whether we should consider assets with nested subfolders
+         */
+        filesInAssetFolder(file: File, folder: string, checkNested = true): Array<Promise<string>> {
+            // Here, if a file in the specified folder has the same name and hash as the file uploaded, then we consider the
+            // two to be the same. Otherwise, we consider them to be different. We even consider if the asset is within a
+            // subfolder of the specified folder, so long as the name and hash of the file is the same. There may be more than one
+            // instance of the specified asset in the specified folder, albeit in seperate subfolders, hence why we collect
+            // an array of duplicate asset promises
+            const sharedAssetPromises = [];
+            this.configFileStructure.assets[folder].forEach((relativePath, compressedBinary) => {
+                const assetName = checkNested ? relativePath.split('/').at(-1) : relativePath;
+
+                // Only compare the hashes of two files when they have the exact same name
+                if (assetName === file.name) {
+                    sharedAssetPromises.push(
+                        this.compareFiles(file, compressedBinary, assetName).then((fileSame) =>
+                            fileSame ? relativePath : 'N/A'
+                        )
+                    );
+                }
+            });
+
+            return sharedAssetPromises;
+        },
+
+        // Helper for onFileChange and dropImages. Maps a File object to an ImageFile object
+        async addUploadedFile(
+            file: File
+        ): Promise<{ inSharedAsset: boolean; newAssetName: string; uploadSource: string }> {
+            const oppositeLang = this.oppositeLang;
+
+            const sharedAssetPaths = await Promise.all(this.filesInAssetFolder(file, 'shared', false));
+            let inSharedAsset = false;
+            let oppositeSourceCount = 0;
+            let newAssetName = file.name;
+            let uploadSource = `${this.configFileStructure.uuid}/assets/shared/${file.name}`;
+
+            // Should contain either 0 or 1 promise.
+            sharedAssetPaths.forEach((sharedAssetPath) => {
+                inSharedAsset = sharedAssetPath !== 'N/A';
+            });
+
+            // If the asset is already in the shared asset folder, we do not need to do anything. We can assume that it
+            // does not exist in the opposite lang's asset folder (i.e. we assume shared asset system is working correctly)
+            if (!inSharedAsset) {
+                const oppositeAssetPaths = await Promise.all(this.filesInAssetFolder(file, oppositeLang));
+                // If the current promise contains 'N/A', then the current path refers to an asset in the opposite asset
+                // folder that has the same name, but different contents, as the asset uploaded. In this case we do
+                // nothing, as this asset is not a valid duplicate.
+                for (const oppositeAssetPath of oppositeAssetPaths) {
+                    if (oppositeAssetPath !== 'N/A') {
+                        const oppositeFileSource = `${this.configFileStructure.uuid}/assets/${oppositeLang}/${oppositeAssetPath}`;
+                        oppositeSourceCount += this.sourceCounts[oppositeFileSource] ?? 0;
+                        this.sourceCounts[oppositeFileSource] = 0;
+                        this.configFileStructure.assets[oppositeLang].remove(oppositeAssetPath);
+
+                        // Add asset to shared folder if asset is yet to be moved to the shared folder. If an asset with the
+                        // same name, but different content, is already in the shared folder, we must give the asset we are
+                        // uploading a unique name. Otherwise the existing asset will be overwritten
+                        if (!inSharedAsset) {
+                            let i = 2;
+                            while (this.configFileStructure.assets['shared'].file(newAssetName)) {
+                                // If the updated name is the same as a file that already exists in the shared asset folder,
+                                // we must compare that file with the uploaded file, since they wouldnt have been compared
+                                // on the first run due to having different names (Such an asset COULD also be in the shared
+                                // or opposite lang asset folder, since a new name is now being used. However we shouldn't
+                                // execute this entire method again just for an edge case like a name change, so we can
+                                // leave this as is for now)
+                                if (i > 2) {
+                                    const filesEqual = await this.compareFiles(
+                                        file,
+                                        this.configFileStructure.assets['shared'].file(newAssetName),
+                                        newAssetName
+                                    );
+                                    if (filesEqual) break;
+                                }
+                                newAssetName = `${file.name.split('.').at(0)}(${i}).${file.name.split('.').at(-1)}`;
+                                i++;
+                            }
+                            uploadSource = `${this.configFileStructure.uuid}/assets/shared/${newAssetName}`;
+                            this.configFileStructure.assets['shared'].file(newAssetName, file);
+                            inSharedAsset = true;
+                        }
+                        this.updateToSharedAsset(oppositeFileSource, uploadSource, oppositeLang); // must be done for each duplicate asset
+                    }
+                }
+            }
+
+            // If the asset uploaded is in the shared asset folder, then no need to upload to the current langs assets folder
+            if (!inSharedAsset) {
+                const currAssetPaths = await Promise.all(this.filesInAssetFolder(file, this.configLang, false));
+                // Should contain either 0 or 1 promise.
+                // Need to use await here
+                for (const currAssetPath of currAssetPaths) {
+                    // If asset w/ same name but different contents is in curr lang asset folder, set name in curr lang
+                    // asset folder to a unique name, to avoid overwriting an existing file.
+                    if (currAssetPath === 'N/A') {
+                        let i = 2;
+                        while (this.configFileStructure.assets[this.configLang].file(newAssetName)) {
+                            // If the updated name is the same as a file that already exists in the current langs asset folder,
+                            // we must compare that file with the uploaded file, since they wouldnt have been compared
+                            // on the first run due to having different names
+                            if (i > 2) {
+                                const filesEqual = await this.compareFiles(
+                                    file,
+                                    this.configFileStructure.assets[this.configLang].file(newAssetName),
+                                    newAssetName
+                                );
+                                if (filesEqual) break;
+                            }
+                            newAssetName = `${file.name.split('.').at(0)}(${i}).${file.name.split('.').at(-1)}`;
+                            i++;
+                        }
+                    }
+                }
+                uploadSource = `${this.configFileStructure.uuid}/assets/${this.configLang}/${newAssetName}`;
+                this.configFileStructure.assets[this.configLang].file(newAssetName, file);
+            }
+
+            // Notify user of the change in the name of their uploaded asset, to avoid any confusion
+            if (file.name !== newAssetName) {
+                Message.info(this.$t('editor.slides.assetNameChange', { oldName: file.name, newName: newAssetName }));
+            }
+
+            if (this.sourceCounts[uploadSource]) {
+                this.sourceCounts[uploadSource] += 1 + oppositeSourceCount;
+            } else {
+                this.sourceCounts[uploadSource] = 1 + oppositeSourceCount;
+            }
+
+            return { inSharedAsset, newAssetName, uploadSource };
+        },
+
+        /**
+         * Updates the source of an asset from the opposite lang's assets folder to the shared assets folder
+         *
+         * @param oppositeAssetPath Path of the asset within the opposite langs asset folder that has been moved
+         * @param sharedAssetName Path of the asset within the shared asset folder
+         * @param oppositeLang Language from which the asset was removed
+         */
+        updateToSharedAsset(oppositeAssetPath: string, sharedAssetPath: string, oppositeLang: string): void {
+            const oppositeConfig = this.configs[oppositeLang];
+
+            const updateAssetSrc = (
+                panel: ImagePanel | VideoPanel,
+                oppositeAssetPath: string,
+                sharedAssetPath: string
+            ) => {
+                if (panel.src) {
+                    if (panel.src === oppositeAssetPath) {
+                        panel.src = sharedAssetPath;
+                    }
+                }
+            };
+
+            // Need to check logo seperately
+            if (oppositeConfig.introSlide.logo.src === oppositeAssetPath) {
+                oppositeConfig.introSlide.logo.src = sharedAssetPath;
+            }
+
+            oppositeConfig?.slides.forEach((slide) => {
+                slide.panel.forEach((panel) => {
+                    this.panelHelper(panel, updateAssetSrc, oppositeAssetPath, sharedAssetPath);
+                });
+            });
+
+            this.updateSaveStatus(true);
+        },
+        /**
+         * Executes a callback for each ImagePanel/VideoPanel within the provided BasePanel
+         *
+         * @param panel The panel which we are processing
+         * @param callback The callback function that is called on each ImagePanel/VideoPanel in the provided BasePanel
+         * @param callbackArgs The additional argument(s) for the callback function (can be empty)
+         */
+        panelHelper(
+            panel: BasePanel,
+            callback: (panel: ImagePanel | VideoPanel, ...args) => void,
+            ...callbackArgs
+        ): void {
+            switch (panel.type) {
+                case 'slideshowImage':
+                case 'slideshow':
+                    panel.items.forEach((item) => this.panelHelper(item, callback, ...callbackArgs));
+                    break;
+                case 'dynamic':
+                    panel.children.forEach((child) => this.panelHelper(child.panel, callback, ...callbackArgs));
+                    break;
+                case 'image':
+                case 'chart':
+                case 'video':
+                case 'map':
+                    callback(panel, ...callbackArgs);
+            }
+        }
+    }
+});

--- a/src/stores/stateStore.ts
+++ b/src/stores/stateStore.ts
@@ -60,6 +60,7 @@ export interface Save {
 }
 
 const MAX_STATE_CHANGES = 30;
+const REQUIRED_PROPS = ['type', 'title', 'src', 'content'];
 
 // @ts-ignore
 function replaceByClonedSource(options) {
@@ -76,7 +77,7 @@ function purgeFalses(obj: any): any {
     }
 
     return Object.entries(obj).reduce((acc, [key, value]) => {
-        if (value !== null && value !== undefined && value) {
+        if ((value !== null && value !== undefined && value) || REQUIRED_PROPS.includes(key)) {
             acc[key] = typeof value === 'object' ? purgeFalses(value) : value;
         }
         return acc;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-import { RouteLocationNormalized } from 'vue-router';
+import { RouteLocationNormalized, Router } from 'vue-router';
 import { Pinia } from 'pinia';
 
 declare module 'vue-router' {
@@ -10,6 +10,8 @@ declare module 'vue-router' {
 declare module '@vue/runtime-core' {
     interface ComponentCustomProperties {
         $route: RouteLocationNormalized;
+        $router: Router;
         $pinia: Pinia;
+        $t: typeof import('vue-i18n')['t'];
     }
 }


### PR DESCRIPTION
### Related Item(s)
#365 

### Changes
- Centralized `configFileStructure`, `sourceCounts`, `configs`, and `configLang` in to a common store.
- Moved many methods in to the store as well. I specifically looked for methods that we had duplicated throughout the code (updating source counts, shared assets, etc).
- Found a few bugs relating to source counts accuracy while testing. Fixed these as well.
- Added `$t` and `$router` to `types.d.ts` to remove `Property '$t' does not exist on type 'X'.` errors throughout the app.
- Removed many unused variables.
- Removed props and event listeners that were no longer needed (passing in `configFileStructure` and `sourceCounts` into every component, `@shared-asset`, `@lang-change`, `@process-panel`, etc.)

### Notes
* The final name of this store doesn't have to be `productStore`, I'm just not creative. It's easy enough to find and replace the store name, so hit me with recommendations if you'd like!
* I don't like that we currently have to access the state by including `this.productStore.X` before the property or method we're trying to access. It can get annoying when trying to access something deep within the state, for example `this.productStore.configFileStructure.zip`. Once we do the `script setup` refactor, we'll have access to `storeToRefs` which we can use to enhance this.
* I had to include [Ishav's fix](https://github.com/ramp4-pcar4/storylines-editor/pull/644) for config properties getting overwritten so that the app would be testable. I'll remove the code from this PR once we merge that PR.

### Testing
This is a big one, and there's nothing specific to test. Lots of important functions were moved around, so please test the everything thoroughly and ensure that the editor still works as expected.

I've left a bunch of `console.log`s in this PR so you can ensure source counts are accurate. These will be removed before merging.
