### PR TITLE
Sanitize text panel content upon saving

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
                 "axios": "^1.2.0",
                 "clone-deep": "^4.0.1",
                 "deep-object-diff": "^1.1.9",
+                "dompurify": "^3.2.6",
                 "file-saver": "^2.0.5",
                 "highcharts": "^9.3.2",
                 "highcharts-vue": "^1.4.3",
@@ -4322,9 +4323,13 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.1.6",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.6.tgz",
-            "integrity": "sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ=="
+            "version": "3.2.6",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+            "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+            "license": "(MPL-2.0 OR Apache-2.0)",
+            "optionalDependencies": {
+                "@types/trusted-types": "^2.0.7"
+            }
         },
         "node_modules/earcut": {
             "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "axios": "^1.2.0",
         "clone-deep": "^4.0.1",
         "deep-object-diff": "^1.1.9",
+        "dompurify": "^3.2.6",
         "file-saver": "^2.0.5",
         "highcharts": "^9.3.2",
         "highcharts-vue": "^1.4.3",

--- a/src/components/panel-editors/text-editor.vue
+++ b/src/components/panel-editors/text-editor.vue
@@ -46,6 +46,7 @@ import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
 import { TextPanel } from '@/definitions';
 import WETDashboardItemV from '../support/wet-dashboard-item.vue';
 import WETComponents from '../support/wet-component-templates.json';
+import DOMPurify from 'dompurify';
 
 interface MDEditor {
     insert(callback: (selected: string) => { text: string; selected: string }): void;
@@ -78,7 +79,7 @@ export default class TextEditorV extends Vue {
     }
 
     // Detecting whether the text editor is in fullscreen mode
-    isFullScreen: boolean = false;
+    isFullScreen = false;
     onFullscreenChange(isFullScreen: boolean) {
         this.isFullScreen = isFullScreen;
     }
@@ -403,6 +404,14 @@ export default class TextEditorV extends Vue {
         } else {
             toggle.children[0].style.right = `${-toggleToRightBorder}px`;
         }
+    }
+
+    saveChanges() {
+        this.panel.content = DOMPurify.sanitize(this.panel.content, {
+            FORCE_BODY: true,
+            ADD_TAGS: ['AudioPlayer'],
+            ADD_ATTR: ['transcript']
+        }).replaceAll('audioplayer', 'AudioPlayer');
     }
 
     mounted(): void {

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -781,10 +781,12 @@ export default class SlideEditorV extends Vue {
     saveChanges(): void {
         if (
             this.$refs.editor != null &&
-            typeof (this.$refs.editor as ImageEditorV | ChartEditorV | VideoEditorV | CustomEditorV).saveChanges ===
-                'function'
+            typeof (this.$refs.editor as ImageEditorV | ChartEditorV | VideoEditorV | CustomEditorV | TextEditorV)
+                .saveChanges === 'function'
         ) {
-            (this.$refs.editor as ImageEditorV | ChartEditorV | VideoEditorV | CustomEditorV).saveChanges();
+            (
+                this.$refs.editor as ImageEditorV | ChartEditorV | VideoEditorV | CustomEditorV | TextEditorV
+            ).saveChanges();
         }
     }
 


### PR DESCRIPTION
### Related Item(s)
https://github.com/ramp4-pcar4/storylines/issues/519

### Changes
- Created a `saveChanges` function for text panels, which sanitizes it's content using the `DOMPurify` library


### Testing
Steps:
1. Create a text panel
2. Try to add an external JS script into the text panel's content
   - Can try `<script>`,  `<iframe>`, `<form>`,  `<component>`, `<a>`, `<img>` , `<video>`, `<embed>`, elements with event handlers, `<meta>`, `<object>`,  `<applet>`, `<link>`, `<base>`, `<picture>`,  `<audio>`, `<source>`, `<track>`, `<svg>`, `<math>`, `<template>`, `<details>`, `<summary>`, `<dialog>`, `<bgsound>`, `<isindex>`, `<frame>`, `<frameset>`, `<noframes>`, `<noscript>`
   - Can ask chatGPT for suggestions, as there are quite a lot of possibilities
3. Now navigate to the advanced editor of the same slide, then go back to the text panel
4. Ensure that none of the external scripts you added are in the text panel
5. Try to add an external script again, and press `Save Changes`
6. Ensure that none of the external scripts you added are in the text panel

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/685)
<!-- Reviewable:end -->
