### PR TITLE
Add keyboard accessibility for Text Editor ToC

### DIFF
--- a/src/components/slide-toc/slide-toc.vue
+++ b/src/components/slide-toc/slide-toc.vue
@@ -97,6 +97,12 @@
                 :list="slides"
                 @update="$emit('slides-updated', slides)"
                 :item-key="getSlideId"
+                v-tippy="{
+                    trigger: 'focus',
+                    delay: '200',
+                    placement: 'top',
+                    content: $t('editor.slides.toc.selectSlide')
+                }"
                 v-focus-list
             >
                 <template #item="{ element, index }">

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -257,6 +257,7 @@ editor.slides.copyAll,Copy all,1,Copier tout,1
 editor.slides.copyAll.confirm,Are you sure you want to copy all slides?,1,Êtes-vous sûr de vouloir copier toutes les diapositives ?,0
 editor.slides.copy,Copy,1,Copier,1
 editor.slides.slide,Slide,1,Diapositive,1
+editor.slides.toc.selectSlide,Use arrow keys to navigate between panes,1,Utilisez les touches fléchées pour naviguer entre les volets,0
 editor.slides.toc.closeToC,Close table of content sidebar,1,Fermer la barre latérale du sommaire,1
 editor.slides.toc.noSlides,No Slides,1,Pas de diapositives,0
 editor.slides.toc.selectNewSlideMessage,Select 'New Blank Slide' to add your first slide.,1,Sélectionnez « Nouvelle diapositive vierge » pour ajouter votre première diapositive.,0
@@ -305,6 +306,7 @@ editor.slides.panelNumber,Panel {num},1,Panneau {num},0
 editor.slides.panel.body,Panel body,1,Corps du panneau,1
 editor.slides.panel.title,Panel title,1,Titre du panneau,1
 editor.slides.panel.textEntry,Panel text entry,1,Saisie de texte dans le panneau,1
+editor.slides.panel.toc,Press enter or space to access TOC panel,1,Appuyez sur Entrée ou sur la barre d'espace pour accéder au panneau TOC,0
 editor.slide.panel.type.text,Text,1,Texte,1
 editor.slide.panel.type.image,Image,1,Image,1
 editor.slide.panel.type.slideshow,Slideshow,1,Diaporama,1


### PR DESCRIPTION
### Related Item(s)
Issue #704 

### Changes
- Made the Text Editor ToC keyboard-accessible and tabbable.
- User must press `Enter` or `Space` to navigate through each ToC item.
- Also added a tooltip on the `Slides ToC` for accessibility guidance. 

### Notes
- The tabbing order currently goes toc &rarr; toolbar &rarr; editor. 
So after pressing `Enable toc` in the toolbar using the keyboard, you'd have to `Shift tab` to be able to access the toc. I don't think this is a major issue, but I'd also like to hear everyone’s thoughts.

- I tried to see if I could change the tabbing order, and one way is moving the toolbar outside the editor's right section to change DOM order.
However, this would change the layout if the toc is enabled, moving the `Directory navigation` underneath the toolbar: 

<img width="853" height="367" alt="image" src="https://github.com/user-attachments/assets/17f0ed7f-a2ec-43c2-861c-5383a5f79c48" />

### Testing
Steps:
1. Enable the Text Editor's ToC.
2. Add some headings (Note: `Heading 1` isn't added to the ToC, but `Heading 2` is).
3. Use the keyboard to tab through and verify that the ToC is accessible. 
