### PR TITLE
feat: Refresh dynamic editor table & functionality

### DIFF
--- a/src/components/panel-editors/dynamic-editor.vue
+++ b/src/components/panel-editors/dynamic-editor.vue
@@ -1,102 +1,242 @@
 <template>
     <div class="block mt-6">
-        <!-- left and right panel buttons for dynamic panels -->
+        <!-- Section selection header buttons -->
         <div class="flex gap-2 border-b pb-1 px-1.5" style="border-color: rgba(209, 213, 219, 1)">
+            <!-- Text section button -->
             <button
                 @click="() => changePanel('text')"
+                :aria-label="$t('dynamic.textSection')"
                 class="respected-standard-button respected-transparent-button respected-thin-button"
                 :class="editingStatus === 'text' ? 'bg-gray-200' : ''"
                 :style="editingStatus === 'text' ? 'font-weight: bold' : ''"
             >
                 {{ $t('dynamic.textSection') }}
             </button>
+            <!-- Panel collection button -->
             <button
                 @click="() => changePanel('panels')"
+                :aria-label="$t('dynamic.panel.collection') + ` (${panel.children.length})`"
                 class="respected-standard-button respected-transparent-button respected-thin-button"
                 :class="editingStatus !== 'text' ? 'bg-gray-200' : ''"
                 :style="editingStatus !== 'text' ? 'font-weight: bold' : ''"
             >
-                {{ $t('dynamic.panel.collection') }}
+                {{ $t('dynamic.panel.collection') + ` (${panel.children.length})` }}
             </button>
         </div>
         <!-- Text Section -->
         <div v-if="editingStatus === 'text'">
             <component :is="'text-editor'" key="text" :panel="panel" :lang="lang"></component>
         </div>
+        <!-- Panel section -->
         <div v-if="editingStatus === 'panels'">
-            <table style="width: 66.66%; min-width: 500px" class="mt-5">
-                <thead>
-                    <tr class="table-header">
-                        <th>{{ $t('dynamic.panel.id') }}</th>
-                        <th>{{ $t('dynamic.panel.type') }}</th>
-                        <th>{{ $t('dynamic.panel.actions') }}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr class="table-contents" v-for="(item, idx) in panel.children" :key="idx">
-                        <td>{{ item.id }}</td>
-                        <td>{{ determineEditorType(item.panel) }}</td>
-                        <td>
-                            <button @click="() => switchSlide(idx)">{{ $t('editor.chart.label.edit') }}</button> |
-                            <button @click="$vfm.open(`delete-item-${idx}`)">{{ $t('editor.remove') }}</button>
-                        </td>
-
-                        <confirmation-modal
-                            :name="`delete-item-${idx}`"
-                            :message="$t('dynamic.panel.remove')"
-                            @ok="() => removeSlide(item.panel as any, idx)"
-                        />
-                    </tr>
-                    <tr class="table-add-row">
-                        <td class="flex flex-col items-center">
-                            <input
-                                id="panelId"
-                                class="respected-standard-input"
-                                type="text"
-                                :placeholder="$t('dynamic.panel.enterID')"
-                                v-model="newSlideName"
-                                :aria-label="$t('dynamic.panel.enterID')"
-                            />
-                        </td>
-                    </tr>
-
-                    <tr class="table-add-row">
-                        <td class="flex flex-col items-center">
-                            <input
-                                id="panelId"
-                                class="respected-standard-input"
-                                type="text"
-                                :placeholder="$t('dynamic.panel.enterID')"
-                                v-model="newSlideName"
-                                :aria-label="$t('dynamic.panel.enterID')"
-                            />
-                            <p v-if="idUsed">{{ $t('dynamic.panel.idTaken') }}</p>
-                        </td>
-                        <td>
-                            <select v-model="newSlideType" class="respected-standard-select justify-self-center">
-                                <option v-for="thing in Object.keys(editors)" :key="thing">
-                                    {{ thing }}
-                                </option>
-                            </select>
-                        </td>
-                        <td>
-                            <button
-                                class="respected-standard-button respected-gray-border-button respected-thin-button justify-self-center"
-                                @click="createNewSlide"
-                                :disabled="idUsed || !newSlideName"
+            <div class="w-full lg:w-4/5 max-h-96 overflow-y-auto mt-5 border border-gray-400 rounded-md">
+                <!-- Panel collection table -->
+                <table class="w-full border-separate">
+                    <thead class="bg-white sticky top-0" style="z-index: 5">
+                        <tr style="top: 2px; z-index: 6" class="table-header sticky">
+                            <!-- Header: Move panel buttons -->
+                            <th
+                                style="width: 10%; text-align: left !important"
+                                class="rounded-tl"
+                                :aria-label="$t('editor.slideshow.label.slideNumber')"
+                            ></th>
+                            <!-- Header: Panel # and ID -->
+                            <th style="width: 40%; text-align: left !important" :aria-label="$t('dynamic.panel.id')">
+                                <span class="mx-2">{{ $t('dynamic.panel.id') }}</span>
+                            </th>
+                            <!-- Header: Panel type -->
+                            <th style="width: 20%; text-align: left !important">
+                                <span class="mx-2">{{ $t('dynamic.panel.type') }}</span>
+                            </th>
+                            <!-- Header: Panel actions -->
+                            <th style="width: 30%; text-align: left !important" class="rounded-tr">
+                                <span class="mx-2">{{ $t('dynamic.panel.actions') }}</span>
+                            </th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr
+                            class="table-contents"
+                            v-for="(item, idx) in panel.children"
+                            :key="idx"
+                            :class="{
+                                'bg-gray-100': idx % 2 !== 0,
+                                'bg-blue-200 hover-editing': editingSlide === idx
+                            }"
+                        >
+                            <!-- Move panel buttons -->
+                            <td
+                                class="px-0.5 flex flex-col lg:flex-row gap-0.5 justify-center items-center"
+                                :class="{ 'rounded-bl': idx === panel.children.length - 1 }"
                             >
-                                {{ $t('dynamic.panel.add') }}
-                            </button>
-                        </td>
-                    </tr>
-                </tbody>
-            </table>
+                                <!-- Move panel up button -->
+                                <button
+                                    :disabled="idx === 0 || editingSlide !== -1"
+                                    @click="moveChildUp(idx)"
+                                    :aria-label="$t('editor.slides.toc.moveSlideUp')"
+                                    style="border: none !important; padding-left: 0.375rem; padding-right: 0.375rem"
+                                    class="respected-standard-button respected-transparent-button"
+                                    v-tippy="{
+                                        delay: '200',
+                                        placement: 'top',
+                                        content: $t('editor.slides.toc.moveSlideUp'),
+                                        touch: ['hold', 500]
+                                    }"
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        x="0px"
+                                        y="0px"
+                                        viewBox="0 0 122.88 66.91"
+                                        style="enable-background: new 0 0 122.88 66.91"
+                                        xml:space="preserve"
+                                        height="14"
+                                        width="14"
+                                        class="fill-current"
+                                    >
+                                        <g>
+                                            <path
+                                                d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95 c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73 c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"
+                                            />
+                                        </g>
+                                    </svg>
+                                </button>
+                                <!-- Move panel down button -->
+                                <button
+                                    :disabled="idx === panel.children.length - 1 || editingSlide !== -1"
+                                    @click="moveChildDown(idx)"
+                                    :aria-label="$t('editor.slides.toc.moveSlideDown')"
+                                    style="border: none !important; padding-left: 0.375rem; padding-right: 0.375rem"
+                                    class="respected-standard-button respected-transparent-button rotate-180 transform"
+                                    v-tippy="{
+                                        delay: '200',
+                                        placement: 'top',
+                                        content: $t('editor.slides.toc.moveSlideDown'),
+                                        touch: ['hold', 500]
+                                    }"
+                                >
+                                    <svg
+                                        xmlns="http://www.w3.org/2000/svg"
+                                        xmlns:xlink="http://www.w3.org/1999/xlink"
+                                        x="0px"
+                                        y="0px"
+                                        viewBox="0 0 122.88 66.91"
+                                        style="enable-background: new 0 0 122.88 66.91"
+                                        xml:space="preserve"
+                                        height="14"
+                                        width="14"
+                                        class="fill-current"
+                                    >
+                                        <g>
+                                            <path
+                                                d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95 c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73 c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"
+                                            />
+                                        </g>
+                                    </svg>
+                                </button>
+                            </td>
+                            <!-- Panel # and ID -->
+                            <td style="text-align: left !important" class="truncate px-2">
+                                <div class="px-2">
+                                    <span class="text-gray-600">{{ `${idx + 1}. ` }}</span> {{ item.id }}
+                                </div>
+                            </td>
+                            <!-- Panel type -->
+                            <td style="text-align: left !important">
+                                <span class="mx-2">{{ determineEditorType(item.panel) }}</span>
+                            </td>
+                            <!-- Panel actions -->
+                            <td style="text-align: left !important">
+                                <div class="px-2">
+                                    <!-- Edit panel -->
+                                    <span
+                                        @click="() => switchSlide(idx)"
+                                        @keydown.enter="() => switchSlide(idx)"
+                                        class="slideshow-text-button underline cursor-pointer rounded-sm"
+                                        tabindex="0"
+                                        >{{ $t('editor.chart.label.edit') }}</span
+                                    >
+                                    |
+                                    <!-- Delete panel -->
+                                    <span
+                                        @click="editingSlide === -1 && $vfm.open(`delete-item-${idx}`)"
+                                        @keydown.enter="editingSlide === -1 && $vfm.open(`delete-item-${idx}`)"
+                                        class="slideshow-text-button underline rounded-sm"
+                                        :class="[
+                                            editingSlide === -1
+                                                ? 'text-red-700 cursor-pointer'
+                                                : 'text-gray-600 cursor-not-allowed'
+                                        ]"
+                                        tabindex="0"
+                                        >{{ $t('editor.remove') }}</span
+                                    >
+                                </div>
+                            </td>
 
-            <div v-if="editingSlide !== -1" :style="{ display: editingMode ? 'block' : 'none' }">
+                            <confirmation-modal
+                                :name="`delete-item-${idx}`"
+                                :message="$t('dynamic.panel.remove')"
+                                @ok="() => removeSlide(item as any, idx)"
+                            />
+                        </tr>
+                        <!-- Add new panel row-->
+                        <tr class="table-add-row sticky bottom-1 z-20 bg-white">
+                            <td></td>
+                            <!-- New panel ID input -->
+                            <td class="flex flex-col items-start">
+                                <input
+                                    id="panelId"
+                                    class="respected-standard-input"
+                                    type="text"
+                                    :placeholder="$t('dynamic.panel.enterID')"
+                                    v-model="newSlideName"
+                                    :aria-label="$t('dynamic.panel.enterID')"
+                                />
+                                <p v-if="idUsed" class="text-red-500">{{ $t('dynamic.panel.idTaken') }}</p>
+                            </td>
+                            <!-- New panel type input -->
+                            <td>
+                                <select
+                                    v-model="newSlideType"
+                                    class="respected-standard-select"
+                                    style="width: 80% !important; text-align-last: left !important; text-align: start !important; justify-self: start !important;"
+                                >
+                                    <option v-for="thing in Object.keys(editors)" :key="thing">
+                                        {{ thing }}
+                                    </option>
+                                </select>
+                            </td>
+                            <!-- Confirm new panel creation button -->
+                            <td>
+                                <button
+                                    class="respected-standard-button respected-gray-border-button respected-thin-button justify-self-start"
+                                    @click="createNewSlide"
+                                    :aria-label="$t('dynamic.panel.add')"
+                                    :disabled="idUsed || !newSlideName"
+                                >
+                                    {{ $t('dynamic.panel.add') }}
+                                </button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+
+            <!-- Panel editing area -->
+            <div id="editor-area" v-if="editingSlide !== -1">
                 <br />
                 <hr />
                 <br />
-                <div>
+                <div class="flex justify-between items-center">
+                    <!-- Header: Title, panel # and ID -->
+                    <div class="flex flex-col">
+                        <h2 class="font-bold text-xl">{{ $t('dynamic.panel.editor') }}</h2>
+                        <p class="font-semibold text-md text-gray-500">
+                            {{ `#${editingSlide + 1} - ${panel.children[editingSlide].id}` }}
+                        </p>
+                    </div>
+                    <!-- Done button: closes panel editing area -->
                     <button
                         class="respected-standard-button respected-black-bg-button"
                         @click="switchSlide(-1)"
@@ -105,6 +245,8 @@
                         {{ $t('editor.done') }}
                     </button>
                 </div>
+
+                <!-- Actual panel editor -->
                 <component
                     ref="slide"
                     :is="editors[determineEditorType(panel.children[editingSlide].panel)]"
@@ -173,7 +315,6 @@ export default class DynamicEditorV extends Vue {
     startingConfig: DefaultConfigs = JSON.parse(JSON.stringify(BaseStartingConfig));
 
     editingStatus = 'text';
-    editingMode = false;
     editingSlide = -1;
 
     newSlideName = '';
@@ -181,6 +322,49 @@ export default class DynamicEditorV extends Vue {
 
     get idUsed(): boolean {
         return this.panel.children.some((ch: DynamicChildItem) => ch.id === this.newSlideName);
+    }
+
+    moveChildUp(index: number): void {
+        if (index === 0) {
+            return;
+        }
+        const item = JSON.parse(JSON.stringify(this.panel.children[index]));
+        this.panel.children.splice(index, 1);
+        this.panel.children.splice(index - 1, 0, item);
+
+        // Just in case we decide to allow it: handling edge case where a child
+        // being edited is moved. In that case, ensure focus remains on that child
+        if (this.editingSlide !== -1) {
+            // If child being edited is current child
+            if (this.editingSlide === index) {
+                this.editingSlide -= 1;
+                // If child being edited is previous child (shift it down)
+            } else if (this.editingSlide === index - 1) {
+                this.editingSlide += 1;
+            }
+        }
+    }
+
+    moveChildDown(index: number): void {
+        if (index === this.panel.children.length - 1) {
+            return;
+        }
+
+        const item = JSON.parse(JSON.stringify(this.panel.children[index]));
+        this.panel.children.splice(index, 1);
+        this.panel.children.splice(index + 1, 0, item);
+
+        // Just in case we decide to allow it: handling edge case where a child
+        // being edited is moved. In that case, ensure focus remains on that child
+        if (this.editingSlide !== -1) {
+            // If child being edited is current child
+            if (this.editingSlide === index) {
+                this.editingSlide += 1;
+                // If child being edited is next child (shift it up)
+            } else if (this.editingSlide === index + 1) {
+                this.editingSlide -= 1;
+            }
+        }
     }
 
     changePanel(target: string): void {
@@ -195,12 +379,16 @@ export default class DynamicEditorV extends Vue {
             // user pressed Done, so apply styles to the last active slide
             const editedPanel = this.panel.children[this.editingSlide].panel;
             applyTextAlign(editedPanel, this.centerSlide, this.dynamicSelected);
-            this.editingMode = false;
+            this.editingSlide = -1;
         } else {
-            // Save slide changes if neccessary and switch to the newly selected slide.
+            // Save slide changes if necessary and switch to the newly selected slide.
             this.saveChanges();
-            this.editingMode = true;
             this.editingSlide = idx;
+
+            // After switching the edit status, scroll to the add button.
+            this.$nextTick(() => {
+                document.getElementById('editor-area')?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            });
         }
     }
 
@@ -217,7 +405,6 @@ export default class DynamicEditorV extends Vue {
                 this.editingSlide = -1;
             }
         }
-        this.editingMode = false;
     }
 
     createNewSlide(): void {
@@ -228,7 +415,7 @@ export default class DynamicEditorV extends Vue {
             panel: JSON.parse(JSON.stringify(this.startingConfig[this.newSlideType as keyof DefaultConfigs]))
         };
         this.editingSlide = this.panel.children.length;
-        this.editingMode = false;
+        // this.editingMode = false;
         this.newSlideName = '';
         this.panel.children.push(newConfig);
     }
@@ -248,6 +435,7 @@ export default class DynamicEditorV extends Vue {
 
     saveChanges(): void {
         if (
+            this.editingSlide !== -1 &&
             this.$refs.slide !== undefined &&
             typeof (this.$refs.slide as ImageEditorV | ChartEditorV).saveChanges === 'function'
         ) {
@@ -279,16 +467,30 @@ export default class DynamicEditorV extends Vue {
     text-align: center;
     border-top: 1px solid #ddd;
     padding: 5px;
+    padding-bottom: 0 !important;
 }
 
 .table-add-row input[type='text'],
 .table-add-row select,
 .table-add-row button {
-    width: 150px !important;
+    width: 250px !important;
+    max-width: 100% !important;
+    padding-top: 3px !important;
+    padding-bottom: 3px !important;
+}
+
+.table-add-row button {
+    width: 180px !important;
+    max-width: 100% !important;
     text-align: center;
-    font-weight: normal;
-    //border: 1px solid black;
-    padding: 2px !important;
-    margin-top: 0 !important;
+    padding: 3px !important;
+}
+
+.table-add-row select {
+    width: 180px !important;
+    max-width: 100% !important;
+    text-align: center;
+    padding-top: 4.5px !important;
+    padding-bottom: 4.5px !important;
 }
 </style>

--- a/src/components/panel-editors/slideshow-editor.vue
+++ b/src/components/panel-editors/slideshow-editor.vue
@@ -123,7 +123,8 @@
                             </button>
                         </td>
                         <td style="text-align: left !important" class="truncate">
-                            {{ idx + 1 }}. {{ (item as any).title || $t('editor.slideshow.noTitle') }}
+                            <span class="ml-2 text-gray-600">{{ `${idx + 1}. ` }}</span>
+                            {{ (item as any).title || $t('editor.slideshow.noTitle') }}
                         </td>
                         <td>{{ $t(`editor.slide.panel.type.${item.type}`) }}</td>
                         <td :class="{ 'rounded-br': idx === panel.items.length - 1 }">
@@ -136,9 +137,14 @@
                             >
                             |
                             <a
-                                @click="deleteItem(idx)"
-                                @keydown.enter="deleteItem(idx)"
-                                class="slideshow-text-button underline cursor-pointer rounded-sm text-red-700"
+                                @click="editingStatus !== 'edit' && deleteItem(idx)"
+                                @keydown.enter="editingStatus !== 'edit' && deleteItem(idx)"
+                                class="slideshow-text-button underline rounded-sm"
+                                :class="[
+                                    editingStatus !== 'edit'
+                                        ? 'text-red-700 cursor-pointer'
+                                        : 'text-gray-600 cursor-not-allowed'
+                                ]"
                                 tabindex="0"
                                 >{{ $t('editor.remove') }}</a
                             >
@@ -184,20 +190,22 @@
             </span>
         </button>
 
-        <br /><br />
-        <div
-            id="create-and-edit-area"
-            v-if="editingStatus !== 'none'"
-            class="border rounded-md p-4"
-            :class="[editingStatus !== 'create' ? 'border-blue-300' : 'border-gray-300']"
-        >
-            <div class="flex w-full justify-between items-center">
-                <h2 class="text-xl font-semibold">
-                    {{
-                        $t(`editor.slideshow.label.${editingStatus}`) +
-                        (editingStatus === 'edit' ? ` (#${editingIdx + 1})` : '')
-                    }}
-                </h2>
+        <br />
+        <hr />
+        <br />
+        <div id="create-and-edit-area" v-if="editingStatus !== 'none'">
+            <div class="flex w-full justify-between items-center mb-2">
+                <div class="flex flex-col">
+                    <h2 class="text-xl font-bold">
+                        {{ $t(`editor.slideshow.label.${editingStatus}`) }}
+                    </h2>
+                    <p v-if="editingStatus === 'edit'" class="font-semibold text-md text-gray-500">
+                        {{
+                            `#${editingIdx + 1} - ` + (panel.items[editingIdx].title || $t('editor.slideshow.noTitle'))
+                        }}
+                    </p>
+                </div>
+
                 <!-- Save new slide -->
                 <button
                     v-if="editingStatus === 'create'"
@@ -258,7 +266,7 @@
                 </button>
             </div>
 
-            <hr class="border-solid border-t-2 border-gray-300 my-2" />
+            <!--            <hr class="border-solid border-t-2 border-gray-300 my-2" />-->
             <div>
                 <div class="mt-3" v-if="editingStatus === 'create'">
                     <!-- Creating new slide -->

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -18,7 +18,7 @@ dynamic.panel.id,Panel ID,1,No d’identification du panneau,1
 dynamic.panel.type,Panel Type,1,Type de panneaux,1
 dynamic.panel.actions,Panel Actions,1,Actions du panneau,1
 dynamic.panel.idTaken,Panel ID is already in use,1,Le nom du panneau est déjà utilisé,1
-dynamic.panel.editor,Panel Editor:,1,Éditeur de panneaux:,1
+dynamic.panel.editor,Panel Editor,1,Éditeur de panneaux,1
 dynamic.panel.remove,Are you sure you want to remove this panel?,1,Etes-vous sûr de vouloir supprimer ce panneau?,0
 dynamic.panel.enterID,Enter Panel ID,1,Entrez l'ID du panneau,0
 dynamic.panel.add,Add New,1,Ajouter un nouveau,0


### PR DESCRIPTION
### Related Item(s)

Issue #658 

### Changes
- [FEATURE] Redesigns the dynamic editor panel collection, with the same principles as the slideshow editor table redesign.
  - General design refresh for the entire table.
  - Allows for reordering the rows in the table (this doesn't change your self-created order in the text section, obviously)
  - Sets the colour of the index of each row to light gray to differentiate from the title/ID
  - Adds the number of panel children to the `Panel Collection` header button, for easy reference
  - Adds a `Done` button to allow closing the panel editor area
  - Adds the panel title/ID to the header in the panel editor area
- [FIX] Implements some of the new design choices into the slideshow editor table too: the "panel editor" headings and borders (no more borders, headings simplified); the gray-coloured row indexes.

### Notes
There's a lot of extremely similar code between the slideshow editor table and the dynamic editor one. Maybe we should make a common `RespectTable` component that's used by both?

<img width="1648" alt="image" src="https://github.com/user-attachments/assets/46f18fe1-f39c-4f92-aeea-5eeaab5b546a" />

### Testing
Steps:
1. Open any product.
2. Open/create a slide with a dynamic panel.
3. Click `Panel Collection`.
4. Try out the new table!
5. Open/create a slide with a slideshow panel.
6. Notice the minor changes (click `Edit` on any table row to see the "panel editor"'s new header/no-border design).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/659)
<!-- Reviewable:end -->
