### PR TITLE
refactor: Standardize more common CSS elements

### DIFF
--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -220,7 +220,7 @@
                                 name: 'editor',
                                 params: { lang: currentRoute.includes('#/en') ? 'fr' : 'en', uid: uuid }
                             }"
-                            class="underline text-black font-medium px-2"
+                            class="respected-standard-link-button px-2"
                         >
                             <a>
                                 {{ currentRoute.includes('#/en') ? 'Français' : 'English' }}
@@ -897,16 +897,9 @@ window.addEventListener('resize', () => {
 }
 
 .toc-popup-button {
-    border: 1px solid rgb(135, 135, 135);
+    border: 1px solid rgb(209, 213, 219);
     background-color: rgb(243, 243, 243);
-    border-radius: 5px;
-    padding: 3px 12px;
-}
-.toc-popup-button:hover {
-    background-color: rgb(234, 234, 234);
-}
-.toc-popup-button:active {
-    background-color: rgb(221, 221, 221);
+    font-weight: 500 !important;
 }
 
 // Independent scrollable editor area only on desktop, so that header isn't fixed on mobile

--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -27,7 +27,7 @@
                 :to="{ name: 'home', params: { lang: currLang === 'en' ? 'fr' : 'en' } }"
                 v-if="!sourceFile.includes('index-ca')"
             >
-                <div class="underline">{{ `${currLang === 'en' ? 'Français' : 'English'}` }}</div>
+                <div class="respected-standard-link-button">{{ `${currLang === 'en' ? 'Français' : 'English'}` }}</div>
             </router-link>
         </header>
         <div class="relative" style="margin-right: 10%; margin-left: 10%">

--- a/src/components/metadata/metadata-editor.vue
+++ b/src/components/metadata/metadata-editor.vue
@@ -35,7 +35,9 @@
                             params: { lang: currLang === 'en' ? 'fr' : 'en', uid: uuid }
                         }"
                     >
-                        <div class="underline">{{ `${currLang === 'en' ? 'Français' : 'English'}` }}</div>
+                        <div class="respected-standard-link-button">
+                            {{ `${currLang === 'en' ? 'Français' : 'English'}` }}
+                        </div>
                     </router-link>
                 </header>
                 <!-- Main section: Page body content -->

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -102,7 +102,7 @@
                         <span class="ml-auto"></span>
                     </div>
                     <!-- Whole-slide options -->
-                    <div class="flex flex-col lg:flex-row mt-3 gap-y-3 gap-x-7 flex-wrap">
+                    <div class="respected-standard-options-area mt-3">
                         <!-- Center slide content -->
                         <div class="flex flex-row" :class="{ 'items-center': !currentRoute.includes('index-ca') }">
                             <input
@@ -403,7 +403,7 @@
                     </div>
                 </div>
                 <!-- Panel options -->
-                <div v-if="!advancedEditorView" class="flex flex-col lg:flex-row mt-3 gap-y-3 gap-x-7 flex-wrap">
+                <div v-if="!advancedEditorView" class="respected-standard-options-area mt-3">
                     <!-- Make the current panel the full slide -->
                     <div
                         class="flex flex-row"

--- a/src/components/slide-toc/slide-toc.vue
+++ b/src/components/slide-toc/slide-toc.vue
@@ -65,13 +65,17 @@
             <p class="ml-auto"></p>
             <!-- Add new slide button -->
             <!-- New slide will have a blank ENG and FR config, with some exceptions -->
-            <button class="mx-auto toc-popup-button py-0 px-2 border-gray-300 font-semibold" @click="addNewSlide">
+            <button
+                class="respected-standard-button toc-popup-button"
+                style="padding: 2px 8px !important"
+                @click="addNewSlide"
+            >
                 <span class="inline-block pr-1"
                     ><svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 24 24">
                         <path d="M24 10h-10v-10h-4v10h-10v4h10v10h4v-10h10z" />
                     </svg>
                 </span>
-                <span class="inline-block text-sm font-normal">{{ $t('editor.slides.addSlide') }}</span>
+                <span class="inline-block text-sm">{{ $t('editor.slides.addSlide') }}</span>
             </button>
             <br />
         </div>

--- a/src/components/support/colour-picker-input.vue
+++ b/src/components/support/colour-picker-input.vue
@@ -24,7 +24,7 @@
                 </div>
                 <input
                     :disabled="disabled"
-                    class="text-center py-2 rounded-r hover:bg-gray-100"
+                    class="text-center py-2 rounded ml-1 hover:bg-gray-100"
                     :aria-label="name"
                     :value="selectedColour"
                     @input="(evt) => selectedColour = (evt.target as HTMLInputElement).value"

--- a/src/standard-components.css
+++ b/src/standard-components.css
@@ -8,6 +8,29 @@
 
 /* Standard components */
 
+/* Standard 'link' button */
+.respected-standard-link-button {
+    text-decoration: underline;
+    color: black;
+    font-weight: 500;
+
+}
+
+/* Standard panel/slide options area */
+.respected-standard-options-area {
+    @apply bg-gray-100 flex flex-col lg:flex-row gap-y-3 gap-x-7 flex-wrap;
+    /*background-color: rgb(245, 245, 246);*/
+    padding: 4px 12px;
+    border-radius: 5px;
+    width: 100%;
+}
+
+@media (min-width: 1024px) {
+    .respected-standard-options-area {
+        width: fit-content;
+    }
+}
+
 /* Standard button base */
 .respected-standard-button {
     border-radius: 5px;


### PR DESCRIPTION
### Related Item(s)

Issue #502 

### Changes
- Adds more elements to the standard components CSS set: the "major link button" (currently used for the page language toggle), and the slide/panel options area.
  - Adds a slight background to the options area, to clearly indicate that these are the slide/panel "settings". This was in the UI/UX team wireframes from way back.
- Refactors the ToC new slide/open metadata modal button to use the `standard-button` set.
- Slightly tweaks the design of the colour picker element.

### Notes

<img width="1780" alt="image" src="https://github.com/user-attachments/assets/5fdae621-c1b5-48e3-b788-8ba5182bb45f" />

_Not a huge difference_

### Testing
Steps:
1. Open any product.
2. Open/create a slide.
3. You can see all the changes above at a glance. See if they look alright.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/666)
<!-- Reviewable:end -->
