### PR TITLE
Fix schema validation for dynamic panels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
                 "nouislider": "^15.5.0",
                 "ramp-config-editor_editeur-config-pcar": "^4.0.0",
                 "ramp-pcar": "^4.10.2",
-                "ramp-storylines_demo-scenarios-pcar": "^3.5.7",
+                "ramp-storylines_demo-scenarios-pcar": "^3.5.8",
                 "throttle-debounce": "^5.0.0",
                 "url": "^0.11.3",
                 "uuid": "^9.0.0",
@@ -9434,9 +9434,9 @@
             }
         },
         "node_modules/ramp-storylines_demo-scenarios-pcar": {
-            "version": "3.5.7",
-            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.5.7.tgz",
-            "integrity": "sha512-RudKTnf5WYTSDfVTsVEPe1BWzDtlVsYk0YX6w+1B8A54MUlgfjiuf0pFlpI2MGy1+cz0lXW1LJx9CbtCwglm7g==",
+            "version": "3.5.8",
+            "resolved": "https://registry.npmjs.org/ramp-storylines_demo-scenarios-pcar/-/ramp-storylines_demo-scenarios-pcar-3.5.8.tgz",
+            "integrity": "sha512-euzYnNfoooGWynOm5rN1ejwWfIsmEHw53gbLD7KMLaLNOkyuPj53Bv99aFT3bJle2UIgH1vNNKDnx5HQiHsW0g==",
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-dsv": "^3.0.4",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "nouislider": "^15.5.0",
         "ramp-config-editor_editeur-config-pcar": "^4.0.0",
         "ramp-pcar": "^4.10.2",
-        "ramp-storylines_demo-scenarios-pcar": "^3.5.7",
+        "ramp-storylines_demo-scenarios-pcar": "^3.5.8",
         "throttle-debounce": "^5.0.0",
         "url": "^0.11.3",
         "uuid": "^9.0.0",


### PR DESCRIPTION
### Related Item(s)
Issue #731 

### Changes
- Updated storylines package version
- Schema validation should now work for dynamic panels 

### Testing
Steps:
1. Create/load a slide with dynamic panels. 
2. Switch to advanced editor tab
3. Modify or remove a property that would make the schema invalid
4. Should now indicate that the configuration violates the Storylines schema

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/735)
<!-- Reviewable:end -->
