### PR TITLE
Padding added in time slider editing config range label

### DIFF
--- a/src/components/support/time-slider-editor.vue
+++ b/src/components/support/time-slider-editor.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="px-5 pt-4">
         <div class="flex items-center">
-            <label class="respected-standard-label">{{ $t('editor.map.timeslider.range') }}</label>
+            <label class="respected-standard-label pr-3">{{ $t('editor.map.timeslider.range') }}</label>
             <input
                 class="respected-standard-input"
                 type="number"
@@ -18,7 +18,7 @@
         </div>
         <br />
         <div class="flex items-center">
-            <label class="respected-standard-label">{{ $t('editor.map.timeslider.start') }}</label>
+            <label class="respected-standard-label pr-3">{{ $t('editor.map.timeslider.start') }}</label>
             <input
                 class="respected-standard-input ml-3"
                 type="number"


### PR DESCRIPTION
### Related Item(s)
Issue #686 

### Changes
- Added padding to the range label so the input does not overlap
<img width="568" height="387" alt="image" src="https://github.com/user-attachments/assets/3e3b1997-f62c-4d03-8248-313f41fa82c4" />


### Notes
- I am not sure if this is the optimal way to line up Range: and Start: since they are different widths

### Testing
Steps:
1. Go to a map slide
2. Click edit time slider config
3. No overlapping inputs
