### PR TITLE
Made MD editor French compliant

### DIFF
--- a/src/components/panel-editors/text-editor.vue
+++ b/src/components/panel-editors/text-editor.vue
@@ -43,6 +43,7 @@
 
 <script lang="ts">
 import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
+import VueMarkdownEditor, { langMap } from '@/plugins/markdown-editor/index';
 import { TextPanel } from '@/definitions';
 import { applyTextAlign } from '@/utils/styleUtils';
 import WETDashboardItemV from '../support/wet-dashboard-item.vue';
@@ -73,9 +74,12 @@ export default class TextEditorV extends Vue {
     components: WETComponentsObject = WETComponents;
     pageLang = window.location.href.includes('index-ca-en') ? 'en' : 'fr'; // this is only used if `index-ca` is already in the URL.
 
-    @Watch('panel.content', { deep: true })
+    @Watch('panel.content', { deep: true, immediate: true })
     onContentChanged() {
         this.$emit('slide-edit');
+
+        const currentLocale = this.$i18n.locale === 'fr' ? 'fr-FR' : 'en-US';
+        VueMarkdownEditor.lang.use(currentLocale, langMap[currentLocale]);
     }
 
     // Detecting whether the text editor is in fullscreen mode
@@ -236,152 +240,155 @@ export default class TextEditorV extends Vue {
     // Minor issue when selecting content after clicking a toolbar item: it will always select the first instance of the content string.
     // For example, if your text is "span", changing font size while selecting it won't select <span style...>SPAN</span> afterward, but <SPAN style...>span</span>.
     // The default (module-provided) toolbar items have the same issue (try the content "*" for Bold).
-    toolbar = {
-        fontSize: {
-            title: 'Font Size',
-            text: 'Aa',
-            menus: {
-                itemWidth: '42px',
-                rowNum: 10,
-                items: this.fontSizes.map((fontSize) => {
-                    return {
-                        name: `${fontSize}`,
-                        text: `${fontSize}`,
+    get toolbar() {
+        const vm = this;
+        return {
+            fontSize: {
+                title: this.$t('editor.text.fontsize.title'),
+                text: 'Aa',
+                menus: {
+                    itemWidth: '42px',
+                    rowNum: 10,
+                    items: this.fontSizes.map((fontSize) => {
+                        return {
+                            name: `${fontSize}`,
+                            text: `${fontSize}`,
+                            action(editor: MDEditor): void {
+                                editor.insert((selected: string) => {
+                                    const content = selected || vm.$t('editor.text.fontsize.resize');
+
+                                    const finalText = content
+                                        .split('\n')
+                                        .map((paragraph: any) => {
+                                            if (!paragraph) {
+                                                return '';
+                                            } else if (
+                                                paragraph.charAt(0) === '|' || // table
+                                                paragraph.charAt(0) === '!' || // image
+                                                paragraph.charAt(0) === '`' || // code block
+                                                paragraph === '------------------------------------'
+                                            ) {
+                                                return paragraph;
+                                            } else {
+                                                return `<span style="font-size:${fontSize}px;">${paragraph}</span>`;
+                                            }
+                                        })
+                                        .join('\n');
+
+                                    return {
+                                        text: finalText,
+                                        selected: content
+                                    };
+                                });
+                            }
+                        };
+                    })
+                }
+            },
+            subsuper: {
+                title: this.$t('editor.text.subsuper.title'),
+                text: 'T',
+                menus: [
+                    {
+                        name: this.$t('editor.text.superscript'),
+                        text: this.$t('editor.text.superscript'),
                         action(editor: MDEditor): void {
                             editor.insert((selected: string) => {
-                                const content = selected || `resize`;
-
-                                const finalText = content
-                                    .split('\n')
-                                    .map((paragraph) => {
-                                        if (!paragraph) {
-                                            return '';
-                                        } else if (
-                                            paragraph.charAt(0) === '|' || // table
-                                            paragraph.charAt(0) === '!' || // image
-                                            paragraph.charAt(0) === '`' || // code block
-                                            paragraph === '------------------------------------'
-                                        ) {
-                                            return paragraph;
-                                        } else {
-                                            return `<span style="font-size:${fontSize}px;">${paragraph}</span>`;
-                                        }
-                                    })
-                                    .join('\n');
+                                const content = selected || vm.$t('editor.text.superscript').toLowerCase();
 
                                 return {
-                                    text: finalText,
+                                    text: `<sup>${content}</sup>`,
                                     selected: content
                                 };
                             });
                         }
-                    };
-                })
-            }
-        },
-        subsuper: {
-            title: 'Superscript/Subscript',
-            text: 'T',
-            menus: [
-                {
-                    name: 'Superscript',
-                    text: 'Superscript',
-                    action(editor: MDEditor): void {
-                        editor.insert((selected: string) => {
-                            const content = selected || `superscript`;
+                    },
+                    {
+                        name: this.$t('editor.text.subscript'),
+                        text: this.$t('editor.text.subscript'),
+                        action(editor: MDEditor): void {
+                            editor.insert((selected: string) => {
+                                const content = selected || vm.$t('editor.text.subscript').toLowerCase();
 
-                            return {
-                                text: `<sup>${content}</sup>`,
-                                selected: content
-                            };
-                        });
+                                return {
+                                    text: `<sub>${content}</sub>`,
+                                    selected: content
+                                };
+                            });
+                        }
                     }
-                },
-                {
-                    name: 'Subscript',
-                    text: 'Subscript',
-                    action(editor: MDEditor): void {
-                        editor.insert((selected: string) => {
-                            const content = selected || `subscript`;
+                ]
+            },
+            addLink: {
+                title: this.$t('editor.text.addLink.title'),
+                icon: 'v-md-icon-link',
+                menus: [
+                    {
+                        name: this.$t('editor.text.addLink.external.newTab'),
+                        text: this.$t('editor.text.addLink.external.newTab'),
+                        action(editor: MDEditor): void {
+                            editor.insert((selected: string) => {
+                                const content = selected || vm.$t('editor.text.addLink.text');
 
-                            return {
-                                text: `<sub>${content}</sub>`,
-                                selected: content
-                            };
-                        });
+                                return {
+                                    text: `<a href='http://' target='_blank'>${content}</a>`,
+                                    selected: content
+                                };
+                            });
+                        }
+                    },
+                    {
+                        name: this.$t('editor.text.addLink.external.sameTab'),
+                        text: this.$t('editor.text.addLink.external.sameTab'),
+                        action(editor: MDEditor): void {
+                            editor.insert((selected: string) => {
+                                const content = selected || vm.$t('editor.text.addLink.text');
+
+                                return {
+                                    text: `<a href='http://' target='_self'>${content}</a>`,
+                                    selected: content
+                                };
+                            });
+                        }
+                    },
+                    {
+                        name: this.$t('editor.text.addLink.dynamic'),
+                        text: this.$t('editor.text.addLink.dynamic'),
+                        action(editor: MDEditor): void {
+                            editor.insert((selected: string) => {
+                                const content = selected || vm.$t('editor.text.addLink.text');
+
+                                return {
+                                    text: `<a panel='panel-id-here'>${content}</a>`,
+                                    selected: content
+                                };
+                            });
+                        }
                     }
-                }
-            ]
-        },
-        addLink: {
-            title: 'Insert Link',
-            icon: 'v-md-icon-link',
-            menus: [
-                {
-                    name: 'Add External Link (New Tab)',
-                    text: 'Add External Link (New Tab)',
-                    action(editor: MDEditor): void {
-                        editor.insert((selected: string) => {
-                            const content = selected || `link text`;
+                ]
+            },
+            wetToolbar: {
+                title: this.$t('editor.text.wetToolbar.title'),
+                text: this.$t('editor.text.wetToolbar.text'),
+                action: (editor: MDEditor): void => {
+                    this.wetComponentsVisible = !this.wetComponentsVisible;
 
-                            return {
-                                text: `<a href='http://' target='_blank'>${content}</a>`,
-                                selected: content
-                            };
-                        });
+                    if (this.wetComponentsVisible) {
+                        // Hate using setTimeout, but it seems to be necessary for this scroll to work.
+                        setTimeout(() => {
+                            document
+                                .getElementById('WETDashboard')
+                                ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+                        }, 100);
                     }
-                },
-                {
-                    name: 'Add External Link (Same Tab)',
-                    text: 'Add External Link (Same Tab)',
-                    action(editor: MDEditor): void {
-                        editor.insert((selected: string) => {
-                            const content = selected || `link text`;
 
-                            return {
-                                text: `<a href='http://' target='_self'>${content}</a>`,
-                                selected: content
-                            };
-                        });
+                    if (editor !== undefined) {
+                        this.editor = editor;
                     }
-                },
-                {
-                    name: 'Add Dynamic Link',
-                    text: 'Add Dynamic Link',
-                    action(editor: MDEditor): void {
-                        editor.insert((selected: string) => {
-                            const content = selected || `link text`;
-
-                            return {
-                                text: `<a panel='panel-id-here'>${content}</a>`,
-                                selected: content
-                            };
-                        });
-                    }
-                }
-            ]
-        },
-        wetToolbar: {
-            title: 'WET Components',
-            text: this.pageLang === 'en' ? 'Components' : 'Composantes',
-            action: (editor: MDEditor): void => {
-                this.wetComponentsVisible = !this.wetComponentsVisible;
-
-                if (this.wetComponentsVisible) {
-                    // Hate using setTimeout, but it seems to be necessary for this scroll to work.
-                    setTimeout(() => {
-                        document
-                            .getElementById('WETDashboard')
-                            ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-                    }, 100);
-                }
-
-                if (editor !== undefined) {
-                    this.editor = editor;
                 }
             }
-        }
-    };
+        };
+    }
 
     toolbarOptions = `undo redo clear | h bold italic strikethrough quote subsuper fontSize | ul ol table hr | addLink image code ${
         window.location.href.includes('index-ca') ? '| wetToolbar' : ''

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -174,6 +174,18 @@ editor.enterText,Enter Text,1,Entrer le texte,1
 editor.frenchConfig,View French Config,1,Afficher la configuration en français,1
 editor.englishConfig,View English Config,1,Afficher la configuration en anglais,1
 editor.returnToLanding,Return to Landing,1,Retour à la page d’accueil,1
+editor.text.fontsize.title,Font Size,1,Taille de la police,0
+editor.text.fontsize.resize,resize,1,redimensionner,0
+editor.text.subsuper.title,Superscript/Subscript,1,Exposant/Indice,0
+editor.text.superscript,Superscript,1,Exposant,0
+editor.text.subscript,Subscript,1,Indice,0
+editor.text.addLink.title,Insert Link,1,Insérer un lien,0
+editor.text.addLink.text,link text,1,texte du lien,0
+editor.text.addLink.external.newTab,Add External Link (New Tab),1,Ajouter un lien externe (nouvel onglet),0
+editor.text.addLink.external.sameTab,Add External Link (Same Tab),1,Ajouter un lien externe (même onglet),0
+editor.text.addLink.dynamic,Add Dynamic Link,1,Ajouter un lien dynamique,0
+editor.text.wetToolbar.title,WET Components,1,Composantes WET,0
+editor.text.wetToolbar.text,Components,1,Composantes,0
 editor.image.label.height,Height,1,Hauteur,1
 editor.image.label.width,Width,1,Largeur,1
 editor.image.label.widthWarning,Maximum width is 2/3 (66%) of screen on desktop and 100% on mobile. Larger widths will be ignored.,1,La largeur maximale est de 2/3 (66 %) de l'écran sur les ordinateurs de bureau et de 100 % sur les téléphones portables. Les largeurs plus importantes seront ignorées.,1

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,41 +9,7 @@ import './standard-components.css';
 import { i18n } from './lang';
 
 import 'ramp-pcar/dist/ramp.css';
-import VueMarkdownEditor from '@kangc/v-md-editor/lib/codemirror-editor';
-import '@kangc/v-md-editor/lib/style/base-editor.css';
-import '@kangc/v-md-editor/lib/style/codemirror-editor.css';
-import githubTheme from '@kangc/v-md-editor/lib/theme/github.js';
-import '@kangc/v-md-editor/lib/theme/style/github.css';
-import enUS from '@kangc/v-md-editor/lib/lang/en-US';
-import hljs from 'highlight.js';
-
-// Resources for the codemirror editor
-import Codemirror from 'codemirror';
-// mode
-import 'codemirror/mode/markdown/markdown';
-import 'codemirror/mode/javascript/javascript';
-import 'codemirror/mode/css/css';
-import 'codemirror/mode/htmlmixed/htmlmixed';
-import 'codemirror/mode/vue/vue';
-// edit
-import 'codemirror/addon/edit/closebrackets';
-import 'codemirror/addon/edit/closetag';
-import 'codemirror/addon/edit/matchbrackets';
-// placeholder
-import 'codemirror/addon/display/placeholder';
-// active-line
-import 'codemirror/addon/selection/active-line';
-// scrollbar
-import 'codemirror/addon/scroll/simplescrollbars';
-import 'codemirror/addon/scroll/simplescrollbars.css';
-// style
-import 'codemirror/lib/codemirror.css';
-
-VueMarkdownEditor.Codemirror = Codemirror;
-VueMarkdownEditor.lang.use('en-US', enUS);
-VueMarkdownEditor.use(githubTheme, {
-    Hljs: hljs
-});
+import VueMarkdownEditor from './plugins/markdown-editor/index';
 
 import { createVfm } from 'vue-final-modal';
 import 'vue-final-modal/style.css';

--- a/src/plugins/markdown-editor/index.ts
+++ b/src/plugins/markdown-editor/index.ts
@@ -1,0 +1,38 @@
+import VueMarkdownEditor from '@kangc/v-md-editor/lib/codemirror-editor';
+import '@kangc/v-md-editor/lib/style/base-editor.css';
+import '@kangc/v-md-editor/lib/style/codemirror-editor.css';
+import githubTheme from '@kangc/v-md-editor/lib/theme/github.js';
+import '@kangc/v-md-editor/lib/theme/style/github.css';
+import enUS from '@kangc/v-md-editor/lib/lang/en-US';
+import frFR from '@kangc/v-md-editor/lib/lang/fr-FR';
+import hljs from 'highlight.js';
+
+// Resources for the codemirror editor
+import Codemirror from 'codemirror';
+// mode
+import 'codemirror/mode/markdown/markdown';
+import 'codemirror/mode/javascript/javascript';
+import 'codemirror/mode/css/css';
+import 'codemirror/mode/htmlmixed/htmlmixed';
+import 'codemirror/mode/vue/vue';
+// edit
+import 'codemirror/addon/edit/closebrackets';
+import 'codemirror/addon/edit/closetag';
+import 'codemirror/addon/edit/matchbrackets';
+// placeholder
+import 'codemirror/addon/display/placeholder';
+// active-line
+import 'codemirror/addon/selection/active-line';
+// scrollbar
+import 'codemirror/addon/scroll/simplescrollbars';
+import 'codemirror/addon/scroll/simplescrollbars.css';
+// style
+import 'codemirror/lib/codemirror.css';
+
+VueMarkdownEditor.Codemirror = Codemirror;
+VueMarkdownEditor.use(githubTheme, {
+    Hljs: hljs
+});
+
+export const langMap = { 'en-US': enUS, 'fr-FR': frFR };
+export default VueMarkdownEditor;

--- a/src/shims-vue.d.ts
+++ b/src/shims-vue.d.ts
@@ -11,6 +11,7 @@ declare module '*lang.csv' {
 
 declare module '@kangc/v-md-editor';
 declare module '@kangc/v-md-editor/lib/lang/en-US';
+declare module '@kangc/v-md-editor/lib/lang/fr-FR';
 declare module '@kangc/v-md-editor/lib/theme/github.js';
 declare module 'highcharts-accessible-configuration-kit';
 declare module 'ramp-storylines_demo-scenarios-pcar';


### PR DESCRIPTION
### Related Item(s)
Issue #698 

### Changes
- Added French language support for Vue Markdown Editor tooltips.
- Updated custom toolbar items (`fontSize`, `addLink`, `subsuper`, and `wetToolbar`) to use `$t()` for translated strings.

### Testing
Steps:
1. Change language to French.
2. Open any Text Editor panel.
3. The tooltips should now be in French. 
4. Switch back to English and confirm tooltips update accordingly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/712)
<!-- Reviewable:end -->
