### PR TITLE
Update preview language button

### DIFF
--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -28,10 +28,13 @@
 
                     <button
                         @click="changeLang"
-                        class="respected-standard-button respected-black-bg-button max-h-[40px] mr-2"
+                        class="respected-standard-button respected-black-bg-button max-h-[40px]"
+                        style="margin-right: 0.5rem"
                     >
                         <span class="inline-block">{{
-                            lang === 'en' ? $t('editor.lang.fr') : $t('editor.lang.en')
+                            lang === 'en'
+                                ? $t('editor.lang.fr', 1, { locale: 'fr' })
+                                : $t('editor.lang.en', 1, { locale: 'en' })
                         }}</span>
                     </button>
                 </header>


### PR DESCRIPTION
### Related Item(s)
#439 

### Changes
- Fixed the language switch button in the Preview display to show the destination language's name in its own language (e.g., button displays `Français` when in English, and `English` when in French).  
- Fixed the `margin-right` styling for the swap language button.

### Notes
* Note for testing: should add at least one slide before showing preview, mainly due to issue #677 

### Testing
Steps:
1. Open `Preview` with at least one slide
2. Confirm that the swap language button displays the name of the destination language in that language.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/678)
<!-- Reviewable:end -->
