### PR TITLE
Remove inner time slider labels

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -14,3 +14,21 @@
 #wb-cont code {
     color: #c7254e !important;
 }
+
+.time-slider .noUi-value {
+    display: none; 
+}
+
+.time-slider .noUi-pips .noUi-value:nth-of-type(2),
+.time-slider .noUi-value:last-of-type {
+    display: block;
+}
+
+.time-slider .noUi-marker {
+    height: 8px !important;
+}
+
+.time-slider .noUi-marker[style*="left: 0%"],
+.time-slider .noUi-marker[style*="left: 100%"] {
+    height: 15px !important;
+}


### PR DESCRIPTION
### Related Item(s)
Issue #300 

### Changes
- Removed most time slider labels, keeping only the first and last labels. 
- Made the first and last tick markers longer to visually see the bounds.

### Notes
- I tested using `nth-child` (e.g., `.time-slider .noUi-pips .noUi-value:nth-child(__n)`) to display every nth label. The problem I found is that it only works well only for certain year ranges and lengths. The spacing can become inconsistent, and labels still get crowded if date ranges more than 80 years. 

### Testing
Steps:
1. Add a map panel.
2. Toggle `Enable time slider`.
3. Click `Edit Time Slider Config` to change the year range. 
4. Open `Preview` and should notice only the first and last markers have labels. Also notice how those markers are longer in height.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/684)
<!-- Reviewable:end -->
