### PR TITLE
Darker link icon for contrast

### DIFF
--- a/src/components/panel-editors/text-editor.vue
+++ b/src/components/panel-editors/text-editor.vue
@@ -581,7 +581,7 @@ label {
 }
 
 :deep(.v-md-icon-link::before) {
-    content: '\1F517';
+    content: '\1F517\fe0e';
 }
 
 :deep(.v-md-editor__tooltip) {


### PR DESCRIPTION
### Related Item(s)
Issue #705 

### Changes
- Changed the link icon from an emoji and applied a darker colour to improve contrast
<img width="180" height="82" alt="image" src="https://github.com/user-attachments/assets/f278c5ba-d5eb-4f7e-b068-72266ac7c3f5" />

### Testing
Steps:
1. Edit or create a product
2. Go to a text editor
3. The link icon is now darker for contrast

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/739)
<!-- Reviewable:end -->
