### PR TITLE
Prevent saving invalid config in advanced editor

### DIFF
--- a/src/components/panel-editors/custom-editor.vue
+++ b/src/components/panel-editors/custom-editor.vue
@@ -83,7 +83,7 @@ export default class CustomEditorV extends Vue {
     validatorErrors: any = [];
     showErrors = false;
 
-    storylinesSchema: any = '';
+    storylinesSchema: Record<string, any> = {};
 
     @Watch('config', { immediate: true, deep: true })
     onConfigChanged(newConfig: any) {
@@ -113,28 +113,30 @@ export default class CustomEditorV extends Vue {
     }
 
     // returns true if no validation errors, false if errors
-    validate(): boolean {
+    validate(validateJson?: any): boolean {
         // TODO: add any missing properties in schema as required (e.g. chart options)
-        const checkValidation = this.validator.validate(this.updatedConfig, this.storylinesSchema as any);
+        const checkConfig = validateJson ?? this.updatedConfig;
+
+        const checkValidation = this.validator.validate(checkConfig, this.storylinesSchema as any);
         this.validatorErrors = checkValidation.errors;
         if (this.jsonError) {
             this.validatorErrors.push(this.jsonError);
             return false;
         }
-        return true;
+        return this.validatorErrors.length === 0;
     }
 
     onJsonChange(json: any): void {
-        // json editor library does not contain 2-way v-model binding so need to set manually
-        this.updatedConfig = json;
-        this.edited = true;
         this.jsonError = '';
-        this.$emit('slide-edit');
+        const valid = this.validate(json);
         this.$emit('title-edit', json.title);
 
         // if there are no validation errors update the slide config
-        const valid = this.validate();
         if (valid) {
+            // json editor library does not contain 2-way v-model binding so need to set manually
+            this.updatedConfig = json;
+            this.edited = true;
+            this.$emit('slide-edit');
             this.$emit('config-edited', this.updatedConfig);
         }
     }


### PR DESCRIPTION
### Related Item(s)
Issue #682 

### Changes
- Updated `onJsonChange` to validate the incoming JSON before updating internal state.
- Prevents invalid config edits (like missing title attribute) from being saved in the advanced editor.
- Avoids broken previews by preserving the last valid config.

### Testing
Steps:
1. For any product without configuration errors, delete any required field in the JSON editor (like title, panel, or type.).
2. The `This configuration violates the Storylines schema` pops up.
3. Save the product and reload the page, or just leave the editor.
4. Open the preview, and confirm that the panels are able to load.
5. Return to the advanced editor and confirm that the invalid changes have been reverted back to the last valid JSON state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/690)
<!-- Reviewable:end -->
