### PR TITLE
Slackbot: Update Ubuntu version

### DIFF
--- a/.github/workflows/slack-bot.yml
+++ b/.github/workflows/slack-bot.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   post-to-slack:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check user permissions (allow only those w/ write access)
         id: permission_check


### PR DESCRIPTION
Change slackbot ubuntu version to `ubuntu-latest`. Previously used version was depreciated, breaking the Github Action.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/663)
<!-- Reviewable:end -->
