### PR TITLE
Fix panel styling within slides and slide title updates

### DIFF
--- a/src/components/helpers/custom-editor.vue
+++ b/src/components/helpers/custom-editor.vue
@@ -60,7 +60,7 @@
 </template>
 
 <script lang="ts">
-import { Options, Prop, Vue } from 'vue-property-decorator';
+import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
 import { Vue3JsonEditor } from 'vue3-json-editor';
 import { Validator } from 'jsonschema';
 
@@ -82,6 +82,12 @@ export default class CustomEditorV extends Vue {
     showErrors = false;
 
     storylinesSchema = '';
+
+    @Watch('config', { immediate: true, deep: true })
+    onConfigChanged(newConfig: any) {
+        this.updatedConfig = JSON.parse(JSON.stringify(newConfig));
+        // this.validate();
+    }
 
     mounted(): void {
         import('ramp-storylines_demo-scenarios-pcar/dist/StorylinesSchema.json').then((StorylinesSchema) => {
@@ -114,6 +120,7 @@ export default class CustomEditorV extends Vue {
         this.edited = true;
         this.jsonError = '';
         this.$emit('slide-edit');
+        this.$emit('title-edit', json.title);
 
         // if there are no validation errors update the slide config
         const valid = this.validate();

--- a/src/components/map-editor.vue
+++ b/src/components/map-editor.vue
@@ -129,7 +129,9 @@ export default class MapEditorV extends Vue {
         }
 
         if (this.centerSlide && this.dynamicSelected) {
-            this.panel.customStyles += 'text-align: left !important;';
+            if (!this.panel.customStyles?.includes('text-align: left !important;')) {
+                this.panel.customStyles = (this.panel.customStyles || '') + 'text-align: left !important;';
+            }
         } else if (!this.centerSlide && this.dynamicSelected) {
             this.panel.customStyles = (this.panel.customStyles || '').replace('text-align: left !important;', '');
         }

--- a/src/components/text-editor.vue
+++ b/src/components/text-editor.vue
@@ -402,7 +402,9 @@ export default class TextEditorV extends Vue {
 
     mounted(): void {
         if (this.centerSlide && this.dynamicSelected) {
-            this.panel.customStyles += 'text-align: left !important;';
+            if (!this.panel.customStyles?.includes('text-align: left !important;')) {
+                this.panel.customStyles = (this.panel.customStyles || '') + 'text-align: left !important;';
+            }
         } else if (!this.centerSlide && this.dynamicSelected) {
             this.panel.customStyles = (this.panel.customStyles || '').replace('text-align: left !important;', '');
         }

--- a/src/components/video-editor.vue
+++ b/src/components/video-editor.vue
@@ -194,7 +194,9 @@ export default class VideoEditorV extends Vue {
             }
         }
         if (this.centerSlide && this.dynamicSelected) {
-            this.panel.customStyles += 'text-align: left !important;';
+            if (!this.panel.customStyles?.includes('text-align: left !important;')) {
+                this.panel.customStyles = (this.panel.customStyles || '') + 'text-align: left !important;';
+            }
         } else if (!this.centerSlide && this.dynamicSelected) {
             this.panel.customStyles = (this.panel.customStyles || '').replace('text-align: left !important;', '');
         }


### PR DESCRIPTION
### Related Item(s)
Issues #570 and #660

### Changes
- Updated panel styling in dynamic slides so that `customStyles` updates properly and does not contain `undefined` or duplicates.
- Slide title changes and toggling of `Center slide content` or `Include in table of contents` now update immediately in the advanced editor without needing to switch tabs first.

### Testing
Steps:
1. In any slide, open the advanced editor tab and change the title from the slide title input.
2. Confirm the config updates with new title without switching tabs.
3. Create a dynamic panel, toggle `Center slide content`, and add panels.
4. Open the advanced editor to verify that `customStyles` are applied correctly without duplication or undefined values.
5. While still in the `Advanced` tab, toggle `Center slide content` or `Include in table of contents` and verify the changes reflected in the editor. 
