### PR TITLE
Fix ability to create new product

### DIFF
--- a/src/components/metadata/metadata-editor.vue
+++ b/src/components/metadata/metadata-editor.vue
@@ -2030,6 +2030,8 @@ export default class MetadataEditorV extends Vue {
                         this.loadStatus = 'waiting';
                         this.clearConfig();
                     });
+            } else {
+                this.loadConfig();
             }
         } else {
             this.loadConfig();


### PR DESCRIPTION
### Related Item(s)
#669

### Changes
- Ensure that `loadConfig()` is called within `correctUuid` when the uuid has no need to be corrected (as is the case when creating a new product)

### Testing
Steps:
1. Try creating a new product and click Next
2. Ensure that you are navigated to `editor-main`
3. Make some changes and ensure that you can save the product

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/670)
<!-- Reviewable:end -->
