### PR TITLE
Ensure metadata reflects language of selected slide

### DIFF
--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -458,7 +458,7 @@
                     @slide-change="selectSlide"
                     @slide-edit="productStore.updateSaveStatus(undefined, 'ToC')"
                     @slides-updated="updateSlides"
-                    @open-metadata-modal="$vfm.open('metadata-edit-modal')"
+                    @open-metadata-modal="openMetadataModal"
                     :lang="productStore.configLang"
                 ></slide-toc>
             </div>
@@ -609,6 +609,17 @@ export default class EditorV extends Vue {
 
     beforeDestroy(): void {
         window.removeEventListener('beforeunload', this.beforeWindowUnload);
+    }
+
+    /**
+     * Opens the metadata editing modal for the currently selected slide language.
+     */
+    openMetadataModal() {
+        const newMetadata = this.productStore.configs[this.productStore.configLang];
+        if (!newMetadata) return;
+
+        Object.assign(this.metadata, newMetadata);
+        this.$vfm.open('metadata-edit-modal');
     }
 
     /**

--- a/src/components/metadata/metadata-content.vue
+++ b/src/components/metadata/metadata-content.vue
@@ -26,24 +26,13 @@
                 <h2 class="text-xl font-bold">{{ $t('editor.metadataForm.layoutAndNav.heading') }}</h2>
                 <!-- Same TOC orientation and return-to-top values across both ENG/FR configs -->
                 <div class="metadata-item">
-                    <div
-                        class="inline-flex gap-2 pt-2"
-                        v-tippy="{
-                            delay: '200',
-                            placement: 'bottom',
-                            content: createNew ? $t('editor.sameConfig.tooltip') : null,
-                            animateFill: true,
-                            touch: ['hold', 500],
-                            offset: [10, 2]
-                        }"
-                    >
+                    <div class="flex gap-2">
                         <input
                             v-show="editing"
                             type="checkbox"
                             id="sameConfig"
                             class="self-center rounded-none cursor-pointer w-4 h-4"
                             v-model="metadata.sameConfig"
-                            :disabled="createNew"
                             @change="metadataChanged"
                         />
                         <label class="respected-standard-label" for="sameConfig">{{ $t('editor.sameConfig') }}</label>
@@ -417,7 +406,6 @@ import ColourPickerInput from '../support/colour-picker-input.vue';
 export default class MetadataEditorV extends Vue {
     @Prop() metadata!: MetadataContent;
     @Prop({ default: true }) editing!: boolean;
-    @Prop({ default: true }) createNew!: boolean;
 
     openFileSelector(where = 'logoUpload'): void {
         document.getElementById(where)?.click();

--- a/src/components/metadata/metadata-editor.vue
+++ b/src/components/metadata/metadata-editor.vue
@@ -477,7 +477,6 @@
                                     <!-- New projects can only be in edit mode; existing projects can be in both -->
                                     <metadata-content
                                         :metadata="metadata"
-                                        :createNew="true && !editExisting"
                                         :editing="editingMetadata"
                                         @metadata-changed="updateMetadata"
                                         @image-changed="onFileChange"
@@ -1125,10 +1124,7 @@ export default class MetadataEditorV extends Vue {
         );
     }
 
-    /**
-     * Generates a new product file for brand new products.
-     */
-    generateNewConfig(): void {
+    generateNewConfig(uuidCheck: boolean = true): void {
         const configLang = this.productStore.configLang;
         const configZip = new JSZip();
         // Generate a new configuration file and populate required fields.
@@ -1158,19 +1154,30 @@ export default class MetadataEditorV extends Vue {
         config.slides = [];
 
         const otherLang = this.productStore.oppositeLang;
-        this.productStore.configs[otherLang] = cloneDeep(config);
-        (this.productStore.configs[otherLang] as StoryRampConfig).lang = otherLang;
-        const formattedOtherLangConfig = JSON.stringify(this.productStore.configs[otherLang], null, 4);
+        const baseConfig = (this.productStore.configs[otherLang] = cloneDeep(config));
+        Object.assign(baseConfig, {
+            title: '',
+            lang: this.productStore.oppositeLang,
+            contextLink: '',
+            contextLabel: '',
+            introSlide: {
+                title: '',
+                subtitle: '',
+                logo: { src: '', altText: '' },
+                backgroundImage: ''
+            }
+        });
+        const otherConfig = this.productStore.configs[otherLang] as StoryRampConfig;
+        const formattedOtherLangConfig = JSON.stringify(otherConfig, null, 4);
 
         // Add the newly generated Storylines configuration file to the ZIP file.
-        const fileName = `${this.uuid}_${configLang}.json`;
         const formattedConfigFile = JSON.stringify(config, null, 4);
 
-        configZip.file(fileName, formattedConfigFile);
+        configZip.file(`${this.uuid}_${configLang}.json`, formattedConfigFile);
         configZip.file(`${this.uuid}_${otherLang}.json`, formattedOtherLangConfig);
 
         // Generate the file structure, defer uploading the image until the structure is created.
-        this.configFileStructureHelper(configZip, [this.logoImage, this.introBgImage]);
+        this.configFileStructureHelper(configZip, uuidCheck, [this.logoImage, this.introBgImage]);
     }
 
     configHelper(): StoryRampConfig {
@@ -1583,7 +1590,11 @@ export default class MetadataEditorV extends Vue {
      * Generates or loads a ZIP file and creates required project folders if needed.
      * Returns an object that makes it easy to access any specific folder.
      */
-    async configFileStructureHelper(configZip: typeof JSZip, uploadFiles?: Array<File | undefined>): Promise<void> {
+    async configFileStructureHelper(
+        configZip: typeof JSZip,
+        uuidCheck: boolean = true,
+        uploadFiles?: Array<File | undefined>
+    ): Promise<void> {
         const assetsFolder = configZip.folder('assets');
         const chartsFolder = configZip.folder('charts');
         const rampConfigFolder = configZip.folder('ramp-config');
@@ -1617,7 +1628,7 @@ export default class MetadataEditorV extends Vue {
                 }
             });
         }
-        this.correctUuid();
+        if (uuidCheck) this.correctUuid();
     }
 
     /**
@@ -2130,10 +2141,10 @@ export default class MetadataEditorV extends Vue {
      */
     async swapLang(): Promise<void> {
         await this.saveMetadata(false, true);
-        this.productStore.configLang = this.productStore.oppositeLang;
         if (!this.productStore.configs[this.productStore.configLang]) {
-            return;
+            await this.generateNewConfig(false);
         }
+        this.productStore.configLang = this.productStore.oppositeLang;
         this.loadConfig(this.productStore.configs[this.productStore.configLang]);
     }
 
@@ -2362,7 +2373,27 @@ export default class MetadataEditorV extends Vue {
                 this.lockStore
                     .lockStoryline(this.uuid)
                     .then(() => {
-                        this.generateNewConfig();
+                        // Only generate config if not already present or UUID mismatch
+                        if (
+                            !this.productStore.configs[this.productStore.configLang] ||
+                            this.uuid !== this.productStore.configFileStructure?.uuid
+                        ) {
+                            this.generateNewConfig();
+                        } else {
+                            // Else config already exists and matches UUID, skip generation
+                            // Update each zip file with their latest changes before loading
+                            this.saveMetadata();
+
+                            const writeConfigFile = (lang: 'en' | 'fr') => {
+                                const configJson = JSON.stringify(this.productStore.configs[lang], null, 4);
+                                this.productStore.configFileStructure.zip.file(`${this.uuid}_${lang}.json`, configJson);
+                            };
+
+                            writeConfigFile(this.productStore.configLang as 'en' | 'fr');
+                            writeConfigFile(this.productStore.oppositeLang as 'en' | 'fr');
+                            
+                            this.correctUuid();
+                        }
                     })
                     .catch(() => {
                         this.error = true;

--- a/src/components/metadata/metadata-modal.vue
+++ b/src/components/metadata/metadata-modal.vue
@@ -46,7 +46,6 @@
             <div class="mx-4">
                 <metadata-content
                     :metadata="metadata"
-                    :createNew="false"
                     @metadata-changed="(key: string, value: string) => $emit('metadata-changed', key, value)"
                     @image-changed="(event: Event, type: string) => $emit('image-changed', event, type)"
                     @image-source-changed="(event: Event, type: string) => $emit('image-source-changed', event, type)"

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -362,7 +362,6 @@ editor.returnTop,Include return to top navigation,1,Inclure le retour en haut de
 editor.sameConfig,Same across configurations,1,Identique dans toutes les configurations,1
 editor.sameConfig.info,"Determines whether the table of contents orientation and return-to-top navigation are shared across English and French configurations.",1,"Détermine si l'orientation de la table des matières et la navigation de retour en haut de page sont communes aux configurations anglaise 
 et française.",1
-editor.sameConfig.tooltip,"Navigation and layout settings are currently synchronized. They can be customized per language on the next page in the metadata editor.",1,Les paramètres de navigation et de mise en page sont actuellement synchronisés. Ils peuvent être personnalisés par langue à la page suivante dans l'éditeur de métadonnées.,1
 editor.landing.greeting,Hello,1,Bonjour,1
 editor.month.january,January,1,Janvier,0
 editor.month.february,February,1,Février,0


### PR DESCRIPTION
### Related Item(s)
Issues #680 & #703 

### Changes
- Added the function `openMetadataModal()` in `Editor.vue` to open the config corresponding to `productStore.configLang` at the time the modal is triggered, ensuring the metadata shown matches the language of the selected slide.

- Updated `swapLang` to generate a new config if it is missing, fixing the issue where metadata on the Create New Product page didn’t reflect language-specific configurations.

### Notes
- Removed the disabled checkbox now that the metadata language config can be loaded separately: 
      <img width="472" height="137" alt="image" src="https://github.com/user-attachments/assets/44f3c2c4-1979-473d-a366-8cce9e9417c3" /> 


### Testing
Steps:
1. Create a new product. 
2. On the `Create New Storylines Product` page, edit the metadata details for both English and French configs
3. Verify that the metadata for each language is now respected and saved separately 
4. Proceed to main editor
5. Add a new slide
6. Click on the EN Slide and click `Edit Project Metadata` 
7. Confirm the metadata displays the EN contents, and language toggle button says "View French Config" (and vice versa when on the FR Slide) 