### PR TITLE
Add support for captions and transcripts

### DIFF
--- a/src/components/home.vue
+++ b/src/components/home.vue
@@ -291,6 +291,7 @@
                                 <input
                                     type="file"
                                     name="folder"
+                                    id="product-folder"
                                     @change="productFolderUploaded"
                                     multiple="false"
                                     webkitdirectory
@@ -841,7 +842,8 @@ td {
     height: 20px;
 }
 
-input[type='file']:not(:focus-visible) {
+#product-zip-file:not(:focus-visible),
+#product-folder:not(:focus-visible) {
     position: absolute !important;
     width: 1px !important;
     height: 1px !important;

--- a/src/components/panel-editors/video-editor.vue
+++ b/src/components/panel-editors/video-editor.vue
@@ -106,15 +106,168 @@
                 :lang="lang"
                 @delete="deleteVideo"
             >
-                <!-- <div class="flex mt-4 items-center w-full text-left">
-                    <label class="text-label">{{ $t('editor.video.label.captions') }}:</label>
-                    <input class="w-4/5" type="file" @change="updateCaptions" />
-                </div>
+                <div class="caption-transcript">
+                    <!-- Captions dont work for YT videos -->
+                    <div
+                        class="flex flex-col gap-1 mt-4 ml-1 w-full text-left"
+                        v-if="videoPreview.videoType !== 'YouTube'"
+                    >
+                        <div class="flex justify-start items-center">
+                            <label for="caption-input" class="text-label font-semibold"
+                                >{{ $t('editor.video.label.captions') }}:</label
+                            >
+                            <span
+                                class=""
+                                :content="$t('editor.video.caption.info')"
+                                v-tippy="{ placement: 'top', hideOnClick: false, animateFill: true }"
+                                tabindex="0"
+                            >
+                                <svg
+                                    class="fill-current"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                                    width="20"
+                                    height="20"
+                                    viewBox="0 0 416.979 416.979"
+                                    xml:space="preserve"
+                                >
+                                    <g>
+                                        <path
+                                            d="M356.004,61.156c-81.37-81.47-213.377-81.551-294.848-0.182c-81.47,81.371-81.552,213.379-0.181,294.85   c81.369,81.47,213.378,81.551,294.849,0.181C437.293,274.636,437.375,142.626,356.004,61.156z M237.6,340.786   c0,3.217-2.607,5.822-5.822,5.822h-46.576c-3.215,0-5.822-2.605-5.822-5.822V167.885c0-3.217,2.607-5.822,5.822-5.822h46.576   c3.215,0,5.822,2.604,5.822,5.822V340.786z M208.49,137.901c-18.618,0-33.766-15.146-33.766-33.765   c0-18.617,15.147-33.766,33.766-33.766c18.619,0,33.766,15.148,33.766,33.766C242.256,122.755,227.107,137.901,208.49,137.901z"
+                                        />
+                                    </g>
+                                </svg>
+                            </span>
+                        </div>
+                        <div class="flex w-full items-center gap-2 mb-1">
+                            <input
+                                id="caption-input"
+                                class="hidden"
+                                type="file"
+                                @change="updateCaptions"
+                                ref="videoCaptionInput"
+                                accept=".vtt"
+                            />
+                            <input
+                                class="file-input-button"
+                                type="button"
+                                @click="inputCaptionFile"
+                                :value="$t('editor.video.label.chooseFile')"
+                            />
+                            <p class="line-clamp-2">
+                                {{ $t('editor.video.label.captions.uploaded') }}:
+                                {{ videoPreview.caption ? videoPreview.caption.split('/').at(-1) : 'N/A' }}
+                            </p>
+                            <button
+                                class="file-remove-button"
+                                v-if="videoPreview.caption"
+                                @click="deleteCaption"
+                                :aria-label="$t('editor.video.label.captions.delete')"
+                                v-tippy="{
+                                    delay: '200',
+                                    placement: 'top',
+                                    content: $t('editor.video.label.captions.delete'),
+                                    animateFill: true,
+                                    hideOnClick: false
+                                }"
+                            >
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    width="24"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="#000000"
+                                    stroke-width="1"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                >
+                                    <path d="M18 6l-12 12" />
+                                    <path d="M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
 
-                <div class="flex mt-4 items-center w-full text-left">
-                    <label class="text-label">{{ $t('editor.video.label.transcript') }}:</label>
-                    <input class="w-4/5" type="file" @change="updateTranscript" />
-                </div> -->
+                    <div class="flex flex-col gap-1 mt-4 ml-1 w-full text-left">
+                        <div class="flex justify-start items-center">
+                            <label for="transcript-input" class="text-label font-semibold"
+                                >{{ $t('editor.video.label.transcript') }}:</label
+                            >
+                            <span
+                                class=""
+                                :content="$t('editor.video.transcript.info')"
+                                v-tippy="{ placement: 'top', hideOnClick: false, animateFill: true }"
+                                tabindex="0"
+                            >
+                                <svg
+                                    class="fill-current"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    xmlns:xlink="http://www.w3.org/1999/xlink"
+                                    width="20"
+                                    height="20"
+                                    viewBox="0 0 416.979 416.979"
+                                    xml:space="preserve"
+                                >
+                                    <g>
+                                        <path
+                                            d="M356.004,61.156c-81.37-81.47-213.377-81.551-294.848-0.182c-81.47,81.371-81.552,213.379-0.181,294.85   c81.369,81.47,213.378,81.551,294.849,0.181C437.293,274.636,437.375,142.626,356.004,61.156z M237.6,340.786   c0,3.217-2.607,5.822-5.822,5.822h-46.576c-3.215,0-5.822-2.605-5.822-5.822V167.885c0-3.217,2.607-5.822,5.822-5.822h46.576   c3.215,0,5.822,2.604,5.822,5.822V340.786z M208.49,137.901c-18.618,0-33.766-15.146-33.766-33.765   c0-18.617,15.147-33.766,33.766-33.766c18.619,0,33.766,15.148,33.766,33.766C242.256,122.755,227.107,137.901,208.49,137.901z"
+                                        />
+                                    </g>
+                                </svg>
+                            </span>
+                        </div>
+
+                        <div class="flex w-full items-center gap-2 mb-1">
+                            <input
+                                id="transcript-input"
+                                class="hidden"
+                                type="file"
+                                @change="updateTranscript"
+                                ref="videoTranscriptInput"
+                                accept=".html,.md"
+                            />
+                            <input
+                                class="file-input-button"
+                                type="button"
+                                @click="inputTranscriptFile"
+                                :value="$t('editor.video.label.chooseFile')"
+                            />
+                            <p class="line-clamp-2 w-3/5">
+                                {{ $t('editor.video.label.transcript.uploaded') }}:
+                                {{ videoPreview.transcript ? videoPreview.transcript.split('/').at(-1) : 'N/A' }}
+                            </p>
+                            <button
+                                class="file-remove-button"
+                                :aria-label="$t('editor.video.label.transcript.delete')"
+                                v-if="videoPreview.transcript"
+                                @click="deleteTranscript"
+                                v-tippy="{
+                                    delay: '200',
+                                    placement: 'top',
+                                    content: $t('editor.video.label.transcript.delete'),
+                                    animateFill: true,
+                                    hideOnClick: false
+                                }"
+                            >
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    width="24"
+                                    height="24"
+                                    viewBox="0 0 24 24"
+                                    fill="none"
+                                    stroke="#000000"
+                                    stroke-width="1"
+                                    stroke-linecap="round"
+                                    stroke-linejoin="round"
+                                >
+                                    <path d="M18 6l-12 12" />
+                                    <path d="M6 6l12 12" />
+                                </svg>
+                            </button>
+                        </div>
+                    </div>
+                </div>
             </VideoPreview>
         </div>
     </div>
@@ -191,8 +344,18 @@ export default class VideoEditorV extends Vue {
                     src: this.panel.src
                 };
             }
+            this.videoPreview.caption = this.panel.caption ?? '';
+            this.videoPreview.transcript = this.panel.transcript ?? '';
         }
         applyTextAlign(this.panel, this.centerSlide, this.dynamicSelected);
+    }
+
+    inputCaptionFile() {
+        document.querySelector('#caption-input').click();
+    }
+
+    inputTranscriptFile() {
+        document.querySelector('#transcript-input').click();
     }
 
     // adds an uploaded file that is either a: video, transcript or captions
@@ -200,8 +363,8 @@ export default class VideoEditorV extends Vue {
         const { inSharedAsset, newAssetName, uploadSource } = await this.productStore.addUploadedFile(file);
 
         // check if source file is creating a new video or uploading captions/transcript for current video
-        const fileSrc = URL.createObjectURL(file);
         if (type === 'src') {
+            const fileSrc = URL.createObjectURL(file);
             const assetName = inSharedAsset ? newAssetName : file.name;
             this.videoPreview = {
                 id: uploadSource,
@@ -211,7 +374,7 @@ export default class VideoEditorV extends Vue {
             };
             this.findFileType(assetName);
         } else {
-            this.videoPreview[type as 'caption' | 'transcript'] = fileSrc;
+            this.videoPreview[type as 'caption' | 'transcript'] = uploadSource;
         }
         this.edited = true;
         this.$emit('slide-edit');
@@ -280,12 +443,24 @@ export default class VideoEditorV extends Vue {
 
     updateCaptions(e: Event): void {
         const file = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
-        this.addUploadedFile(file, 'caption');
+        if (file.name.split('.').at(-1) === 'vtt') {
+            this.addUploadedFile(file, 'caption').then(() => {
+                this.onVideoEdited();
+            });
+        } else {
+            Message.error(this.$t('editor.video.caption.error'));
+        }
     }
 
     updateTranscript(e: Event): void {
         const file = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
-        this.addUploadedFile(file, 'transcript');
+        if (['html', 'md'].includes(file.name.split('.').at(-1))) {
+            this.addUploadedFile(file, 'transcript').then(() => {
+                this.onVideoEdited();
+            });
+        } else {
+            Message.error(this.$t('editor.video.transcript.error'));
+        }
     }
 
     dropVideo(e: DragEvent): void {
@@ -293,9 +468,9 @@ export default class VideoEditorV extends Vue {
             const file = [...e.dataTransfer.files][0];
             this.addUploadedFile(file, 'src').then(() => {
                 this.dragging = false;
+                this.onVideoEdited();
             });
         }
-        this.onVideoEdited();
     }
 
     deleteVideo(): void {
@@ -310,6 +485,24 @@ export default class VideoEditorV extends Vue {
         (this.$refs.videoFileInput as HTMLInputElement).value = '';
         this.videoPreview = {};
         this.onVideoEdited();
+    }
+
+    deleteCaption(): void {
+        if (this.videoPreview.caption) {
+            this.productStore.decrementSourceCount(this.videoPreview.caption);
+            this.videoPreview.caption = '';
+            (this.$refs.videoCaptionInput as HTMLInputElement).value = '';
+            this.onVideoEdited();
+        }
+    }
+
+    deleteTranscript(): void {
+        if (this.videoPreview.transcript) {
+            this.productStore.decrementSourceCount(this.videoPreview.transcript);
+            this.videoPreview.transcript = '';
+            (this.$refs.videoTranscriptInput as HTMLInputElement).value = '';
+            this.onVideoEdited();
+        }
     }
 
     saveChanges(): void {
@@ -334,6 +527,52 @@ export default class VideoEditorV extends Vue {
 </script>
 
 <style lang="scss" scoped>
+.line-clamp-2 {
+    overflow: hidden;
+    word-wrap: break-word;
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+}
+
+.caption-transcript {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 20px;
+}
+
+.file-input-button {
+    border-radius: 5px;
+    padding: 0.375rem 15px;
+    font-weight: 600;
+    transition-duration: 0.2s;
+    margin: 0;
+    --tw-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
+    box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    border: 1px solid black;
+    height: 40px;
+}
+
+.file-input-button:hover {
+    background-color: rgba(209, 213, 219, var(--tw-border-opacity));
+    color: black;
+}
+
+.file-remove-button {
+    border-radius: 20px;
+    transition-duration: 0.2s;
+    margin: 5px;
+    padding: 2px;
+}
+
+.file-remove-button:hover {
+    background-color: rgba(209, 213, 219, var(--tw-border-opacity));
+}
+
 .upload-video {
     input[type='file']:not(:focus-visible) {
         position: absolute !important;
@@ -353,7 +592,6 @@ export default class VideoEditorV extends Vue {
 }
 
 .text-label {
-    width: 25% !important;
     margin-right: 0.5rem !important;
     margin-bottom: 0 !important;
 }

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -206,10 +206,19 @@ editor.image.altTag,Alt tag,1,Texte de remplacement,1
 editor.image.slideshowCaption,Slideshow caption,1,Légende du diaporama,1
 editor.image.loadingError,An error occurred when trying to load image,1,Une erreur est survenue lors du chargement de l’image.,1
 editor.video.title,Video Title,1,Titre de la vidéo,1
+editor.video.label.chooseFile,Choose File,1,Choisir le fichier,0
 editor.video.label.drag,Drag your video file here,1,Glissez votre fichier vidéo ici,1
 editor.video.label.sizeLimit,({size}MB limit),1,(limite de {size}MB),1
 editor.video.label.captions,Video Captions,1,Sous-titres,1
+editor.video.label.captions.uploaded,Caption uploaded,1,Légende téléchargée,0
+editor.video.label.captions.delete,Delete Caption,1,Enlever la légende,0
+editor.video.caption.info,File must be of type .vtt,1,Le fichier doit être de type .vtt,0
+editor.video.caption.error,Incorrect file type for caption (must be .vtt file),1,Type de fichier incorrect pour la légende (doit être un fichier .vtt),0
 editor.video.label.transcript,Video Transcript,1,Transcription,1
+editor.video.label.transcript.uploaded,Transcript uploaded,1,Transcription téléchargée,0
+editor.video.label.transcript.delete,Delete Transcript,1,Enlever la transcription,0
+editor.video.transcript.info,File must be of type .html or .md,1,Le fichier doit être de type .html ou .md,0
+editor.video.transcript.error,Incorrect file type for transcript (must be .html or .md file),1,Type de fichier incorrect pour la transcription (doit être un fichier .html ou .md),0
 editor.video.label.upload,Upload,1,Télécharger,1
 editor.video.sizeExceeded,File too big!,1,Fichier trop volumineux!,1
 editor.video.label.linkSupport,Supports YouTube links (regular and shortened) as well as direct links to mp4 videos.,1,Prend en charge les liens YouTube (normaux et raccourcis) ainsi que les liens directs vers des vidéos mp4.,1


### PR DESCRIPTION
### Related Item(s)
#267

### Changes
- Add support for uploading caption and transcript for a video


### Notes
- Markdown files are interpreted as plain text in the preview, but are parsed correctly in storylines. Will need to make PR in the other repo to fix that

### Testing
Steps:
1. Create a video panel and upload a video file (ex. mp4)
2. Upload a caption file, which should be a `vtt` file. Heres an example:
```
WEBVTT

00:01.520 --> 00:04.625
Here are some subtitles

00:04.625 --> 00:05.995
And here are some more
```
4. Upload a transcript file, which should be an `html` or `md` file
5. Save changes
6. Open the preview
7. Notice the transcript below the video
8. Play the video and enable captions
9. The captions from the `vtt` file should appear as subtitles
10. Go back and try to upload a caption/transcript that is not a supported file type, and observe the toast error message

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/692)
<!-- Reviewable:end -->
