### PR TITLE
Integrate RAMP config editor translations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
                 "markdown-it": "^12.0.6",
                 "marked": "^4.0.10",
                 "nouislider": "^15.5.0",
-                "ramp-config-editor_editeur-config-pcar": "^3.6.0",
+                "ramp-config-editor_editeur-config-pcar": "^4.0.0",
                 "ramp-pcar": "^4.10.2",
                 "ramp-storylines_demo-scenarios-pcar": "^3.5.1",
                 "throttle-debounce": "^5.0.0",
@@ -8723,10 +8723,11 @@
             "optional": true
         },
         "node_modules/ramp-config-editor_editeur-config-pcar": {
-            "version": "3.6.0",
-            "resolved": "https://registry.npmjs.org/ramp-config-editor_editeur-config-pcar/-/ramp-config-editor_editeur-config-pcar-3.6.0.tgz",
-            "integrity": "sha512-ULEi4ELCkhvqzOMxgYirk+sURdJ57IIkX/hDQbjxVu+xA7OgvVPFotHuv8XSCJO4Xbl6DXEFanJB7QlotsXYBQ==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/ramp-config-editor_editeur-config-pcar/-/ramp-config-editor_editeur-config-pcar-4.0.0.tgz",
+            "integrity": "sha512-1AHp5wvMmHOGPBQdYcB5Y4ndVu+q7eQSEM528mmb6HCKBGImaNIUlgHxNwdwjcR6MxAZo6KzeviNPQlFyoOOqQ==",
             "dependencies": {
+                "@rollup/plugin-dsv": "^3.0.4",
                 "deepmerge": "^4.3.1",
                 "pinia": "^2.0.32",
                 "ramp-pcar": "^4.8.0",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "markdown-it": "^12.0.6",
         "marked": "^4.0.10",
         "nouislider": "^15.5.0",
-        "ramp-config-editor_editeur-config-pcar": "^3.6.0",
+        "ramp-config-editor_editeur-config-pcar": "^4.0.0",
         "ramp-pcar": "^4.10.2",
         "ramp-storylines_demo-scenarios-pcar": "^3.5.1",
         "throttle-debounce": "^5.0.0",

--- a/src/components/panel-editors/map-editor.vue
+++ b/src/components/panel-editors/map-editor.vue
@@ -99,6 +99,7 @@ export default class MapEditorV extends Vue {
 
     // config editor
     rampEditorApi: any = '';
+    currLang = 'en';
 
     // For creating new files.
     newFileName = '';
@@ -111,6 +112,7 @@ export default class MapEditorV extends Vue {
     strippedFileName = '';
 
     mounted(): void {
+        this.currLang = (this.$route.params.lang as string) || 'en';
         this.usingTimeSlider = !!this.panel.timeSlider;
         this.status = this.panel.config !== '' ? 'default' : 'creating';
         this.strippedFileName = this.panel.config !== '' ? this.panel.config.split('/')[2].split('.')[0] : '';
@@ -175,6 +177,7 @@ export default class MapEditorV extends Vue {
                 configFile.async('string').then((res: string) => {
                     const conf = JSON.parse(res);
                     this.rampEditorApi = createRampEditorInstance(this.$refs.editor, conf);
+                    this.rampEditorApi.setLanguage(this.currLang);
                 });
             } else {
                 // If it does not exist in the ZIP folder, try and fetch from server.
@@ -183,6 +186,7 @@ export default class MapEditorV extends Vue {
                         let stringResponse = JSON.stringify(res);
                         const conf = JSON.parse(stringResponse);
                         this.rampEditorApi = createRampEditorInstance(this.$refs.editor, conf);
+                        this.rampEditorApi.setLanguage(this.currLang);
                     });
                 });
             }


### PR DESCRIPTION
### Related Item(s)
Closes #695 

### Changes
- integrates config editor translations from latest NPM release using API call

### Testing

Ensure that the RAMP editor aligns with the app language.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/696)
<!-- Reviewable:end -->
