### PR TITLE
styling fix for dynamic slide panels tab

### DIFF
--- a/src/components/metadata/metadata-editor.vue
+++ b/src/components/metadata/metadata-editor.vue
@@ -2030,6 +2030,8 @@ export default class MetadataEditorV extends Vue {
                         this.loadStatus = 'waiting';
                         this.clearConfig();
                     });
+            } else {
+                this.loadConfig();
             }
         } else {
             this.loadConfig();

--- a/src/components/panel-editors/dynamic-editor.vue
+++ b/src/components/panel-editors/dynamic-editor.vue
@@ -30,7 +30,7 @@
             ></component>
         </div>
         <div v-if="editingStatus === 'panels'">
-            <table class="w-2/3 mt-5">
+            <table style="width: 66.66%; min-width: 500px" class="mt-5">
                 <tr class="table-header">
                     <th>{{ $t('dynamic.panel.id') }}</th>
                     <th>{{ $t('dynamic.panel.type') }}</th>


### PR DESCRIPTION
### Related Item(s)
Issue #475 

### Changes
In the panel collection tab of dynamic slides, added a minimum size so the table contents will no longer overlap each other if the screen size is decreased

### Testing
Steps:
1. Make a dynamic slide
2. Go to panel collection
3. Decrease the size of your screen
4. No styling overlaps!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/676)
<!-- Reviewable:end -->
