### PR TITLE
added iframe title

### DIFF
--- a/src/components/support/video-preview.vue
+++ b/src/components/support/video-preview.vue
@@ -23,6 +23,7 @@
                         :height="file.height ? file.height : 400"
                         :width="file.width"
                         allowfullscreen
+                        :title="file.title"
                     ></iframe>
                 </template>
 


### PR DESCRIPTION
### Related Item(s)
Issue #492 

### Changes
Added a title attribute for the iframe for youtube videos

### Notes
The title attribute is set to the link of the youtube video, wondering if it should be more descriptive or not 

### Testing
Steps:
1. Check for a title attribute for the iframe
2. Title!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/673)
<!-- Reviewable:end -->
