### PR TITLE
Enhance chart name defaulting, add currentSlide and slideIndex to Pinia

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "nouislider": "^15.5.0",
                 "ramp-config-editor_editeur-config-pcar": "^4.0.0",
                 "ramp-pcar": "^4.10.2",
-                "ramp-storylines_demo-scenarios-pcar": "^3.5.4",
+                "ramp-storylines_demo-scenarios-pcar": "^3.5.7",
                 "throttle-debounce": "^5.0.0",
                 "url": "^0.11.3",
                 "uuid": "^9.0.0",
@@ -9434,9 +9434,9 @@
             }
         },
         "node_modules/ramp-storylines_demo-scenarios-pcar": {
-            "version": "3.5.4",
-            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.5.4.tgz",
-            "integrity": "sha512-WyaVudXHlBkoIBRVBcrawWvb8mYmg7+U5+u0mvj1mQn1euon9Vr34XYrQUAb79gjmy03O6CxTlg5jwB/sThKZQ==",
+            "version": "3.5.7",
+            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.5.7.tgz",
+            "integrity": "sha512-RudKTnf5WYTSDfVTsVEPe1BWzDtlVsYk0YX6w+1B8A54MUlgfjiuf0pFlpI2MGy1+cz0lXW1LJx9CbtCwglm7g==",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "nouislider": "^15.5.0",
         "ramp-config-editor_editeur-config-pcar": "^4.0.0",
         "ramp-pcar": "^4.10.2",
-        "ramp-storylines_demo-scenarios-pcar": "^3.5.4",
+        "ramp-storylines_demo-scenarios-pcar": "^3.5.7",
         "throttle-debounce": "^5.0.0",
         "url": "^0.11.3",
         "uuid": "^9.0.0",

--- a/src/components/panel-editors/chart-editor.vue
+++ b/src/components/panel-editors/chart-editor.vue
@@ -116,7 +116,7 @@
                 :key="`new-editor-${chartIdx}`"
                 :plugin="true"
                 :lang="lang"
-                :title="$t('editor.chart.label.newTitle', { num: chartIdx })"
+                :title="defaultChartTitle"
                 @cancel="() => $vfm.close('highcharts-create-modal')"
                 @saved="createNewChart"
             />
@@ -127,7 +127,7 @@
 <script lang="ts">
 import ActionModal from '@/components/support/action-modal.vue';
 import { Options, Prop, Vue } from 'vue-property-decorator';
-import { ChartConfig, ChartPanel, HighchartsConfig, PanelType, SlideshowChartPanel } from '@/definitions';
+import { ChartConfig, ChartPanel, HighchartsConfig, PanelType, Slide, SlideshowChartPanel } from '@/definitions';
 import { VueFinalModal } from 'vue-final-modal';
 import { useProductStore } from '@/stores/productStore';
 
@@ -168,6 +168,16 @@ export default class ChartEditorV extends Vue {
     chartVersions: Record<string, number> = {};
     editingConfig: HighchartsConfig | null = null;
     editingName: string | null = null;
+
+    // compute unique default chart title when creating new highchart
+    get defaultChartTitle(): string {
+        const slideTitle = (this.productStore.currentSlide as Slide).title;
+        const slideIdx = this.productStore.slideIndex + 1;
+        const chartNum = this.$t('editor.chart.label.newTitle', { num: this.chartIdx });
+        return slideTitle
+            ? `${slideTitle} - ${chartNum}`
+            : `${this.$t('editor.slides.slide')} ${slideIdx} - ${chartNum}`;
+    }
 
     mounted(): void {
         applyTextAlign(this.panel, this.centerSlide, this.dynamicSelected);
@@ -350,6 +360,7 @@ export default class ChartEditorV extends Vue {
             this.highchartsChartConfigs.splice(idx, 1);
         }
         this.onChartsEdited();
+        this.chartIdx -= 1;
     }
 
     saveChanges(): void {

--- a/src/components/slide-editor.vue
+++ b/src/components/slide-editor.vue
@@ -573,10 +573,8 @@ import { useProductStore } from '@/stores/productStore';
 })
 export default class SlideEditorV extends Vue {
     config: StoryRampConfig | undefined = undefined;
-    @Prop() currentSlide!: Slide;
     @Prop() lang!: string;
     @Prop() uid!: string;
-    @Prop() slideIndex!: number;
     @Prop() isLast!: boolean;
     @Prop() otherLangSlide!: Slide;
 
@@ -605,6 +603,14 @@ export default class SlideEditorV extends Vue {
         loading: 'loading-page',
         dynamic: 'dynamic-editor'
     };
+
+    get slideIndex(): number {
+        return this.productStore.slideIndex;
+    }
+
+    get currentSlide(): Slide {
+        return this.productStore.currentSlide as Slide;
+    }
 
     mounted() {
         this.langTranslate = this.$t(`editor.lang.${this.lang}`);

--- a/src/components/slide-toc/slide-toc-button.vue
+++ b/src/components/slide-toc/slide-toc-button.vue
@@ -4,10 +4,10 @@
         class="flex gap-2 px-2 rounded-md bg-transparent hover:bg-gray-200"
         :disabled="!element[selectedLang]"
         :class="{
-            'selected-toc-config-item': element[selectedLang] === currentSlide,
+            'selected-toc-config-item': element[selectedLang] === productStore.currentSlide,
             'py-1': !isMobileSidebar,
             'py-2': isMobileSidebar,
-            'border-2 border-blue-500': isMobileSidebar && element[selectedLang] === currentSlide,
+            'border-2 border-blue-500': isMobileSidebar && element[selectedLang] === productStore.currentSlide,
             'cursor-not-allowed border-2 border-red-400': !element[selectedLang]
         }"
         @click.stop="
@@ -162,8 +162,9 @@
 <script lang="ts">
 import { BasePanel, MapPanel, MultiLanguageSlide, PanelType, Slide } from '@/definitions';
 import { Options, Prop, Vue } from 'vue-property-decorator';
-import TocOptions from './toc-options.vue';
+import { useProductStore } from '@/stores/productStore';
 
+import TocOptions from './toc-options.vue';
 import TextEditorIcon from '@/assets/text-editor.svg?raw';
 import ImageEditorIcon from '@/assets/image-editor.svg?raw';
 import MapEditorIcon from '@/assets/map-editor.svg?raw';
@@ -181,10 +182,10 @@ import DynamicEditorIcon from '@/assets/dynamic-editor.svg?raw';
 export default class SlideTocV extends Vue {
     @Prop() selectedLang!: 'en' | 'fr';
     @Prop() element!: MultiLanguageSlide;
-    @Prop() currentSlide!: Slide | string;
     @Prop({ default: false }) isMobileSidebar!: boolean;
     @Prop() isActiveSlide!: boolean;
 
+    productStore = useProductStore();
     oppositeLang: 'en' | 'fr' = 'fr';
     content: string | undefined = '';
 

--- a/src/components/slide-toc/slide-toc.vue
+++ b/src/components/slide-toc/slide-toc.vue
@@ -177,7 +177,6 @@
                                     <slide-toc-button
                                         :element="element"
                                         selectedLang="en"
-                                        :currentSlide="currentSlide"
                                         :isMobileSidebar="isMobileSidebar"
                                         :isActiveSlide="slideIndex === index"
                                         @selectSlide="selectSlide(index, 'en')"
@@ -229,7 +228,6 @@
                                     <slide-toc-button
                                         :element="element"
                                         selectedLang="fr"
-                                        :currentSlide="currentSlide"
                                         :isMobileSidebar="isMobileSidebar"
                                         :isActiveSlide="slideIndex === index"
                                         @selectSlide="selectSlide(index, 'fr')"
@@ -409,8 +407,6 @@ import { useProductStore } from '@/stores/productStore';
 })
 export default class SlideTocV extends Vue {
     @Prop() slides!: MultiLanguageSlide[];
-    @Prop() currentSlide!: Slide | string;
-    @Prop() slideIndex!: number;
     @Prop() lang!: string;
     @Prop() closeSidebar!: () => void;
     @Prop({ default: false }) isMobileSidebar!: boolean;
@@ -433,6 +429,10 @@ export default class SlideTocV extends Vue {
         ],
         includeInToc: true
     };
+
+    get slideIndex(): number {
+        return this.productStore.slideIndex;
+    }
 
     /**
      * Determines if a particular config is empty.

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -282,7 +282,6 @@ export interface SlideshowChartPanel extends BasePanel {
 export interface ChartPanel extends BasePanel {
     type: PanelType.Chart;
     src: string;
-
     config?: any;
     name?: string;
     options?: DQVOptions;

--- a/src/stores/productStore.ts
+++ b/src/stores/productStore.ts
@@ -24,6 +24,8 @@ interface ProductState {
     configFileStructure: ConfigFileStructure;
     configs: { [key: string]: StoryRampConfig | undefined };
     configLang: string;
+    currentSlide: Slide | string; // TODO: move this into the editor store when metadata refactor is complete #281
+    slideIndex: number; // TODO: move this into the editor store when metadata refactor is complete #281
     sourceCounts: SourceCounts;
     debounceTimer: ReturnType<typeof setTimeout> | null;
     i18n: any;
@@ -35,6 +37,9 @@ export const useProductStore = defineStore('product', {
         configs: { en: undefined, fr: undefined },
         configLang: 'en',
         sourceCounts: {},
+        // TODO: move currentSlide + slideIndex into the editor store when metadata refactor is complete if it makes more sense #281
+        currentSlide: '',
+        slideIndex: -1,
 
         // Debounce timer used for updateSaveStatus only.
         // IMPORTANT: Avoid using stateStore's handlePotentialChange() directly, this timer may cause issues with change detection and saving to the configs variable.


### PR DESCRIPTION
### Related Item(s)
Closes #716

### Changes
- improves chart name defaulting to the following format: `{Slide title} - Chart {number}` if slide title exists, `Slide {number} - Chart {number}` otherwise
- moved `currentSlide` and `slideIdx` to product store, can be moved to editor store when metadata refactor is introduced

### Notes
Limitation of current approach is the naming will still conflict when there are multiple chart editors in one slide (e.g. dynamic slideshow, double chart panels, dynamic panels).  

### Testing
Create a new chart panel for any slide and check default chart title + file name in config
