### PR TITLE
ToC scrolls when next/previous slide and other slide changes

### DIFF
--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -454,6 +454,7 @@
                     :slides="slides"
                     :currentSlide="currentSlide"
                     :slideIndex="slideIndex"
+                    @scroll-to-element="scrollToElement"
                     @slide-change="selectSlide"
                     @slide-edit="$emit('save-status', undefined, 'ToC')"
                     @slides-updated="updateSlides"
@@ -516,6 +517,7 @@
                     @shared-asset="(oppositeAssetPath: string, sharedAssetPath: string, oppositeLang: string) => {
                         $emit('shared-asset', oppositeAssetPath, sharedAssetPath, oppositeLang);
                     }"
+                    @scroll-to-element="scrollToElement"
                     @slide-change="selectSlide"
                     @slide-edit="onSlidesEdited"
                     @custom-slide-updated="updateCustomSlide"
@@ -587,6 +589,7 @@ export default class EditorV extends Vue {
     @Prop() configLang!: string;
     @Prop() saving!: boolean;
     @Prop() unsavedChanges!: boolean;
+    @Prop({ default: false }) isMobileSidebar!: boolean;
 
     currentRoute = window.location.href;
 
@@ -765,6 +768,18 @@ export default class EditorV extends Vue {
                 this.originalTextArray.push(info_results);
             }
         });
+    }
+
+    /**
+     * Smooth scroll to an element on the table of contents. Will end scroll in the middle of the ToC vertical area, if able.
+     * @param index The index of the slide to scroll to.
+     */
+    scrollToElement(index: number): void {
+        setTimeout(() => {
+            document
+                .getElementById((this.isMobileSidebar ? 'mobile' : '') + 'slide' + index)
+                ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }, 10);
     }
 
     exportProduct(): void {

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -790,6 +790,7 @@ export default class SlideEditorV extends Vue {
 
     selectSlide(index: number, lang?: SupportedLanguages): void {
         this.$emit('slide-change', index, lang);
+        this.$emit('scroll-to-element', index);
     }
 
     cancelTypeChange(): void {

--- a/src/components/slide-toc/slide-toc.vue
+++ b/src/components/slide-toc/slide-toc.vue
@@ -472,7 +472,7 @@ export default class SlideTocV extends Vue {
         });
         this.selectSlide(this.slides.length - 1, this.lang);
         this.$emit('slides-updated', this.slides);
-        this.scrollToElement(this.slides.length - 1);
+        this.$emit('scroll-to-element', this.slides.length - 1);
     }
 
     /**
@@ -484,18 +484,6 @@ export default class SlideTocV extends Vue {
         slides[currLang].panels.forEach((panel: BasePanel) => this.removeSourceHelper(panel));
         slides[currLang] = undefined;
         this.$emit('slides-updated', this.slides);
-    }
-
-    /**
-     * Smooth scroll to an element on the table of contents. Will end scroll in the middle of the ToC vertical area, if able.
-     * @param index The index of the slide to scroll to.
-     */
-    scrollToElement(index: number): void {
-        setTimeout(() => {
-            document
-                .getElementById((this.isMobileSidebar ? 'mobile' : '') + 'slide' + index)
-                ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        }, 10);
     }
 
     // Assumes that you've already checked that the other lang DOES have a config.
@@ -605,7 +593,7 @@ export default class SlideTocV extends Vue {
         this.$emit('slides-updated', this.slides);
         this.selectSlide(index + 1, this.lang);
         Message.success(this.$t('editor.slide.copy.success'));
-        this.scrollToElement(index + 1);
+        this.$emit('scroll-to-element', index + 1);
     }
 
     removeSlide(index: number): void {
@@ -701,11 +689,12 @@ export default class SlideTocV extends Vue {
 
     moveUp(index: number): void {
         this.moveDown(index - 1);
+        this.$emit('scroll-to-element', index - 1);
     }
 
     moveDown(index: number): void {
         this.slides.splice(index + 1, 0, this.slides.splice(index, 1)[0]);
-        this.scrollToElement(index + 1);
+        this.$emit('scroll-to-element', index + 1);
         this.$emit('slides-updated', this.slides);
     }
 

--- a/src/components/support/chart-preview.vue
+++ b/src/components/support/chart-preview.vue
@@ -122,7 +122,7 @@ export default class ChartPreviewV extends Vue {
      * Save initial set of chart options used to create chart.
      */
     loadChart(chartOptions: DQVChartConfig): void {
-        // initialize higcharts editor and link to edit summoner node
+        // initialize highcharts editor and link to edit summoner node
         if (this.modalEditor) {
             return;
         }


### PR DESCRIPTION
### Related Item(s)
Issue #533 

### Changes
- when a new slide is in focus, the ToC now scrolls to it

### Testing
Steps:
1. Navigate the slides using next or previous slide buttons
2. Notice the ToC correctly scrolling to the new slide if it is off the screen

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/654)
<!-- Reviewable:end -->
