### PR TITLE
add content sanitization bypass for admin role

### DIFF
--- a/src/components/panel-editors/text-editor.vue
+++ b/src/components/panel-editors/text-editor.vue
@@ -11,6 +11,7 @@
                 v-model="panel.content"
                 height="400px"
                 :left-toolbar="toolbarOptions"
+                :right-toolbar="rightToolbarOptions"
                 :toolbar="toolbar"
                 @fullscreen-change="onFullscreenChange"
             ></v-md-editor>
@@ -46,6 +47,7 @@ import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
 import VueMarkdownEditor, { langMap } from '@/plugins/markdown-editor/index';
 import { TextPanel } from '@/definitions';
 import { applyTextAlign } from '@/utils/styleUtils';
+import { useUserStore } from '@/stores/userStore';
 import WETDashboardItemV from '../support/wet-dashboard-item.vue';
 import WETComponents from '../support/wet-component-templates.json';
 import DOMPurify from 'dompurify';
@@ -71,10 +73,12 @@ export default class TextEditorV extends Vue {
     @Prop({ default: false }) dynamicSelected!: boolean;
     @Prop() lang!: string;
 
+    userStore = useUserStore();
     wetComponentsVisible = false;
     editor: MDEditor = {} as MDEditor;
     components: WETComponentsObject = WETComponents;
     pageLang = window.location.href.includes('index-ca-en') ? 'en' : 'fr'; // this is only used if `index-ca` is already in the URL.
+    bypassSanitization = false; // An admin-only feature that when enabled will allow the user to bypass sanitization of the text editor content.
 
     @Watch('panel.content', { deep: true, immediate: true })
     onContentChanged() {
@@ -472,6 +476,20 @@ export default class TextEditorV extends Vue {
                         this.editor = editor;
                     }
                 }
+            },
+            sanitization: {
+                title: this.$t('editor.text.sanitize'),
+                text: this.$t('editor.text.sanitize'),
+                icon: 'sanitize-content-button',
+                active: () => !this.bypassSanitization,
+                action: (editor: MDEditor): void => {
+                    if (this.bypassSanitization) {
+                        const confirmChange = confirm(this.$t('editor.text.sanitize.confirm'));
+                        if (!confirmChange) return;
+                    }
+
+                    this.bypassSanitization = !this.bypassSanitization;
+                }
             }
         };
     }
@@ -479,6 +497,11 @@ export default class TextEditorV extends Vue {
     toolbarOptions = `undo redo clear | h bold italic strikethrough quote subsuper fontSize | ul ol table hr | addLink image code ${
         window.location.href.includes('index-ca') ? '| wetToolbar' : ''
     } | save`;
+
+    rightToolbarOptions = `preview toc sync-scroll fullscreen ${
+        // TODO: remove the ! before merging. First one to block gets a cookie
+        this.userStore.userProfile.role !== 'Admin' ? 'sanitization' : ''
+    }`;
 
     toolbarTooltipAdjust(toggle: HTMLElement): void {
         const slideEditor = document.querySelector('#slideEditor') as HTMLElement;
@@ -500,11 +523,13 @@ export default class TextEditorV extends Vue {
     }
 
     saveChanges() {
-        this.panel.content = DOMPurify.sanitize(this.panel.content, {
-            FORCE_BODY: true,
-            ADD_TAGS: ['AudioPlayer'],
-            ADD_ATTR: ['transcript']
-        }).replaceAll('audioplayer', 'AudioPlayer');
+        if (!this.bypassSanitization) {
+            this.panel.content = DOMPurify.sanitize(this.panel.content, {
+                FORCE_BODY: true,
+                ADD_TAGS: ['AudioPlayer'],
+                ADD_ATTR: ['transcript']
+            }).replaceAll('audioplayer', 'AudioPlayer');
+        }
     }
 
     mounted(): void {
@@ -520,6 +545,9 @@ export default class TextEditorV extends Vue {
         });
 
         this.makeTextEditorElementsTabbable();
+
+        // TODO: remove the ! before merging.
+        this.bypassSanitization = this.userStore.userProfile.role !== 'Admin'; // admins will bypass sanitization by default. They can enable it with the 'sanitize' button.
 
         // selects the <textarea> and adds label attribute dynamically
         this.$nextTick(() => {
@@ -551,6 +579,10 @@ export default class TextEditorV extends Vue {
     transition-duration: 0.075s;
 }
 
+:deep(.sanitize-content-button) {
+    font-size: 14px;
+}
+
 :deep(.v-md-editor__toolbar-right-wrapper) {
     background-color: #f3f4f6;
     border-radius: 3px;
@@ -574,6 +606,12 @@ export default class TextEditorV extends Vue {
 
 label {
     text-align: left !important;
+    margin-left: 0.5rem;
+}
+
+input[type='checkbox']:checked {
+    accent-color: black;
+    color: white;
 }
 
 .WETDashboard {

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -195,6 +195,8 @@ editor.text.addLink.external.sameTab,Add External Link (Same Tab),1,Ajouter un l
 editor.text.addLink.dynamic,Add Dynamic Link,1,Ajouter un lien dynamique,0
 editor.text.wetToolbar.title,WET Components,1,Composantes WET,0
 editor.text.wetToolbar.text,Components,1,Composantes,0
+editor.text.sanitize,Sanitize,0,Sanitiser,0
+editor.text.sanitize.confirm,'Are you sure you want to enable content sanitization? This may remove some HTML tags such as iframes. Click OK to continue or Cancel to keep the current state.',1,"Êtes-vous sûr de vouloir activer la désinfection du contenu? Cela peut supprimer certaines balises HTML telles que les iframes. Cliquez sur OK pour continuer ou Annuler pour conserver l'état actuel.",0
 editor.image.label.height,Height,1,Hauteur,1
 editor.image.label.width,Width,1,Largeur,1
 editor.image.label.widthWarning,Maximum width is 2/3 (66%) of screen on desktop and 100% on mobile. Larger widths will be ignored.,1,La largeur maximale est de 2/3 (66 %) de l'écran sur les ordinateurs de bureau et de 100 % sur les téléphones portables. Les largeurs plus importantes seront ignorées.,1


### PR DESCRIPTION
### Related Item(s)
#713 

### Changes
- Adds a `sanitize` button to the text editor toolbar for users with the "admin" role, which allows admins to bypass content sanitization when working on a product.

### Notes
The "sanitize" selection gets assigned every time the text panel is mounted, which means that admins who want to sanitize content will need to re-enable it every time they open a text panel. This is pretty annoying, so maybe it's worth storing their preference in the user store for convenience.

### Testing
Steps:
1. Open the demo link.
2. Load a product.
3. Create or open a text panel.
4. With sanitization disabled, try to include an `iframe` or another element that sanitization would remove.
5. Ensure that the element is not removed.
6. Go back to the text panel and click the `sanitize` button so that it's enabled.
7. Try to include an `iframe`.
8. This time ensure that the `iframe` is removed correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/737)
<!-- Reviewable:end -->
