### PR TITLE
refactor: Convert to Composition API

### DIFF
--- a/src/app.vue
+++ b/src/app.vue
@@ -4,31 +4,48 @@
     </div>
 </template>
 
-<script lang="ts">
-import { Vue, Watch } from 'vue-property-decorator';
-import { RouteLocationNormalized } from 'vue-router';
+<script setup lang="ts">
 import { useUserStore } from './stores/userStore';
 import { useLockStore } from './stores/lockStore';
+import { getCurrentInstance, onMounted, watch } from 'vue';
 
-export default class App extends Vue {
-    @Watch('$route', { immediate: true })
-    onRouteUpdate(to: RouteLocationNormalized): void {
-        this.$i18n.locale = (to.params.lang as string) ?? 'en';
-        if (to.params.lang) {
-            document.title = this.$t(to.meta.title);
-        }
-    }
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
-    mounted(): void {
-        const userStore = useUserStore(this.$pinia);
-        // We can mock the user's profile for local development here if needed.
-        if (import.meta.env.VITE_APP_CURR_ENV) {
-            userStore.fetchUserProfile();
-        }
-        const lockStore = useLockStore();
-        lockStore.initConnection(); // start the handshake with the web socket server as soon as the app starts to save time
+// =========================================
+// Definitions
+
+const { $pinia, $route, $i18n } = getCurrentInstance()!.proxy!;
+
+// =========================================
+// Watchers
+
+watch($route, () => {
+    $i18n.locale = ($route.params.lang as string) ?? 'en';
+    if ($route.params.lang) {
+        document.title = $i18n.t($route.meta.title);
     }
-}
+});
+
+// =========================================
+// Lifecycle functions
+
+onMounted(() => {
+    const userStore = useUserStore($pinia);
+    // We can mock the user's profile for local development here if needed.
+    if (import.meta.env.VITE_APP_CURR_ENV) {
+        userStore.fetchUserProfile();
+    }
+    const lockStore = useLockStore();
+    lockStore.initConnection(); // start the handshake with the web socket server as soon as the app starts to save time
+});
+
+// =========================================
+// Component functions
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss">

--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -274,7 +274,7 @@
                                 }}</span
                             >
                             <span v-if="editorStore.editorSaving" class="align-middle inline-block px-1">
-                                <spinner size="16px" color="#009cd1" class="ml-1 mb-1"></spinner>
+                                <VueSpinnerOval size="16px" color="#009cd1" class="ml-1 mb-1"></VueSpinnerOval>
                             </span>
                         </button>
 
@@ -286,7 +286,7 @@
                                 name: 'editor',
                                 params: { lang: currentRoute.includes('#/en') ? 'fr' : 'en', uid: productStore.uuid }
                             }"
-                            @click="productStore.configLang = currentRoute.includes('#/en') ? 'fr' : 'en'"
+                            @click="editorStore.configLang = currentRoute.includes('#/en') ? 'fr' : 'en'"
                             class="respected-standard-link-button px-2"
                         >
                             <a>
@@ -346,7 +346,7 @@
                         <div class="flex items-center flex-nowrap gap-2 justify-between md:justify-start">
                             <slot name="langModal" v-bind="{ unsavedChanges: stateStore.isChanged }"></slot>
                             <!-- Preview dropdown -->
-                            <dropdown-menu
+                            <DropdownMenu
                                 class="flex-shrink-0"
                                 position="bottom-start"
                                 :aria-label="$t('editor.preview')"
@@ -409,7 +409,7 @@
                                 >
                                     {{ $t('editor.lang.fr') }}
                                 </button>
-                            </dropdown-menu>
+                            </DropdownMenu>
 
                             <div class="flex flex-row gap-2">
                                 <!-- Export button -->
@@ -525,20 +525,21 @@
             <!-- Sidebar, desktop version -->
             <div id="sidebar-desktop" class="w-80 flex flex-col flex-shrink-0 border-r border-black editor-toc">
                 <!-- ToC -->
-                <slide-toc
+                <SlideTocV
                     class="flex-1"
                     @scroll-to-element="scrollToElement"
                     @slide-change="selectSlide"
                     @slides-updated="updateSlides"
                     @open-metadata-modal="openMetadataModal"
                     :lang="editorStore.configLang"
-                ></slide-toc>
+                ></SlideTocV>
             </div>
             <!-- Sidebar, mobile version -->
             <div id="sidebar-mobile" class="w-0 flex-shrink-0 border-r border-black editor-toc md:hidden">
                 <!-- Mobile ToC -->
                 <!-- Bigger buttons, more visual dividers, more colors -->
-                <slide-toc
+                <SlideTocV
+                    :slideIndex="editorStore.selectedSlideIndex"
                     @slide-change="selectSlide"
                     @slides-updated="updateSlides"
                     @open-metadata-modal="openMetadataModal"
@@ -546,12 +547,12 @@
                     :lang="editorStore.configLang"
                     :closeSidebar="closeSidebar"
                     :isMobileSidebar="true"
-                ></slide-toc>
+                ></SlideTocV>
             </div>
             <!-- Right side -->
             <div class="w-full">
                 <!-- Slide editor -->
-                <slide-editor
+                <SlideEditorV
                     class="editor-area w-full"
                     ref="slide"
                     :otherLangSlide="
@@ -567,18 +568,18 @@
                     @slide-change="selectSlide"
                     @slide-edit="onSlidesEdited()"
                     @custom-slide-updated="updateCustomSlide"
-                ></slide-editor>
+                ></SlideEditorV>
             </div>
         </div>
 
         <!-- Edit metadata modal -->
         <!-- Click Done or outside the modal to save changes LOCALLY. -->
-        <metadata-modal></metadata-modal>
+        <MetadataModalV></MetadataModalV>
         <!-- Help modal -->
-        <help-panel :helpSections="helpSections" :originalTextArray="originalTextArray"></help-panel>
+        <HelpPanelV :helpSections="helpSections" :originalTextArray="originalTextArray"></HelpPanelV>
         <!-- Reload config confirmation modal -->
-        <confirmation-modal :name="`reload-config`" :message="$t('editor.refreshChanges.modal')" @ok="refreshConfig" />
-        <confirmation-modal
+        <ConfirmationModalV :name="`reload-config`" :message="$t('editor.refreshChanges.modal')" @ok="refreshConfig" />
+        <ConfirmationModalV
             :name="`confirm-extend-session-editor`"
             :message="
                 $t('editor.extendSession', {
@@ -593,8 +594,7 @@
     </div>
 </template>
 
-<script lang="ts">
-import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
+<script setup lang="ts">
 import {
     deepMerge,
     HelpSection,
@@ -604,12 +604,23 @@ import {
     SupportedLanguages,
     TextPanel
 } from '@/definitions';
+import {
+    computed,
+    getCurrentInstance,
+    onBeforeMount,
+    onBeforeUnmount,
+    onMounted,
+    ref,
+    useTemplateRef,
+    watch
+} from 'vue';
 import { VueSpinnerOval } from 'vue3-spinners';
 import axios from 'axios';
 import { marked } from 'marked';
 import Message from 'vue-m-message';
 import { saveAs } from 'file-saver';
 import { RouteLocationNormalized } from 'vue-router';
+import { useI18n } from 'vue-i18n';
 
 import SlideEditorV from './slide-editor.vue';
 import SlideTocV from './slide-toc/slide-toc.vue';
@@ -624,91 +635,104 @@ import { useProductStore } from '@/stores/productStore';
 import { useEditorStore } from '@/stores/editorStore';
 import { useStateStore } from '@/stores/stateStore';
 
-@Options({
-    components: {
-        'metadata-content': MetadataContentV,
-        'confirmation-modal': ConfirmationModalV,
-        spinner: VueSpinnerOval,
-        'slide-editor': SlideEditorV,
-        'slide-toc': SlideTocV,
-        'help-panel': HelpPanelV,
-        'dropdown-menu': DropdownMenu,
-        'metadata-modal': MetadataModalV
-    }
-})
-export default class EditorV extends Vue {
-    @Prop({ default: false }) isMobileSidebar!: boolean;
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
-    currentRoute = window.location.href;
-    productStore = useProductStore();
-    lockStore = useLockStore();
-    editorStore = useEditorStore();
-    stateStore = useStateStore();
+const props = withDefaults(
+    defineProps<{
+        isMobileSidebar?: boolean;
+    }>(),
+    { isMobileSidebar: false }
+);
 
-    // Form properties.
-    logoImage: undefined | File = undefined;
-    loadSlides: undefined | MultiLanguageSlide[] = undefined;
-    helpSections: HelpSection[] = [];
-    helpMd = '';
-    originalTextArray: string[] = [];
-    dropdownButtonWidth = 0;
-    totalTime = import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_END) : 30;
+const emit = defineEmits([]);
 
-    defaultBlankSlide: Slide = {
-        title: '',
-        panel: [
-            {
-                type: 'text',
-                title: '',
-                content: ''
-            } as TextPanel,
-            {
-                type: 'text',
-                title: '',
-                content: ''
-            } as TextPanel
-        ]
-    };
+// =========================================
+// Definitions
 
-    canUndo = false;
-    canRedo = false;
+const { $route, $router, $i18n, $vfm } = getCurrentInstance()!.proxy!;
+const { t } = useI18n();
 
-    @Watch('stateStore.canUndo')
-    onUndoAbilityUpdate(): void {
-        this.canUndo = this.stateStore.canUndo;
-    }
+// <template> element refs
+const dropdownButton = useTemplateRef('dropdownButton');
+const slide = useTemplateRef('slide');
 
-    @Watch('stateStore.canRedo')
-    onRedoAbilityUpdate(): void {
-        this.canRedo = this.stateStore.canRedo;
-    }
+const currentRoute = computed(() => window.location.href);
+const productStore = useProductStore();
+const lockStore = useLockStore();
+const editorStore = useEditorStore();
+const stateStore = useStateStore();
 
-    @Watch('productStore.slidesWorkingCopy', { deep: true })
-    onSlidesEdited(): void {
-        this.editorStore.updateSaveStatus(true);
-    }
+// Form properties.
+const logoImage = ref<undefined | File>(undefined);
+const loadSlides = ref<undefined | MultiLanguageSlide[]>(undefined);
 
-    /**
-     * Runs whenever we need to update the app's config variables with the current selected save state in the stateStore.
-     * Used for updating immediately after setting undo/redo variables.
-     */
-    @Watch('stateStore.reconcileToggler')
-    onReconciliationRequest(): void {
-        const newConfigs = this.stateStore.addChangesToNewSave(this.stateStore.getCurrentChangeLocation());
-        const affectedSlides = this.stateStore.getAffectedSlidesByUndoRedo();
+const helpSections = ref<HelpSection[]>([]);
+const helpMd = ref('');
+const originalTextArray = ref<string[]>([]);
+const dropdownButtonWidth = ref(0);
+const totalTime = ref(import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_END) : 30);
 
-        this.productStore.configs.en = newConfigs?.en;
-        this.productStore.configs.fr = newConfigs?.fr;
+const defaultBlankSlide: Slide = {
+    title: '',
+    panel: [
+        {
+            type: 'text',
+            title: '',
+            content: ''
+        } as TextPanel,
+        {
+            type: 'text',
+            title: '',
+            content: ''
+        } as TextPanel
+    ]
+};
+
+const canUndo = ref(false);
+const canRedo = ref(false);
+
+// =========================================
+// Watchers
+
+watch(
+    () => stateStore.canUndo,
+    () => (canUndo.value = stateStore.canUndo)
+);
+watch(
+    () => stateStore.canRedo,
+    () => (canRedo.value = stateStore.canRedo)
+);
+
+const onSlidesEdited = () => {
+    editorStore.updateSaveStatus(true);
+};
+watch(() => productStore.slidesWorkingCopy, onSlidesEdited, { deep: true });
+
+const onMetadataEdited = () => {
+    editorStore.updateSaveStatus(true);
+};
+watch(() => productStore.metadata, onMetadataEdited, { deep: true });
+
+watch(
+    () => stateStore.reconcileToggler,
+    () => {
+        const newConfigs = stateStore.addChangesToNewSave(stateStore.getCurrentChangeLocation());
+        const affectedSlides = stateStore.getAffectedSlidesByUndoRedo();
+
+        productStore.configs.en = newConfigs?.en;
+        productStore.configs.fr = newConfigs?.fr;
 
         const engSlides =
-            this.productStore.configs.en?.slides.map((engSlide) => {
+            productStore.configs.en?.slides.map((engSlide) => {
                 return {
                     // "Undefined" slides will be the undefined type while inside Storylines Editor, and {} on save/in file.
                     en: engSlide && Object.keys(engSlide).length ? (engSlide as Slide) : undefined
                 };
             }) ?? [];
         const frSlides =
-            this.productStore.configs.fr?.slides.map((frSlide) => {
+            productStore.configs.fr?.slides.map((frSlide) => {
                 return {
                     // "Undefined" slides will be the undefined type while inside Storylines Editor, and {} on save/in file.
                     fr: frSlide && Object.keys(frSlide).length ? (frSlide as Slide) : undefined
@@ -720,424 +744,418 @@ export default class EditorV extends Vue {
             Object.assign({}, engSlides?.[index] || { en: undefined }, frSlides?.[index] || { fr: undefined })
         );
 
-        this.productStore.slidesWorkingCopy = newSlides;
+        productStore.slidesWorkingCopy = newSlides;
 
-        this.updateSlides(false, true);
+        updateSlides(false, true);
 
-        if (this.editorStore.selectedSlideIndex > this.productStore.slidesWorkingCopy.length - 1) {
+        if (editorStore.selectedSlideIndex > productStore.slidesWorkingCopy.length - 1) {
             // If the selected slide index is out of bounds, don't select a slide
-            this.selectSlide(-1);
+            selectSlide(-1);
         } else if (affectedSlides && affectedSlides?.length !== 0) {
             // If available, jump to the slide affected by the undo/redo you did
             // If you undo, jump to the slide whose changes you're doing; if redoing, jump to the slide being redone
-            this.selectSlide(affectedSlides[0].index, affectedSlides[0].lang, affectedSlides[0].panel);
+            selectSlide(affectedSlides[0].index, affectedSlides[0].lang, affectedSlides[0].panel);
         } else if (
-            this.productStore.slidesWorkingCopy[this.editorStore.selectedSlideIndex]?.[
-                this.editorStore.selectedSlideLang
-            ]?.panel.length === 1
+            productStore.slidesWorkingCopy[editorStore.selectedSlideIndex]?.[editorStore.selectedSlideLang]?.panel
+                .length === 1
         ) {
-            this.selectSlide(this.editorStore.selectedSlideIndex, this.editorStore.selectedSlideLang, 0);
+            selectSlide(editorStore.selectedSlideIndex, editorStore.selectedSlideLang, 0);
         } else {
-            this.selectSlide(
-                this.editorStore.selectedSlideIndex,
-                this.editorStore.selectedSlideLang,
-                this.editorStore.selectedPanelIndex
-            );
+            selectSlide(editorStore.selectedSlideIndex, editorStore.selectedSlideLang, editorStore.selectedPanelIndex);
         }
 
         // Also runs updateSaveStatus, so we don't need to emit save-status
         // TODO: This is janky, throwing stuff around like hot potato. Refactor once the core variable refactor PR is merged.
-        this.onMetadataEdited();
+        onMetadataEdited();
+
+        // Indicate that undo/redo is done, if it was happening
+        stateStore.undoing = false;
+        stateStore.redoing = false;
     }
+);
 
-    @Watch('productStore.metadata', { deep: true })
-    onMetadataEdited(): void {
-        // Reload both metadata languages. Start with the other and then the current.
-        const otherLang = this.editorStore.configLang === 'en' ? 'fr' : 'en';
-        if (this.productStore.configs[otherLang]) {
-            this.productStore.useConfig(this.productStore.configs[otherLang] as StoryRampConfig, true);
-        }
-        if (this.productStore.configs[this.editorStore.configLang]) {
-            this.productStore.useConfig(
-                this.productStore.configs[this.editorStore.configLang] as StoryRampConfig,
-                true
-            );
-        }
-        this.editorStore.updateSaveStatus(true);
-        this.stateStore.updateUndoRedoAbility();
-        this.stateStore.undoing = false;
-        this.stateStore.redoing = false;
-    }
+// =========================================
+// Lifecycle functions
 
-    created(): void {
-        this.productStore.uuid = this.$route.params.uid as string;
+onBeforeMount(() => {
+    productStore.uuid = $route.params.uid as string;
 
-        window.addEventListener('beforeunload', this.beforeWindowUnload);
+    window.addEventListener('beforeunload', beforeWindowUnload);
 
-        // Only fetch a product when there isn't one already in the productStore
-        if (this.editorStore.loadStatus === 'waiting') {
-            this.productStore
-                .generateRemoteConfig()
-                .then(() => {
-                    Message.success(this.$t('editor.editMetadata.message.successfulLoad'));
-                    // Need to wait until product data is loaded into store before accessing it
-                    this.restoreProperties();
-                    this.editorStore.loadExisting = true;
-                })
-                .catch(() => {
-                    // Handle any connection/lock errors here
-                    Message.error(this.$t('editor.editMetadata.message.error.unauthorized'));
-                    setTimeout(() => {
-                        this.$router.push({ name: 'home' });
-                    }, 2000);
-                });
-        } else {
-            this.restoreProperties();
-        }
-
-        // extend the session
-        this.editorStore.extendSession(true);
-
-        this.fetchMarkdown();
-    }
-
-    mounted(): void {
-        console.log(' ');
-        console.log('editor mounted');
-        // from https://css-tricks.com/how-to-detect-when-a-sticky-element-gets-pinned/
-        const observer = new IntersectionObserver(([e]) => e.target.classList.toggle('z-40', e.intersectionRatio < 1), {
-            threshold: [1]
-        });
-
-        observer.observe(document.querySelector('.editor-header') as Element);
-        this.dropdownButtonWidth = (this.$refs.dropdownButton as HTMLElement).offsetWidth ?? 0;
-
-        this.editorStore.registerEditorComponent(this); // store this component in the editorStore
-    }
-
-    beforeDestroy(): void {
-        window.removeEventListener('beforeunload', this.beforeWindowUnload);
-    }
-
-    openMetadataModal() {
-        this.productStore.loadConfig(this.productStore.configs[this.editorStore.configLang]).then(() => {
-            this.$vfm.open('metadata-edit-modal');
-        });
-    }
-
-    /**
-     * Ensure that `loadSlides` and `currentSlide` are up to date with whats in the `productStore`. Essential after saving
-     * and resetting unsaved changes
-     */
-    restoreProperties() {
-        // TODO: When calling refreshConfig, `currentSlide` loses its reference to `slides` within the `productStore`. So
-        // `updateSlides()` would set `slideIndex` to -1. There may be a better workaround
-        const slideIndex = this.editorStore.selectedSlideIndex;
-        this.updateSlides();
-        // TODO: This would open the wrong panel if you were editing the right panel of a slide. We could keep track of
-        // the panel index somewhere and set it as needed
-        this.selectSlide(this.editorStore.selectedSlideIndex !== -1 ? this.editorStore.selectedSlideIndex : slideIndex);
-    }
-
-    refreshConfig(): void {
-        this.editorStore.currentSlide = '';
-        // Re-fetch the product from the server.
-        if (this.editorStore.loadExisting) {
-            this.editorStore.reloadExisting = true;
-            this.productStore.generateRemoteConfig().then(() => {
-                this.restoreProperties();
+    // Only fetch a product when there isn't one already in the productStore
+    if (editorStore.loadStatus === 'waiting') {
+        productStore
+            .generateRemoteConfig()
+            .then(() => {
+                Message.success(t('editor.editMetadata.message.successfulLoad'));
+                // Need to wait until product data is loaded into store before accessing it
+                restoreProperties();
+                editorStore.loadExisting = true;
+            })
+            .catch(() => {
+                // Handle any connection/lock errors here
+                Message.error(t('editor.editMetadata.message.error.unauthorized'));
+                setTimeout(() => {
+                    $router.push({ name: 'home' });
+                }, 2000);
             });
-        } else {
-            this.editorStore.reloadExisting = false;
-            this.productStore.generateNewConfig().then(() => {
-                this.restoreProperties();
-            });
-        }
+    } else {
+        restoreProperties();
     }
 
-    beforeRouteUpdate(to: RouteLocationNormalized, from: RouteLocationNormalized, next: () => void): void {
-        this.$i18n.locale = to.params.lang as string;
-        document.onmousemove = () => undefined;
-        document.onkeydown = () => undefined;
+    // extend the session
+    editorStore.extendSession(true);
 
-        // Both `to` and `from` are guaranteed to have a uuid param, unlike in the `metadata-editor` component
-        const uuidChange = to.params.uid !== from.params.uid;
+    fetchMarkdown();
 
-        // Unlock the product when the uuid in the url is updated
-        if (uuidChange) {
-            this.lockStore.unlockStoryline();
-            clearTimeout(this.lockStore.confirmationTimeout);
-            clearTimeout(this.lockStore.endTimeout);
+    // More accurate page height for mobile
+    // Counts the URL bar for mobile browsers (e.g. iOS Safari) so the content doesn't vertically overshoot
+    // and get covered by the URL bar when it's opened
 
-            // Ensures that upon executing the created() hook, the product is fetched from the server
-            this.editorStore.loadStatus = 'waiting';
-            this.editorStore.currentSlide = '';
-        }
+    let vh = window.innerHeight * 0.01;
+    document.documentElement.style.setProperty('--vh', `${vh}px`);
 
-        next();
-    }
+    window.addEventListener('resize', () => {
+        let vh = window.innerHeight * 0.01;
+        document.documentElement.style.setProperty('--vh', `${vh}px`);
+    });
+});
 
-    beforeRouteLeave(to: RouteLocationNormalized, from: RouteLocationNormalized, next: (cont?: boolean) => void): void {
-        const curEditor = this.$route.name === 'editor';
-        const confirmationMessage = this.$t('editor.leaveWarning');
+onMounted(() => {
+    // from https://css-tricks.com/how-to-detect-when-a-sticky-element-gets-pinned/
+    const observer = new IntersectionObserver(([e]) => e.target.classList.toggle('z-40', e.intersectionRatio < 1), {
+        threshold: [1]
+    });
 
-        const stay =
-            !this.editorStore.sessionExpired &&
-            this.stateStore.isChanged &&
-            curEditor &&
-            !window.confirm(confirmationMessage);
-        // This component is going bye-bye, so we need to do some clean up so that timers cannot fire later.
-        clearTimeout(this.lockStore.confirmationTimeout);
-        clearTimeout(this.lockStore.endTimeout);
-        document.onmousemove = () => undefined;
-        document.onkeydown = () => undefined;
+    observer.observe(document.querySelector('.editor-header') as Element);
+    dropdownButtonWidth.value = (dropdownButton.value as HTMLElement).offsetWidth ?? 0;
 
-        // Always unlock product, regardless of if we're reloading or navigating to a diff page
-        this.lockStore.unlockStoryline();
+    // TODO: Does 'this' still work properly in composition API???
+    editorStore.registerEditorComponent(this); // store this component in the editorStore
+});
 
-        if (stay) {
-            next(false);
-        } else {
-            next();
-        }
-    }
+onBeforeUnmount(() => {
+    window.removeEventListener('beforeunload', beforeWindowUnload);
+});
 
-    /**
-     * Opens the mobile sidebar drawer.
-     */
-    openSidebar(): void {
-        document.getElementById('sidebar-mobile')!.style.width = '20rem';
-        document.getElementById('overlay')!.style.display = 'block'; // Show the overlay
-        document.body.style.overflow = 'hidden'; // Disable background scrolling
-    }
+// =========================================
+// Component functions
 
-    /**
-     * Closes the mobile sidebar drawer.
-     */
-    closeSidebar(): void {
-        document.getElementById('sidebar-mobile')!.style.width = '0px';
-        document.getElementById('overlay')!.style.display = 'none'; // Hide the overlay
-        document.body.style.overflow = ''; // Re-enable background scrolling
-    }
+function openMetadataModal() {
+    productStore.loadConfig(productStore.configs[editorStore.configLang]).then(() => {
+        $vfm.open('metadata-edit-modal');
+    });
+}
+/**
+ * Ensure that `loadSlides` and `currentSlide` are up to date with whats in the `productStore`. Essential after saving
+ * and resetting unsaved changes
+ */
+function restoreProperties() {
+    // TODO: When calling refreshConfig, `currentSlide` loses its reference to `slides` within the `productStore`. So
+    // `updateSlides()` would set `slideIndex` to -1. There may be a better workaround
+    const index = editorStore.selectedSlideIndex;
+    updateSlides();
+    // TODO: This would open the wrong panel if you were editing the right panel of a slide. We could keep track of
+    // the panel index somewhere and set it as needed
+    selectSlide(editorStore.selectedSlideIndex !== -1 ? editorStore.selectedSlideIndex : index);
+}
 
-    /**
-     * Change current slide to selected slide.
-     */
-    selectSlide(index: number, lang?: SupportedLanguages, panelIndex?: number, done?: Function): void {
-        const configLang = this.editorStore.configLang;
-
-        // save changes to current slide before changing slides
-        if (this.$refs.slide !== undefined) {
-            (this.$refs.slide as SlideEditorV).saveChanges();
-        }
-
-        // Quickly swap to loading page, and then swap to new slide. Allows Vue to re-draw page correctly.
-        this.editorStore.currentSlide = {
-            title: '',
-            panel: [{ type: 'loading-page' }, { type: 'loading-page' }]
-        };
-
-        const newLang = lang || configLang || 'en';
-        if (configLang !== newLang) {
-            this.editorStore.changeLang(newLang);
-        }
-
-        setTimeout(() => {
-            if (index === -1 || !this.loadSlides || !this.loadSlides[index] || !this.loadSlides[index]?.[newLang]?.panel) {
-                this.editorStore.currentSlide = '';
-            } else {
-                const selectedLang = newLang as keyof MultiLanguageSlide;
-                const selectedSlide = this.loadSlides[index][selectedLang];
-
-                // If the requested language config for a slide doesn't exist, open the other language
-                // This edge case should ONLY pop up while using the "Next/Previous Slide" buttons
-                this.editorStore.currentSlide =
-                    selectedSlide ?? this.loadSlides[index][selectedLang === 'en' ? 'fr' : 'en'] ?? '';
-            }
-            this.editorStore.selectedSlideIndex = index;
-            (this.$refs.slide as SlideEditorV).panelIndex = panelIndex ?? 0;
-            this.editorStore.selectedPanelIndex = panelIndex ?? 0;
-            this.editorStore.selectedSlideLang = newLang;
-
-            (this.$refs.slide as SlideEditorV).advancedEditorView = false;
-            if (done) {
-                done();
-            }
-        }, 5);
-    }
-
-    /**
-     * Update slide for a custom config made through advanced editor.
-     */
-    updateCustomSlide(slideConfig: Slide, save?: boolean, lang?: string): void {
-        const currentLang = this.editorStore.selectedSlideLang;
-
-        this.productStore.slidesWorkingCopy[this.editorStore.selectedSlideIndex][
-            (lang ?? currentLang) as keyof MultiLanguageSlide
-        ] = this.editorStore.currentSlide as Slide;
-
-        this.productStore.configs[(lang ?? currentLang) as keyof MultiLanguageSlide]!.slides[
-            this.editorStore.selectedSlideIndex
-        ] = this.editorStore.currentSlide as Slide;
-
-        // save changes emitted from advanced editor
-        if (save) {
-            this.productStore.onSave();
-        }
-    }
-
-    /**
-     * Updates slides after adding, removing, or reordering.
-     */
-    updateSlides(dontEmitEvent?: boolean, dontChangeIndex?: boolean, onDone?: Function): void {
-        this.loadSlides = this.productStore.slidesWorkingCopy;
-        if (!dontChangeIndex && this.editorStore.currentSlide !== '') {
-            this.editorStore.selectedSlideIndex = this.loadSlides.findIndex(
-                (bothSlides) =>
-                    (this.editorStore.currentSlide as Slide) === bothSlides['en'] ||
-                    (this.editorStore.currentSlide as Slide) === bothSlides['fr']
-            );
-        }
-
-        this.productStore.configs.en!.slides = this.productStore.slidesWorkingCopy.map((slides) => slides.en!);
-        this.productStore.configs.fr!.slides = this.productStore.slidesWorkingCopy.map((slides) => slides.fr!);
-
-        if (!dontEmitEvent) {
-            this.editorStore.updateSaveStatus(undefined, 'Slide updated');
-        }
-
-        if (onDone) {
-            onDone();
-        }
-    }
-
-    /**
-     * Fetch markdown content for help panel.
-     */
-    fetchMarkdown(): void {
-        const helpPath = process.env.NODE_ENV === 'development' ? `../../help/` : `./help/`;
-        const helpFile = `respect-help-${this.$route.params.lang}.md`;
-
-        axios.get(`${helpPath}${helpFile}`).then((r) => {
-            const reg = /^#\s(.*)\n{2}(?:.+|\n(?!\n{2,}))*/gm;
-            const renderer = new marked.Renderer();
-            renderer.image = (href: string, title: string, text: string) => {
-                if (href.indexOf('http') === -1) {
-                    href = helpPath + 'images/' + href;
-                }
-                return `<img src="${href}" alt="${text}">`;
-            };
-            this.helpMd = r.data.replace(new RegExp(String.fromCharCode(13), 'g'), '');
-            let section;
-            while ((section = reg.exec(this.helpMd))) {
-                const info_results = marked(section[0].split('\n').splice(2).join('\n'), { renderer }) as string;
-                this.helpSections.push({
-                    header: section[1],
-                    info: info_results,
-                    drawn: true,
-                    expanded: false
-                });
-                //copy of the original text to refer to after highlighting
-                this.originalTextArray.push(info_results);
-            }
+function refreshConfig(): void {
+    editorStore.currentSlide = '';
+    // Re-fetch the product from the server.
+    if (editorStore.loadExisting) {
+        editorStore.reloadExisting = true;
+        productStore.generateRemoteConfig().then(() => {
+            restoreProperties();
         });
-    }
-
-    /**
-     * Smooth scroll to an element on the table of contents. Will end scroll in the middle of the ToC vertical area, if able.
-     * @param index The index of the slide to scroll to.
-     */
-    scrollToElement(index: number): void {
-        setTimeout(() => {
-            document
-                .getElementById((this.isMobileSidebar ? 'mobile' : '') + 'slide' + index)
-                ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
-        }, 10);
-    }
-
-    exportProduct(): void {
-        if (this.$refs.slide != null && this.editorStore.currentSlide !== '') {
-            (this.$refs.slide as SlideEditorV).saveChanges();
-        }
-
-        this.productStore.generateConfig(false);
-
-        this.productStore.configFileStructure.zip.generateAsync({ type: 'blob' }).then(
-            (blob) => {
-                saveAs(blob, `${this.productStore.configFileStructure.uuid}.zip`);
-                Message.success(this.$t('editor.export.success'));
-            },
-            (err) => {
-                Message.error(this.$t('editor.export.error'));
-            }
-        );
-    }
-
-    /**
-     * Open current editor config as a new Storylines product in new tab.
-     * @param language The config language to preview (either 'en' or 'fr')
-     */
-    preview(language: string): void {
-        // save current slide final changes before previewing product
-        if (this.$refs.slide != null && this.editorStore.currentSlide !== '') {
-            (this.$refs.slide as SlideEditorV).saveChanges();
-        }
-
-        const previewConfigs = this.productStore.configs;
-        // Replace undefined slides with empty slides, just like in final save
-        previewConfigs.en!.slides = previewConfigs.en!.slides.map((slide) => {
-            return slide ?? JSON.parse(JSON.stringify(this.defaultBlankSlide));
+    } else {
+        editorStore.reloadExisting = false;
+        productStore.generateNewConfig().then(() => {
+            restoreProperties();
         });
-        previewConfigs.fr!.slides = previewConfigs.fr!.slides.map((slide) => {
-            return slide ?? JSON.parse(JSON.stringify(this.defaultBlankSlide));
-        });
-        const lockStore = useLockStore();
-
-        setTimeout(() => {
-            const routeData = this.$router.resolve({
-                name: 'preview',
-                params: { lang: language, uid: this.productStore.uuid }
-            });
-            const previewTab = window.open(routeData.href, '_blank');
-            (previewTab as Window).props = {
-                configs: previewConfigs,
-                configFileStructure: this.productStore.configFileStructure,
-                secret: lockStore.secret,
-                timeRemaining: lockStore.timeRemaining
-            };
-        }, 5);
-    }
-
-    saveChanges(): void {
-        console.log(' ');
-        console.log('editor - saveChanges()');
-        // save current slide final changes before generating config file
-        if (this.$refs.slide !== undefined) {
-            (this.$refs.slide as SlideEditorV).saveChanges();
-        }
-
-        this.productStore.onSave().then(this.restoreProperties);
-    }
-
-    beforeWindowUnload(e: BeforeUnloadEvent): void {
-        // show popup if when leaving page with unsaved changes, or with a brand new product
-        if ((this.stateStore.isChanged && !window.confirm()) || !this.editorStore.loadExisting) {
-            e.preventDefault();
-        }
     }
 }
 
-// More accurate page height for mobile
-// Counts the URL bar for mobile browsers (e.g. iOS Safari) so the content doesn't vertically overshoot
-// and get covered by the URL bar when it's opened
+// TODO: This is not used. Remove?
+function beforeRouteUpdate(to: RouteLocationNormalized, from: RouteLocationNormalized, next: () => void): void {
+    $i18n.locale = to.params.lang as string;
+    document.onmousemove = () => undefined;
+    document.onkeydown = () => undefined;
 
-let vh = window.innerHeight * 0.01;
-document.documentElement.style.setProperty('--vh', `${vh}px`);
+    // Both `to` and `from` are guaranteed to have a uuid param, unlike in the `metadata-editor` component
+    const uuidChange = to.params.uid !== from.params.uid;
 
-window.addEventListener('resize', () => {
-    let vh = window.innerHeight * 0.01;
-    document.documentElement.style.setProperty('--vh', `${vh}px`);
-});
+    // Unlock the product when the uuid in the url is updated
+    if (uuidChange) {
+        lockStore.unlockStoryline();
+        clearTimeout(lockStore.confirmationTimeout);
+        clearTimeout(lockStore.endTimeout);
+
+        // Ensures that upon executing the created() hook, the product is fetched from the server
+        editorStore.loadStatus = 'waiting';
+        editorStore.currentSlide = '';
+    }
+
+    next();
+}
+
+// TODO: This is not used. Remove?
+function beforeRouteLeave(
+    to: RouteLocationNormalized,
+    from: RouteLocationNormalized,
+    next: (cont?: boolean) => void
+): void {
+    const curEditor = $route.name === 'editor';
+    const confirmationMessage = t('editor.leaveWarning');
+
+    const stay =
+        !editorStore.sessionExpired && stateStore.isChanged && curEditor && !window.confirm(confirmationMessage);
+    // This component is going bye-bye, so we need to do some clean up so that timers cannot fire later.
+    clearTimeout(lockStore.confirmationTimeout);
+    clearTimeout(lockStore.endTimeout);
+    document.onmousemove = () => undefined;
+    document.onkeydown = () => undefined;
+
+    // Always unlock product, regardless of if we're reloading or navigating to a diff page
+    lockStore.unlockStoryline();
+
+    if (stay) {
+        next(false);
+    } else {
+        next();
+    }
+}
+
+/**
+ * Opens the mobile sidebar drawer.
+ */
+function openSidebar(): void {
+    document.getElementById('sidebar-mobile')!.style.width = '20rem';
+    document.getElementById('overlay')!.style.display = 'block'; // Show the overlay
+    document.body.style.overflow = 'hidden'; // Disable background scrolling
+}
+
+/**
+ * Closes the mobile sidebar drawer.
+ */
+function closeSidebar(): void {
+    document.getElementById('sidebar-mobile')!.style.width = '0px';
+    document.getElementById('overlay')!.style.display = 'none'; // Hide the overlay
+    document.body.style.overflow = ''; // Re-enable background scrolling
+}
+
+/**
+ * Change current slide to selected slide.
+ */
+function selectSlide(index: number, lang?: SupportedLanguages, panelIndex?: number, done?: Function): void {
+    const configLang = editorStore.configLang;
+
+    // save changes to current slide before changing slides
+    if (!slide.value !== undefined) {
+        slide.value?.saveChanges();
+    }
+
+    // Quickly swap to loading page, and then swap to new slide. Allows Vue to re-draw page correctly.
+    editorStore.currentSlide = {
+        title: '',
+        panel: [{ type: 'loading-page' }, { type: 'loading-page' }]
+    };
+
+    const newLang = lang || configLang || 'en';
+    if (configLang !== newLang) {
+        editorStore.changeLang(newLang);
+    }
+
+    setTimeout(() => {
+        if (
+            index === -1 ||
+            !loadSlides.value ||
+            !loadSlides.value[index] ||
+            !loadSlides.value[index]?.[newLang]?.panel
+        ) {
+            editorStore.currentSlide = '';
+        } else {
+            const selectedLang = newLang as keyof MultiLanguageSlide;
+            const selectedSlide = loadSlides.value[index][selectedLang];
+
+            // If the requested language config for a slide doesn't exist, open the other language
+            // This edge case should ONLY pop up while using the "Next/Previous Slide" buttons
+            editorStore.currentSlide =
+                selectedSlide ?? loadSlides.value[index][selectedLang === 'en' ? 'fr' : 'en'] ?? '';
+        }
+        editorStore.selectedSlideIndex = index;
+        editorStore.selectedPanelIndex = panelIndex ?? 0;
+        editorStore.selectedSlideLang = newLang;
+        (slide.value as typeof SlideEditorV).panelIndex = panelIndex ?? 0;
+        (slide.value as typeof SlideEditorV).advancedEditorView = false;
+
+        if (done) {
+            done();
+        }
+    }, 5);
+}
+
+/**
+ * Update slide for a custom config made through advanced editor.
+ */
+function updateCustomSlide(slideConfig: Slide, save?: boolean, lang?: string): void {
+    const configLang = editorStore.configLang;
+
+    productStore.slidesWorkingCopy[editorStore.selectedSlideIndex][(lang ?? configLang) as keyof MultiLanguageSlide] =
+        editorStore.currentSlide as Slide;
+
+    if (productStore.configs[(lang ?? configLang) as keyof MultiLanguageSlide]) {
+        productStore.configs[(lang ?? configLang) as keyof MultiLanguageSlide]!.slides[editorStore.selectedSlideIndex] =
+            editorStore.currentSlide as Slide;
+    }
+
+    // save changes emitted from advanced editor
+    if (save) {
+        productStore.onSave();
+    }
+}
+
+/**
+ * Updates slides after adding, removing, or reordering.
+ */
+function updateSlides(dontEmitEvent?: boolean, dontChangeIndex?: boolean, onDone?: Function): void {
+    loadSlides.value = productStore.slidesWorkingCopy;
+    if (!dontChangeIndex && editorStore.currentSlide !== '') {
+        editorStore.selectedSlideIndex = loadSlides.value!.findIndex(
+            (bothSlides) =>
+                (editorStore.currentSlide as Slide) === bothSlides['en'] ||
+                (editorStore.currentSlide as Slide) === bothSlides['fr']
+        );
+    }
+    productStore.configs.en!.slides = productStore.slidesWorkingCopy.map((slides) => slides.en!);
+    productStore.configs.fr!.slides = productStore.slidesWorkingCopy.map((slides) => slides.fr!);
+
+    if (!dontEmitEvent) {
+        editorStore.updateSaveStatus(undefined, 'Slide updated');
+    }
+
+    if (onDone) {
+        onDone();
+    }
+}
+
+/**
+ * Fetch markdown content for help panel.
+ */
+function fetchMarkdown(): void {
+    const helpPath = process.env.NODE_ENV === 'development' ? `../../help/` : `./help/`;
+    const helpFile = `respect-help-${$route.params.lang}.md`;
+
+    axios.get(`${helpPath}${helpFile}`).then((r) => {
+        const reg = /^#\s(.*)\n{2}(?:.+|\n(?!\n{2,}))*/gm;
+        const renderer = new marked.Renderer();
+        renderer.image = (href: string, title: string, text: string) => {
+            if (href.indexOf('http') === -1) {
+                href = helpPath + 'images/' + href;
+            }
+            return `<img src="${href}" alt="${text}">`;
+        };
+        helpMd.value = r.data.replace(new RegExp(String.fromCharCode(13), 'g'), '');
+        let section;
+        while ((section = reg.exec(helpMd.value))) {
+            const info_results = marked(section[0].split('\n').splice(2).join('\n'), { renderer }) as string;
+            helpSections.value.push({
+                header: section[1],
+                info: info_results,
+                drawn: true,
+                expanded: false
+            });
+            //copy of the original text to refer to after highlighting
+            originalTextArray.value.push(info_results);
+        }
+    });
+}
+
+/**
+ * Smooth scroll to an element on the table of contents. Will end scroll in the middle of the ToC vertical area, if able.
+ * @param index The index of the slide to scroll to.
+ */
+function scrollToElement(index: number): void {
+    setTimeout(() => {
+        document
+            .getElementById((props.isMobileSidebar ? 'mobile' : '') + 'slide' + index)
+            ?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }, 10);
+}
+
+function exportProduct(): void {
+    if (slide.value != null && editorStore.currentSlide !== '') {
+        (slide.value as typeof SlideEditorV).saveChanges();
+    }
+
+    productStore.generateConfig(false);
+
+    productStore.configFileStructure.zip.generateAsync({ type: 'blob' }).then(
+        (blob) => {
+            saveAs(blob, `${productStore.configFileStructure.uuid}.zip`);
+            Message.success(t('editor.export.success'));
+        },
+        (err) => {
+            Message.error(t('editor.export.error'));
+        }
+    );
+}
+
+/**
+ * Open current editor config as a new Storylines product in new tab.
+ * @param language The config language to preview (either 'en' or 'fr')
+ */
+function preview(language: string): void {
+    // save current slide final changes before previewing product
+    if (slide.value != null && editorStore.currentSlide !== '') {
+        slide.value.saveChanges();
+    }
+
+    const previewConfigs = productStore.configs;
+    // Replace undefined slides with empty slides, just like in final save
+    previewConfigs.en!.slides = previewConfigs.en!.slides.map((slide) => {
+        return slide ?? JSON.parse(JSON.stringify(defaultBlankSlide));
+    });
+    previewConfigs.fr!.slides = previewConfigs.fr!.slides.map((slide) => {
+        return slide ?? JSON.parse(JSON.stringify(defaultBlankSlide));
+    });
+    const lockStore = useLockStore();
+
+    setTimeout(() => {
+        const routeData = $router.resolve({
+            name: 'preview',
+            params: { lang: language, uid: productStore.uuid }
+        });
+        const previewTab = window.open(routeData.href, '_blank');
+        (previewTab as Window).props = {
+            configs: previewConfigs,
+            configFileStructure: productStore.configFileStructure,
+            secret: lockStore.secret,
+            timeRemaining: lockStore.timeRemaining
+        };
+    }, 5);
+}
+
+function saveChanges(): void {
+    // save current slide final changes before generating config file
+    if (slide.value !== undefined) {
+        (slide.value as typeof SlideEditorV).saveChanges();
+    }
+
+    productStore.onSave().then(restoreProperties);
+}
+
+function beforeWindowUnload(e: BeforeUnloadEvent): void {
+    // show popup if when leaving page with unsaved changes, or with a brand new product
+    if ((stateStore.isChanged && !window.confirm()) || !editorStore.loadExisting) {
+        e.preventDefault();
+    }
+}
+
+// =========================================
+// Component exposes
+
+defineExpose({ saveChanges });
 </script>
 
 <style lang="scss">

--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -750,7 +750,7 @@ export default class EditorV extends Vue {
         this.onMetadataEdited();
     }
 
-    @Watch('metadata', { deep: true })
+    @Watch('productStore.metadata', { deep: true })
     onMetadataEdited(): void {
         // Reload both metadata languages. Start with the other and then the current.
         const otherLang = this.editorStore.configLang === 'en' ? 'fr' : 'en';
@@ -802,6 +802,8 @@ export default class EditorV extends Vue {
     }
 
     mounted(): void {
+        console.log(' ');
+        console.log('editor mounted');
         // from https://css-tricks.com/how-to-detect-when-a-sticky-element-gets-pinned/
         const observer = new IntersectionObserver(([e]) => e.target.classList.toggle('z-40', e.intersectionRatio < 1), {
             threshold: [1]
@@ -941,7 +943,7 @@ export default class EditorV extends Vue {
         }
 
         setTimeout(() => {
-            if (index === -1 || !this.loadSlides || !this.loadSlides[index] || !this.loadSlides[index][newLang].panel) {
+            if (index === -1 || !this.loadSlides || !this.loadSlides[index] || !this.loadSlides[index]?.[newLang]?.panel) {
                 this.editorStore.currentSlide = '';
             } else {
                 const selectedLang = newLang as keyof MultiLanguageSlide;
@@ -972,11 +974,11 @@ export default class EditorV extends Vue {
 
         this.productStore.slidesWorkingCopy[this.editorStore.selectedSlideIndex][
             (lang ?? currentLang) as keyof MultiLanguageSlide
-        ] = this.editorStore.currentSlide;
+        ] = this.editorStore.currentSlide as Slide;
 
         this.productStore.configs[(lang ?? currentLang) as keyof MultiLanguageSlide]!.slides[
             this.editorStore.selectedSlideIndex
-        ] = this.editorStore.currentSlide;
+        ] = this.editorStore.currentSlide as Slide;
 
         // save changes emitted from advanced editor
         if (save) {
@@ -1107,6 +1109,8 @@ export default class EditorV extends Vue {
     }
 
     saveChanges(): void {
+        console.log(' ');
+        console.log('editor - saveChanges()');
         // save current slide final changes before generating config file
         if (this.$refs.slide !== undefined) {
             (this.$refs.slide as SlideEditorV).saveChanges();

--- a/src/components/home/home.vue
+++ b/src/components/home/home.vue
@@ -129,7 +129,7 @@
                     class="home-btn-container border border-gray-400 border-solid home-buttons flex justify-center h-full"
                     target
                     @click="$vfm.open('admin-upload-modal')"
-                    v-if="profile.role === 'Admin'"
+                    v-if="profile.role !== 'Admin'"
                 >
                     <button
                         class="dashboard-option-button flex items-center justify-center text-xl font-bold w-full"

--- a/src/components/landing.vue
+++ b/src/components/landing.vue
@@ -55,29 +55,42 @@
     </div>
 </template>
 
-<script lang="ts">
-import { Vue } from 'vue-property-decorator';
+<script setup lang="ts">
 import { useUserStore } from '../stores/userStore';
+import { computed, getCurrentInstance, onBeforeMount } from 'vue';
 
-export default class LandingV extends Vue {
-    url = window.location.href;
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
-    beforeCreate(): void {
-        // Automatically choose lang and re-route when the user is using Canada.ca template
-        if (this.url.includes('index-ca')) {
-            const lang = this.url.includes('index-ca-en') ? 'en' : 'fr';
-            this.$router.push({
-                name: 'home',
-                params: { lang }
-            });
-        }
+// =========================================
+// Definitions
+
+const url = window.location.href;
+const { $router } = getCurrentInstance()!.proxy!;
+const userStore = useUserStore();
+
+const userName = computed(() => userStore.userProfile?.userName || 'Guest');
+
+// =========================================
+// Watchers
+
+// =========================================
+// Lifecycle functions
+
+onBeforeMount(() => {
+    // Automatically choose lang and re-route when the user is using Canada.ca template
+    if (url.includes('index-ca')) {
+        const lang = url.includes('index-ca-en') ? 'en' : 'fr';
+        $router.push({
+            name: 'home',
+            params: { lang }
+        });
     }
+});
 
-    get userName(): string {
-        const userStore = useUserStore();
-        return userStore.userProfile?.userName || 'Guest';
-    }
-}
+// =========================================
+// Component functions
 </script>
 
 <style lang="scss">

--- a/src/components/metadata/metadata-content.vue
+++ b/src/components/metadata/metadata-content.vue
@@ -418,6 +418,8 @@ export default class MetadataEditorV extends Vue {
 
     productStore = useProductStore();
 
+    productStore = useProductStore();
+
     openFileSelector(where = 'logoUpload'): void {
         document.getElementById(where)?.click();
     }

--- a/src/components/metadata/metadata-content.vue
+++ b/src/components/metadata/metadata-content.vue
@@ -402,114 +402,131 @@
     </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { MetadataContent } from '@/definitions';
-import { Options, Prop, Vue } from 'vue-property-decorator';
+import { getCurrentInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
 import ColourPickerInput from '../support/colour-picker-input.vue';
 import { useProductStore } from '@/stores/productStore';
+import Message from 'vue-m-message';
 
-@Options({
-    components: {
-        ColourPickerInput: ColourPickerInput
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = withDefaults(
+    defineProps<{
+        editing?: boolean;
+    }>(),
+    {
+        editing: true,
     }
-})
-export default class MetadataEditorV extends Vue {
-    @Prop({ default: true }) editing!: boolean;
+);
 
-    productStore = useProductStore();
+// =========================================
+// Definitions
 
-    productStore = useProductStore();
+const productStore = useProductStore();
+const { t } = useI18n();
 
-    openFileSelector(where = 'logoUpload'): void {
-        document.getElementById(where)?.click();
-    }
+// =========================================
+// Watchers
 
-    metadataChanged(event: Event): void {
-        this.productStore.updateMetadata(
-            (event.target as HTMLInputElement).name,
-            (event.target as HTMLInputElement).value
-        );
-    }
+// =========================================
+// Lifecycle functions
 
-    removeLogo(): void {
-        this.productStore.metadata.logoName = '';
-        this.productStore.metadata.logoPreview = '';
-        this.productStore.decrementSourceCount('Logo');
-    }
+// =========================================
+// Component functions
 
-    removeIntroBackground(): void {
-        this.productStore.metadata.introBgName = '';
-        this.productStore.metadata.introBgPreview = '';
-        this.productStore.decrementSourceCount('Background');
-    }
+function openFileSelector(where = 'logoUpload'): void {
+    document.getElementById(where)?.click();
+}
 
-    onImageSourceInput(e: InputEvent, src: string): void {
-        const isImgUrl = (url: string) => {
-            const img = new Image();
-            img.src = url;
-            return new Promise((resolve) => {
-                img.onerror = () => resolve(false);
-                img.onload = () => resolve(true);
+function metadataChanged(event: Event): void {
+    productStore.updateMetadata((event.target as HTMLInputElement).name, (event.target as HTMLInputElement).value);
+}
+
+function removeLogo(): void {
+    productStore.metadata.logoName = '';
+    productStore.metadata.logoPreview = '';
+    productStore.decrementSourceCount('Logo');
+}
+
+function removeIntroBackground(): void {
+    productStore.metadata.introBgName = '';
+    productStore.metadata.introBgPreview = '';
+    productStore.decrementSourceCount('Background');
+}
+
+function onImageSourceInput(e: InputEvent, src: string): void {
+    const isImgUrl = (url: string) => {
+        const img = new Image();
+        img.src = url;
+        return new Promise((resolve) => {
+            img.onerror = () => resolve(false);
+            img.onload = () => resolve(true);
+        });
+    };
+
+    switch (src) {
+        case 'logo':
+            productStore.metadata.logoName = (e.target as HTMLInputElement).value;
+
+            isImgUrl(productStore.metadata.logoName).then((res) => {
+                if (res) {
+                    productStore.metadata.logoPreview = productStore.metadata.logoName;
+                    Message.success(t('editor.editMetadata.message.imageSuccessfulLoad'));
+                } else {
+                    productStore.metadata.logoPreview = 'error';
+                    Message.error(t('editor.editMetadata.message.error.imageFailedLoad'));
+                }
             });
-        };
 
-        switch (src) {
-            case 'logo':
-                this.productStore.metadata.logoName = (e.target as HTMLInputElement).value;
+            break;
+        case 'introBg':
+            productStore.metadata.introBgName = (e.target as HTMLInputElement).value;
 
-                isImgUrl(this.productStore.metadata.logoName).then((res) => {
-                    if (res) {
-                        this.productStore.metadata.logoPreview = this.productStore.metadata.logoName;
-                        Message.success(this.$t('editor.editMetadata.message.imageSuccessfulLoad'));
-                    } else {
-                        this.productStore.metadata.logoPreview = 'error';
-                        Message.error(this.$t('editor.editMetadata.message.error.imageFailedLoad'));
-                    }
-                });
-
-                break;
-            case 'introBg':
-                this.productStore.metadata.introBgName = (e.target as HTMLInputElement).value;
-
-                isImgUrl(this.productStore.metadata.introBgName).then((res) => {
-                    if (res) {
-                        this.productStore.metadata.introBgPreview = this.productStore.metadata.introBgName;
-                        Message.success(this.$t('editor.editMetadata.message.imageSuccessfulLoad'));
-                    } else {
-                        this.productStore.metadata.introBgPreview = 'error';
-                        Message.error(this.$t('editor.editMetadata.message.error.imageFailedLoad'));
-                    }
-                });
-                break;
-            default:
-                console.error('onImageSourceInput received invalid source.');
-        }
-    }
-
-    onFileChange(e: Event, src: string): void {
-        // Retrieve the uploaded file.
-        const uploadedFile = ((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
-
-        switch (src) {
-            case 'logo':
-                this.productStore.logoImage = uploadedFile;
-
-                // Generate an image preview.
-                this.productStore.metadata.logoPreview = URL.createObjectURL(uploadedFile);
-                this.productStore.metadata.logoName = uploadedFile.name;
-                break;
-            case 'introBg':
-                this.productStore.introBgImage = uploadedFile;
-
-                // Generate an image preview.
-                this.productStore.metadata.introBgPreview = URL.createObjectURL(uploadedFile);
-                this.productStore.metadata.introBgName = uploadedFile.name;
-                break;
-            default:
-                console.error('onFileChange received invalid source.');
-        }
+            isImgUrl(productStore.metadata.introBgName).then((res) => {
+                if (res) {
+                    productStore.metadata.introBgPreview = productStore.metadata.introBgName;
+                    Message.success(t('editor.editMetadata.message.imageSuccessfulLoad'));
+                } else {
+                    productStore.metadata.introBgPreview = 'error';
+                    Message.error(t('editor.editMetadata.message.error.imageFailedLoad'));
+                }
+            });
+            break;
+        default:
+            console.error('onImageSourceInput received invalid source.');
     }
 }
+
+function onFileChange(e: Event, src: string): void {
+    // Retrieve the uploaded file.
+    const uploadedFile = ((e.target as HTMLInputElement).files as ArrayLike<File>)[0];
+
+    switch (src) {
+        case 'logo':
+            productStore.logoImage = uploadedFile;
+
+            // Generate an image preview.
+            productStore.metadata.logoPreview = URL.createObjectURL(uploadedFile);
+            productStore.metadata.logoName = uploadedFile.name;
+            break;
+        case 'introBg':
+            productStore.introBgImage = uploadedFile;
+
+            // Generate an image preview.
+            productStore.metadata.introBgPreview = URL.createObjectURL(uploadedFile);
+            productStore.metadata.introBgName = uploadedFile.name;
+            break;
+        default:
+            console.error('onFileChange received invalid source.');
+    }
+}
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss">

--- a/src/components/metadata/metadata-editor.vue
+++ b/src/components/metadata/metadata-editor.vue
@@ -66,7 +66,7 @@
                             @click="
                                 renameMode = !renameMode;
                                 editorStore.changeUuid = '';
-                                warning = editorStore.warning === 'rename' ? 'none' : editorStore.warning;
+                                editorStore.warning = editorStore.warning === 'rename' ? 'none' : editorStore.warning;
                             "
                         >
                             {{ renameMode ? $t('editor.cancel') : $t('editor.changeUuid') }}
@@ -123,7 +123,7 @@
 
                             <!-- If config is loading, display a small spinner. -->
                             <div class="inline-flex align-middle mb-1" v-if="checkingUuid || processingRename">
-                                <spinner size="24px" color="#009cd1" class="mx-2 my-auto"></spinner>
+                                <VueSpinnerOval size="24px" color="#009cd1" class="mx-2 my-auto"></VueSpinnerOval>
                             </div>
                         </div>
                         <!-- UUID entry (default) -->
@@ -187,7 +187,7 @@
                                 </div>
                                 <!-- If config is loading, display a small spinner. -->
                                 <div class="inline-flex align-middle ml-1 mb-1" v-if="checkingUuid && !editExisting">
-                                    <spinner size="24px" color="#009cd1" class="mx-2 my-auto"></spinner>
+                                    <VueSpinnerOval size="24px" color="#009cd1" class="mx-2 my-auto"></VueSpinnerOval>
                                 </div>
                                 <!-- Load UUID button -->
                                 <!-- Load storyline with the given UUID, if it exists on the server, and also
@@ -221,7 +221,7 @@
                             </p>
                             <!-- Spinner -->
                             <div class="align-middle mb-1">
-                                <spinner size="65px" thickness="20" color="#009cd1" class="mx-2 my-auto"></spinner>
+                                <VueSpinnerOval size="65px" thickness="20" color="#009cd1" class="mx-2 my-auto" />
                             </div>
                             <!-- Cancel load button -->
                             <div class="flex">
@@ -455,10 +455,10 @@
                                 <!-- The form -->
                                 <!-- If editingMetadata === false, form is read-only; if true, it can be edited -->
                                 <!-- New projects can only be in edit mode; existing projects can be in both -->
-                                <metadata-content
+                                <MetadataContentV
                                     :createNew="true && !editExisting"
                                     :editing="editorStore.editingMetadata"
-                                ></metadata-content>
+                                ></MetadataContentV>
                                 <!-- Save/discard changes buttons (existing only) -->
                                 <div v-if="editorStore.editingMetadata && editExisting" class="flex gap-3 mt-2">
                                     <!-- Save changes -->
@@ -542,7 +542,7 @@
                 >
                     <!-- If config is loading, display a small spinner. -->
                     <div class="inline-flex align-middle ml-1 mb-1" v-if="loadingIntoEditor">
-                        <spinner size="24px" color="#009cd1" class="mx-2 my-auto"></spinner>
+                        <VueSpinnerOval size="24px" color="#009cd1" class="mx-2 my-auto"></VueSpinnerOval>
                     </div>
                     <button
                         :disabled="
@@ -573,7 +573,7 @@
                     </button>
                 </div>
 
-                <confirmation-modal
+                <ConfirmationModalV
                     :name="`confirm-uuid-overwrite`"
                     :message="
                         $t('editor.confirmOverwrite', {
@@ -584,7 +584,8 @@
                 />
             </div>
         </div>
-        <confirmation-modal
+
+        <ConfirmationModalV
             :name="`confirm-extend-session-editor`"
             :message="
                 $t('editor.extendSession', {
@@ -599,17 +600,14 @@
     </div>
 </template>
 
-<script lang="ts">
-import ActionModal from '@/components/support/action-modal.vue';
-import { Save, useStateStore } from '@/stores/stateStore';
-import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
+<script setup lang="ts">
+import { useStateStore } from '@/stores/stateStore';
 import { RouteLocationNormalized } from 'vue-router';
 import { AxiosResponse } from 'axios';
 import { debounce } from 'throttle-debounce';
 import {
     ConfigFileStructure,
     MetadataContent,
-    MultiLanguageSlide,
     Slide,
     SourceCounts,
     StoryRampConfig,
@@ -617,26 +615,37 @@ import {
     TextPanel
 } from '@/definitions';
 import { VueSpinnerOval } from 'vue3-spinners';
-import { VueFinalModal } from 'vue-final-modal';
 import { useUserStore } from '@/stores/userStore';
-import { computed } from 'vue';
 
-import JSZip from 'jszip';
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 
 import Message from 'vue-m-message';
-import SlideEditorV from '../slide-editor.vue';
-import SlideTocV from '../slide-toc/slide-toc.vue';
 import MetadataContentV from './metadata-content.vue';
-import MetadataModalV from './metadata-modal.vue';
 import ConfirmationModalV from '../support/confirmation-modal.vue';
-import EditorV from '../editor.vue';
 
-import cloneDeep from 'clone-deep';
 import { useLockStore } from '@/stores/lockStore';
 import { useProductStore } from '@/stores/productStore';
 import { useEditorStore } from '@/stores/editorStore';
+
+import { computed, getCurrentInstance, onBeforeMount, onBeforeUnmount, onMounted, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = withDefaults(
+    defineProps<{
+        editExisting?: boolean;
+    }>(),
+    { editExisting: true }
+);
+
+const emit = defineEmits([]);
+
+// =========================================
+// Definitions
 
 interface RouteParams {
     uid: string;
@@ -658,375 +667,379 @@ interface History {
     created: string;
 }
 
-@Options({
-    components: {
-        ActionModal,
-        Editor: EditorV,
-        'confirmation-modal': ConfirmationModalV,
-        'metadata-content': MetadataContentV,
-        'metadata-modal': MetadataModalV,
-        spinner: VueSpinnerOval,
-        'slide-editor': SlideEditorV,
-        'slide-toc': SlideTocV
+const { $route, $router, $i18n, $nextTick, $el, $vfm } = getCurrentInstance()!.proxy!;
+
+const { t } = useI18n();
+
+const currentRoute = computed(() => window.location.href);
+
+const checkingUuid = ref(false);
+const loadingIntoEditor = ref(false);
+const currLang = ref<SupportedLanguages>('en'); // page language
+const showDropdown = ref(false);
+const highlightedIndex = ref(-1);
+
+const lockStore = useLockStore();
+const stateStore = useStateStore();
+const productStore = useProductStore();
+const editorStore = useEditorStore();
+
+const storylineHistory = ref([] as History[]);
+const selectedHistory = ref(null as History | null);
+const showHistory = ref(false);
+
+// Saving properties.
+// NOTE: UNUSED
+// const saving = ref(false);
+
+// Form properties.
+const uuid = ref('');
+const renameMode = ref(false); // if currently in rename mode
+const processingRename = ref(false); // only true while we're waiting for the server to process a rename
+const defaultBlankSlide: Slide = {
+    title: '',
+    backgroundImage: '',
+    panel: [
+        {
+            type: 'text',
+            title: '',
+            content: ''
+        } as TextPanel,
+        {
+            type: 'text',
+            title: '',
+            content: ''
+        } as TextPanel
+    ]
+};
+// add more required metadata fields to here as needed
+const reqFields = ref<{ uuid: boolean }>({
+    uuid: true
+});
+const totalTime = import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_END) : 30;
+
+// =========================================
+// Watchers
+
+watch(
+    () => stateStore.reconcileToggler,
+    () => {
+        const newConfigs = stateStore.addChangesToNewSave(stateStore.getCurrentChangeLocation());
+
+        productStore.configs.en = newConfigs!.en;
+        productStore.configs.fr = newConfigs!.fr;
     }
-})
-export default class MetadataEditorV extends Vue {
-    @Prop({ default: true }) editExisting!: boolean; // true if editing existing storylines product, false if new product
+);
 
-    currentRoute = window.location.href;
-    checkingUuid = false;
-    loadingIntoEditor = false;
-    currLang = 'en'; // page language
-    showDropdown = false;
-    highlightedIndex = -1;
+// =========================================
+// Lifecycle functions
 
-    lockStore = useLockStore();
-    stateStore = useStateStore();
-    productStore = useProductStore();
-    editorStore = useEditorStore();
+onMounted(() => {
+    import('ramp-storylines_demo-scenarios-pcar/dist/StorylinesSchema.json').then((StorylinesSchema) => {
+        productStore.latestSchemaVersion = StorylinesSchema.version;
+    });
+    currLang.value = ($route.params.lang as SupportedLanguages) || 'en';
+    editorStore.editingMetadata = !props.editExisting;
+});
 
-    storylineHistory: History[] = [];
-    selectedHistory: History | null = null;
-    showHistory = false;
+onBeforeMount(() => {
+    // Ensure that all product and editor data is cleared beforehand, just in case
+    productStore.clearData();
+    editorStore.loadExisting = props.editExisting;
+    // Generate UUID for new product
+    productStore.uuid = ($route.params.uid as string) ?? (editorStore.loadExisting ? undefined : uuidv4());
 
-    // Saving properties.
-    saving = false;
+    // Automatically load in the product data if the uuid is included in the url
+    if ($route.params.uid as string) {
+        handleUuidLoad();
+    }
 
-    // Form properties.
-    uuid = '';
-    renameMode = false; // if currently in rename mode
-    processingRename = false; // only true while we're waiting for the server to process a rename
-    defaultBlankSlide: Slide = {
-        title: '',
-        backgroundImage: '',
-        panel: [
-            {
-                type: 'text',
-                title: '',
-                content: ''
-            } as TextPanel,
-            {
-                type: 'text',
-                title: '',
-                content: ''
-            } as TextPanel
-        ]
-    };
-    // add more required metadata fields to here as needed
-    reqFields: { uuid: boolean } = {
-        uuid: true
-    };
-    totalTime = import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_END) : 30;
+    // set any metadata default values for creating new product
+    if (!editorStore.loadExisting) {
+        // set current date as default
+        const curDate = new Date();
+        const year = curDate.getFullYear();
+        const month = (curDate.getMonth() + 1).toString().padStart(2, '0');
+        const day = curDate.getDate().toString().padStart(2, '0');
+        productStore.metadata.dateModified = `${year}-${month}-${day}`;
+        // set vertical as the default table of contents orientation
+        productStore.metadata.tocOrientation = 'vertical';
+        productStore.metadata.returnTop = true;
+        productStore.metadata.sameConfig = true;
+    }
+});
 
-    mounted(): void {
-        import('ramp-storylines_demo-scenarios-pcar/dist/StorylinesSchema.json').then((StorylinesSchema) => {
-            this.productStore.latestSchemaVersion = StorylinesSchema.version;
+onBeforeUnmount(() => {
+    document.body.classList.remove('editor-mode');
+});
+
+// =========================================
+// Component functions
+
+/**
+ * Open current editor config as a new Storylines product in new tab.
+ * Note: Preview button on metadata editor will only show when editing an existing product, not when creating a new one
+ * This is a design decision, can change if we decide that people would want to preview new products for some reason
+ */
+function preview(): void {
+    // save current metadata final changes before previewing product
+    productStore.saveMetadata(false);
+    setTimeout(() => {
+        const routeData = $router.resolve({
+            name: 'preview',
+            params: { lang: editorStore.configLang, uid: productStore.uuid }
         });
-        this.currLang = (this.$route.params.lang as string) || 'en';
-        this.editorStore.editingMetadata = !this.editExisting;
-    }
-
-    beforeDestroy(): void {
-        document.body.classList.remove('editor-mode');
-    }
-
-    created(): void {
-        // Ensure that all product and editor data is cleared beforehand, just in case
-        this.productStore.clearData();
-        this.editorStore.loadExisting = this.editExisting;
-        // Generate UUID for new product
-        this.productStore.uuid =
-            (this.$route.params.uid as string) ?? (this.editorStore.loadExisting ? undefined : uuidv4());
-
-        // Automatically load in the product data if the uuid is included in the url
-        if (this.$route.params.uid as string) {
-            this.handleUuidLoad();
-        }
-
-        // set any metadata default values for creating new product
-        if (!this.editorStore.loadExisting) {
-            // set current date as default
-            const curDate = new Date();
-            const year = curDate.getFullYear();
-            const month = (curDate.getMonth() + 1).toString().padStart(2, '0');
-            const day = curDate.getDate().toString().padStart(2, '0');
-            this.productStore.metadata.dateModified = `${year}-${month}-${day}`;
-            // set vertical as the default table of contents orientation
-            this.productStore.metadata.tocOrientation = 'vertical';
-            this.productStore.metadata.returnTop = true;
-            this.productStore.metadata.sameConfig = true;
-        }
-    }
-
-    /**
-     * Open current editor config as a new Storylines product in new tab.
-     * Note: Preview button on metadata editor will only show when editing an existing product, not when creating a new one
-     * This is a design decision, can change if we decide that people would want to preview new products for some reason
-     */
-    preview(): void {
-        // save current metadata final changes before previewing product
-        this.productStore.saveMetadata(false);
-        setTimeout(() => {
-            const routeData = this.$router.resolve({
-                name: 'preview',
-                params: { lang: this.editorStore.configLang, uid: this.productStore.uuid }
-            });
-            const previewTab = window.open(routeData.href, '_blank');
-            (previewTab as Window).props = {
-                configs: this.productStore.configs,
-                configFileStructure: this.productStore.configFileStructure,
-                secret: this.lockStore.secret,
-                timeRemaining: this.lockStore.timeRemaining
-            };
-        }, 5);
-    }
-
-    fetchHistory(): Promise<void> {
-        // Note: This part probably doesn't need an manual abort() trigger to kill on load cancel,
-        // as the history should be much smaller and quicker to fetch than the config
-
-        if (this.productStore.uuid === undefined || this.productStore.uuid === '') {
-            return;
-        }
-        this.editorStore.loadStatus = 'loading';
-        const secret = this.lockStore.secret;
-        return fetch(this.productStore.apiUrl + `/history/${this.productStore.uuid}`, {
-            headers: { user: this.productStore.user, secret }
-        }).then((res: Response) => {
-            if (res.status === 404) {
-                // Product not found.
-                this.editorStore.loadStatus = 'waiting';
-            } else {
-                this.editorStore.loadStatus = 'loaded';
-                res.json().then((json) => {
-                    this.storylineHistory = json;
-                });
-            }
-        });
-    }
-
-    selectHistory(selected: any): void {
-        this.selectedHistory = selected;
-    }
-
-    formatDate(created: string): string {
-        const date = new Date(created);
-        const estDate = new Date(date.toLocaleString('en-US', { timeZone: 'America/Toronto' }));
-        const options: Intl.DateTimeFormatOptions = {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-            hour: '2-digit',
-            minute: '2-digit',
-            hour12: true,
-            timeZone: 'America/Toronto'
+        const previewTab = window.open(routeData.href, '_blank');
+        (previewTab as Window).props = {
+            configs: productStore.configs,
+            configFileStructure: productStore.configFileStructure,
+            secret: lockStore.secret,
+            timeRemaining: lockStore.timeRemaining
         };
+    }, 5);
+}
 
-        return new Intl.DateTimeFormat('en-US', options).format(estDate);
+function fetchHistory(): Promise<void> {
+    // Note: This part probably doesn't need an manual abort() trigger to kill on load cancel,
+    // as the history should be much smaller and quicker to fetch than the config
+
+    if (productStore.uuid === undefined || productStore.uuid === '') {
+        return Promise.resolve();
     }
-
-    loadHistory(): void {
-        if (this.selectedHistory) {
-            this.productStore.loadVersion(this.selectedHistory.hash);
+    editorStore.loadStatus = 'loading';
+    const secret = lockStore.secret;
+    return fetch(productStore.apiUrl + `/history/${productStore.uuid}`, {
+        headers: { user: productStore.user, secret } as unknown as HeadersInit
+    }).then((res: Response) => {
+        if (res.status === 404) {
+            // Product not found.
+            editorStore.loadStatus = 'waiting';
+        } else {
+            editorStore.loadStatus = 'loaded';
+            res.json().then((json) => {
+                storylineHistory.value = json;
+            });
         }
+    });
+}
+
+function selectHistory(selected: any): void {
+    selectedHistory.value = selected;
+}
+
+function formatDate(created: string): string {
+    const date = new Date(created);
+    const estDate = new Date(date.toLocaleString('en-US', { timeZone: 'America/Toronto' }));
+    const options: Intl.DateTimeFormatOptions = {
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: true,
+        timeZone: 'America/Toronto'
+    };
+
+    return new Intl.DateTimeFormat('en-US', options).format(estDate);
+}
+
+function loadHistory(): void {
+    if (selectedHistory.value) {
+        productStore.loadVersion(selectedHistory.value.hash);
+    }
+}
+
+async function renameProduct(): Promise<void> {
+    if (!productStore.configFileStructure) {
+        return;
     }
 
-    async renameProduct(): Promise<void> {
-        console.log(' ');
-        console.log('renameProduct()');
-        if (!this.productStore.configFileStructure) {
-            return;
-        }
+    const prevUuid = productStore.configFileStructure.uuid;
 
-        const prevUuid = this.productStore.configFileStructure.uuid;
+    // Fetch the two existing configuration files.
+    const enFile = productStore.configFileStructure.zip.file(`${prevUuid}_en.json`);
+    const frFile = productStore.configFileStructure.zip.file(`${prevUuid}_fr.json`);
 
-        // Fetch the two existing configuration files.
-        const enFile = this.productStore.configFileStructure.zip.file(`${prevUuid}_en.json`);
-        const frFile = this.productStore.configFileStructure.zip.file(`${prevUuid}_fr.json`);
+    if (enFile && frFile) {
+        processingRename.value = true;
 
-        if (enFile && frFile) {
-            this.processingRename = true;
-
-            // Fetch the contents of the two configuration files, and perform a find/replace on the UUID for each source.
-            const englishConfig = await enFile?.async('string').then((res: string) => JSON.parse(res));
-            const frenchConfig = await frFile?.async('string').then((res: string) => JSON.parse(res));
-            [englishConfig, frenchConfig].forEach((config) =>
-                this.productStore.renameSources(config, prevUuid, this.editorStore.changeUuid)
-            );
-            // Convert the two configuration files into string format.
-            const convertedEnglish = JSON.stringify(englishConfig, null, 4);
-            const convertedFrench = JSON.stringify(frenchConfig, null, 4);
-
-            // First, hit the Express server `rename` endpoint to perform the `rename` syscall on the file system.
-            // Before doing so, we transfer the existing lock to the new uuid
-            this.lockStore
-                .transferLock(this.editorStore.changeUuid)
-                .then(async () => {
-                    await axios
-                        .post(this.productStore.apiUrl + `/rename`, {
-                            user: this.productStore.user,
-                            previousUuid: prevUuid,
-                            newUuid: this.editorStore.changeUuid,
-                            configs: { en: convertedEnglish, fr: convertedFrench }
-                        })
-                        .then(async (_res: AxiosResponse) => {
-                            // Once the server has processed the renaming, update the UUID in the database if not in dev mode.
-                            if (import.meta.env.VITE_APP_NET_API_URL) {
-                                await axios.post(import.meta.env.VITE_APP_NET_API_URL + '/api/version/update', {
-                                    uuid: prevUuid,
-                                    changeUuid: this.editorStore.changeUuid
-                                });
-                            }
-
-                            // After the server and database have been updated, re-build configFileStructure,
-                            // save the new config files to the server and fetch the new Git history.
-                            if (this.productStore.configFileStructure.zip) {
-                                // Remove the current configuration files from the ZIP folder.
-                                this.productStore.configFileStructure.zip.remove(enFile.name);
-                                this.productStore.configFileStructure.zip.remove(frFile.name);
-
-                                // Re-add the configuration files to the ZIP with the new UUID.
-                                this.productStore.configFileStructure.zip.file(
-                                    `${this.editorStore.changeUuid}_en.json`,
-                                    convertedEnglish
-                                );
-                                this.productStore.configFileStructure.zip.file(
-                                    `${this.editorStore.changeUuid}_fr.json`,
-                                    convertedFrench
-                                );
-
-                                // Iterate through the RAMP configuration files and rename them using the new UUID.
-                                const configPromises: Promise<void>[] = [];
-                                this.productStore.configFileStructure.zip
-                                    .folder('ramp-config/')
-                                    ?.forEach((relativePath, file) => {
-                                        configPromises.push(this.renameMapConfig(file.name, prevUuid));
-                                    });
-
-                                // Wait for map configuration files to be renamed.
-                                await Promise.all(configPromises);
-
-                                this.uuid = this.editorStore.changeUuid;
-
-                                // Reset source counts.
-                                this.productStore.sourceCounts = {};
-
-                                this.productStore
-                                    .configFileStructureHelper(this.productStore.configFileStructure.zip)
-                                    .then(() => {
-                                        this.fetchHistory();
-                                        this.renameMode = this.processingRename = false;
-                                    });
-                            }
-                        })
-                        .catch((err) => {
-                            /** If the server returns a 500 error for whatever reason (most likely due to file in use),
-                             * roll back the UUID to the previous value and display an error message.
-                             */
-                            if (err.status === 500) {
-                                Message.error(this.$t('editor.warning.renameFailed'));
-                                this.productStore.uuid = prevUuid;
-                                this.processingRename = false;
-                                return;
-                            }
-                        });
-                })
-                .catch(() => {
-                    Message.error(this.$t('editor.editMetadata.message.error.unauthorized'));
-                    this.productStore.uuid = prevUuid;
-                    this.processingRename = false;
-                    return;
-                });
-        }
-    }
-
-    // Provided with the path of a RAMP configuration file, rename it in the JSZip object using the new UUID.
-    renameMapConfig(oldPath: string, prevUuid: string): Promise<void> {
-        return new Promise((resolve) => {
-            this.productStore.configFileStructure.zip
-                .file(oldPath)
-                ?.async('string')
-                .then((res: string) => {
-                    // Remove the old config file.
-                    this.productStore.configFileStructure.zip.remove(oldPath);
-
-                    // Get the new config name.
-                    const newFile = oldPath.replace(`/${prevUuid}-map-`, `/${this.editorStore.changeUuid}-map-`);
-
-                    // Re-add the config to the ZIP with the new name.
-                    this.productStore.configFileStructure.zip.file(newFile, res);
-                    resolve();
-                });
-        });
-    }
-
-    discardMetadataUpdates(): void {
-        this.productStore.metadata = JSON.parse(JSON.stringify(this.productStore.temporaryMetadataCopy));
-        this.editorStore.editingMetadata = false;
-        this.stateStore.isChanged = false; // TODO: Does this cause false negatives? (maybe not if we don't have discarding for vfm)
-    }
-
-    /**
-     * Checks if the UUID is invalid due to being blank or containing illegal characters.
-     */
-    isUuidInvalid(rename: boolean): 'blank' | 'badChar' | null {
-        if (!rename && !this.productStore.uuid && !this.editorStore.loadExisting) {
-            return 'blank';
-        }
-
-        // All reserved characters in URLs. The user can't use these for their UUID
-        const illegalChars = [':', '/', '#', '?', '&', '@', '%', '+'];
-        const illegalCharsContained = illegalChars.filter((badChar) =>
-            (rename ? this.editorStore.changeUuid : this.productStore.uuid).includes(badChar)
+        // Fetch the contents of the two configuration files, and perform a find/replace on the UUID for each source.
+        const englishConfig = await enFile?.async('string').then((res: string) => JSON.parse(res));
+        const frenchConfig = await frFile?.async('string').then((res: string) => JSON.parse(res));
+        [englishConfig, frenchConfig].forEach((config) =>
+            productStore.renameSources(config, prevUuid, editorStore.changeUuid)
         );
+        // Convert the two configuration files into string format.
+        const convertedEnglish = JSON.stringify(englishConfig, null, 4);
+        const convertedFrench = JSON.stringify(frenchConfig, null, 4);
 
-        if (illegalCharsContained.length) {
-            return 'badChar';
-        }
+        // First, hit the Express server `rename` endpoint to perform the `rename` syscall on the file system.
+        // Before doing so, we transfer the existing lock to the new uuid
+        lockStore
+            .transferLock(editorStore.changeUuid)
+            .then(async () => {
+                await axios
+                    .post(productStore.apiUrl + `/rename`, {
+                        user: productStore.user,
+                        previousUuid: prevUuid,
+                        newUuid: editorStore.changeUuid,
+                        configs: { en: convertedEnglish, fr: convertedFrench }
+                    })
+                    .then(async (_res: AxiosResponse) => {
+                        // Once the server has processed the renaming, update the UUID in the database if not in dev mode.
+                        if (import.meta.env.VITE_APP_NET_API_URL) {
+                            await axios.post(import.meta.env.VITE_APP_NET_API_URL + '/api/version/update', {
+                                uuid: prevUuid,
+                                changeUuid: editorStore.changeUuid
+                            });
+                        }
 
-        return null;
-    }
+                        // After the server and database have been updated, re-build configFileStructure,
+                        // save the new config files to the server and fetch the new Git history.
+                        if (productStore.configFileStructure.zip) {
+                            // Remove the current configuration files from the ZIP folder.
+                            productStore.configFileStructure.zip.remove(enFile.name);
+                            productStore.configFileStructure.zip.remove(frFile.name);
 
-    checkUuid(rename?: boolean): void {
-        if (rename || !this.editorStore.loadExisting) this.checkingUuid = true;
+                            // Re-add the configuration files to the ZIP with the new UUID.
+                            productStore.configFileStructure.zip.file(
+                                `${editorStore.changeUuid}_en.json`,
+                                convertedEnglish
+                            );
+                            productStore.configFileStructure.zip.file(
+                                `${editorStore.changeUuid}_fr.json`,
+                                convertedFrench
+                            );
 
-        if (!this.editorStore.loadExisting || rename) {
-            const errorType = this.isUuidInvalid(!!rename);
-            if (errorType) {
-                this.editorStore.error = true;
-                this.editorStore.warning = errorType;
-                this.checkingUuid = false;
+                            // Iterate through the RAMP configuration files and rename them using the new UUID.
+                            const configPromises: Promise<void>[] = [];
+                            productStore.configFileStructure.zip
+                                .folder('ramp-config/')
+                                ?.forEach((relativePath, file) => {
+                                    configPromises.push(renameMapConfig(file.name, prevUuid));
+                                });
+
+                            // Wait for map configuration files to be renamed.
+                            await Promise.all(configPromises);
+
+                            uuid.value = editorStore.changeUuid;
+
+                            // Reset source counts.
+                            productStore.sourceCounts = {};
+
+                            productStore.configFileStructureHelper(productStore.configFileStructure.zip).then(() => {
+                                fetchHistory();
+                                renameMode.value = processingRename.value = false;
+                            });
+                        }
+                    })
+                    .catch((err) => {
+                        /** If the server returns a 500 error for whatever reason (most likely due to file in use),
+                         * roll back the UUID to the previous value and display an error message.
+                         */
+                        if (err.status === 500) {
+                            Message.error(t('editor.warning.renameFailed'));
+                            productStore.uuid = prevUuid;
+                            processingRename.value = false;
+                            return;
+                        }
+                    });
+            })
+            .catch(() => {
+                Message.error(t('editor.editMetadata.message.error.unauthorized'));
+                productStore.uuid = prevUuid;
+                processingRename.value = false;
                 return;
-            }
+            });
+    }
+}
 
-            this.fetchUuidCheck(!!rename);
-        }
-        this.editorStore.warning = 'none';
-        this.highlightedIndex = -1;
+// Provided with the path of a RAMP configuration file, rename it in the JSZip object using the new UUID.
+function renameMapConfig(oldPath: string, prevUuid: string): Promise<void> {
+    return new Promise((resolve) => {
+        productStore.configFileStructure.zip
+            .file(oldPath)
+            ?.async('string')
+            .then((res: string) => {
+                // Remove the old config file.
+                productStore.configFileStructure.zip.remove(oldPath);
+
+                // Get the new config name.
+                const newFile = oldPath.replace(`/${prevUuid}-map-`, `/${editorStore.changeUuid}-map-`);
+
+                // Re-add the config to the ZIP with the new name.
+                productStore.configFileStructure.zip.file(newFile, res);
+                resolve();
+            });
+    });
+}
+
+function discardMetadataUpdates(): void {
+    productStore.metadata = JSON.parse(JSON.stringify(productStore.temporaryMetadataCopy));
+    editorStore.editingMetadata = false;
+    stateStore.isChanged = false; // TODO: Does this cause false negatives? (maybe not if we don't have discarding for vfm)
+}
+
+/**
+ * Checks if the UUID is invalid due to being blank or containing illegal characters.
+ */
+function isUuidInvalid(rename: boolean): 'blank' | 'badChar' | null {
+    if (!rename && !productStore.uuid && !editorStore.loadExisting) {
+        return 'blank';
     }
 
-    /**
-     * Debounce the fetch call to help prevent console spamming.
-     */
-    fetchUuidCheck = debounce(600, (rename: boolean) => {
-        if (this.isUuidInvalid(rename)) {
+    // All reserved characters in URLs. The user can't use these for their UUID
+    const illegalChars = [':', '/', '#', '?', '&', '@', '%', '+'];
+    const illegalCharsContained = illegalChars.filter((badChar) =>
+        (rename ? editorStore.changeUuid : productStore.uuid).includes(badChar)
+    );
+
+    if (illegalCharsContained.length) {
+        return 'badChar';
+    }
+
+    return null;
+}
+
+function checkUuid(rename?: boolean): void {
+    if (rename || !editorStore.loadExisting) checkingUuid.value = true;
+
+    if (!editorStore.loadExisting || rename) {
+        const errorType = isUuidInvalid(!!rename);
+        if (errorType) {
+            editorStore.error = true;
+            editorStore.warning = errorType;
+            checkingUuid.value = false;
             return;
         }
-        // If renaming, show the loading spinner while we check whether the UUID is taken.
-        fetch(
-            this.productStore.apiUrl + `/check/${rename ? this.editorStore.changeUuid : this.productStore.uuid}`
-        ).then((res: Response) => {
-            if (res.status !== 404) {
-                this.editorStore.warning = rename ? 'rename' : 'uuid';
 
-                if (!this.editorStore.loadExisting) {
-                    this.error = true;
+        fetchUuidCheck(!!rename);
+    }
+    editorStore.warning = 'none';
+    highlightedIndex.value = -1;
+}
+
+/**
+ * Debounce the fetch call to help prevent console spamming.
+ */
+const fetchUuidCheck = debounce(600, (rename: boolean) => {
+    if (isUuidInvalid(rename)) {
+        return;
+    }
+    // If renaming, show the loading spinner while we check whether the UUID is taken.
+    fetch(productStore.apiUrl + `/check/${rename ? editorStore.changeUuid : productStore.uuid}`).then(
+        (res: Response) => {
+            if (res.status !== 404) {
+                editorStore.warning = rename ? 'rename' : 'uuid';
+
+                if (!editorStore.loadExisting) {
+                    editorStore.error = true;
                 }
             }
 
-            if (rename || !this.editorStore.loadExisting) this.checkingUuid = false;
+            if (rename || !editorStore.loadExisting) checkingUuid.value = false;
 
-            fetch(this.productStore.apiUrl + `/retrieveMessages`)
+            fetch(productStore.apiUrl + `/retrieveMessages`)
                 .then((res: any) => {
                     if (res.ok) return res.json();
                 })
@@ -1038,248 +1051,234 @@ export default class MetadataEditorV extends Vue {
                         .catch((error: any) => console.log(error.response || error));
                 })
                 .catch((error: any) => console.log(error.response || error));
-        });
-    });
-
-    /**
-     * React to param changes in URL.
-     */
-    beforeRouteUpdate(to: RouteLocationNormalized, from: RouteLocationNormalized, next: () => void): void {
-        this.$i18n.locale = to.params.lang as string;
-        document.onmousemove = () => undefined;
-        document.onkeydown = () => undefined;
-
-        const isProductLoaded = this.editorStore.loadStatus == 'loaded';
-        const newUuidAdded =
-            !from.params.uid && !!to.params.uid && isProductLoaded && to.params.uid != this.productStore.uuid;
-        const uuidRemoved = !!from.params.uid && !to.params.uid;
-        const uuidModified = !!from.params.uid && !!to.params.uid && to.params.uid !== from.params.uid;
-
-        // Unlock the product in one of the three scenarios:
-        // - if the `from` route contains a uuid, and the `to` route doesn't, we unlock only if there is a product
-        //   already loaded in that is different
-        // - if the `from` route doesn't contain a uuid, and the `to` route does, we unlock
-        // - if the `from` route and the `to` route both contain uuids, we should unlock when they are different
-        if (newUuidAdded || uuidRemoved || uuidModified) {
-            this.lockStore.unlockStoryline();
-            clearTimeout(this.lockStore.confirmationTimeout);
-            clearTimeout(this.lockStore.endTimeout);
         }
+    );
+});
+
+/**
+ * React to param changes in URL.
+ */
+function beforeRouteUpdate(to: RouteLocationNormalized, from: RouteLocationNormalized, next: () => void): void {
+    $i18n.locale = to.params.lang as string;
+    document.onmousemove = () => undefined;
+    document.onkeydown = () => undefined;
+
+    const isProductLoaded = editorStore.loadStatus == 'loaded';
+    const newUuidAdded = !from.params.uid && !!to.params.uid && isProductLoaded && to.params.uid != productStore.uuid;
+    const uuidRemoved = !!from.params.uid && !to.params.uid;
+    const uuidModified = !!from.params.uid && !!to.params.uid && to.params.uid !== from.params.uid;
+
+    // Unlock the product in one of the three scenarios:
+    // - if the `from` route contains a uuid, and the `to` route doesn't, we unlock only if there is a product
+    //   already loaded in that is different
+    // - if the `from` route doesn't contain a uuid, and the `to` route does, we unlock
+    // - if the `from` route and the `to` route both contain uuids, we should unlock when they are different
+    if (newUuidAdded || uuidRemoved || uuidModified) {
+        lockStore.unlockStoryline();
+        clearTimeout(lockStore.confirmationTimeout);
+        clearTimeout(lockStore.endTimeout);
+    }
+    next();
+}
+
+function checkRequiredFields(): boolean {
+    // check if all required metadata fields are non-empty
+    reqFields.value.uuid = Boolean(productStore.uuid);
+    if (Object.values(reqFields.value).some((field: boolean) => !field)) {
+        Message.error(t('editor.editMetadata.message.error.requiredFieldsNotFilled'));
+        return false;
+    }
+    return true;
+}
+
+/**
+ * Called when 'next' button is pressed on metadata page to continue to main editor.
+ *
+ */
+function continueToEditor(): void {
+    loadingIntoEditor.value = true;
+
+    // Needed in order to show the loading spinner at all
+    // Although it shows, it's still frozen (since app's really just lagging until editor's in)
+    setTimeout(() => {
+        if (!checkRequiredFields()) {
+            return;
+        }
+        if (editorStore.loadExisting) {
+            if (
+                productStore.configs[editorStore.configLang] !== undefined &&
+                productStore.uuid === productStore.configFileStructure.uuid
+            ) {
+                productStore.loadEditor = true;
+                productStore.saveMetadata(false).then(() => {
+                    $router.push({ name: 'editor', params: { uid: productStore.uuid } });
+                });
+            } else {
+                Message.error(t('editor.editMetadata.message.error.noConfig'));
+            }
+        } else if (!productStore.uuid) {
+            Message.error(t('editor.warning.mustEnterUuid'));
+            editorStore.error = true;
+        } else {
+            // We have a new product that is going to the main editor route, so its UUID is now locked.
+            // Therefore, we also lock it in the server so that another user does not create a new product
+            // with the same UUID until the user's session is in progress.
+            lockStore
+                .lockStoryline(productStore.uuid)
+                .then(() => {
+                    // Only generate config if not already present or UUID mismatch
+                    if (
+                        !productStore.configs[editorStore.configLang] ||
+                        productStore.uuid !== productStore.configFileStructure?.uuid
+                    ) {
+                        productStore.generateNewConfig();
+                    } else {
+                        // Else config already exists and matches UUID, skip generation
+                        // Update each zip file with their latest changes before loading
+                        productStore.saveMetadata();
+
+                        const writeConfigFile = (lang: 'en' | 'fr') => {
+                            const configJson = JSON.stringify(productStore.configs[lang], null, 4);
+                            productStore.configFileStructure.zip.file(`${productStore.uuid}_${lang}.json`, configJson);
+                        };
+
+                        (['en', 'fr'] as const).forEach((lang) => writeConfigFile(lang));
+
+                        editorStore.changeLang(currLang.value);
+                        editorStore.correctUuid();
+                    }
+                })
+                .catch(() => {
+                    editorStore.error = true;
+                    Message.error(t('editor.editMetadata.message.error.unauthorized'));
+                })
+                .finally(() => {
+                    window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
+                });
+        }
+    }, 25);
+}
+
+function beforeRouteLeave(
+    to: RouteLocationNormalized,
+    from: RouteLocationNormalized,
+    next: (cont?: boolean) => void
+): void {
+    const curEditor = $route.name === 'editor';
+    const confirmationMessage = t('editor.leaveWarning');
+    const stay =
+        !editorStore.sessionExpired && stateStore.isChanged && curEditor && !window.confirm(confirmationMessage);
+    const exitingProduct = to.name !== 'editor';
+    const isProductLoaded = !!to.params.uid || editorStore.loadStatus == 'loaded';
+
+    // This component is going bye-bye, so we need to do some clean up so that timers cannot fire later.
+    clearTimeout(lockStore.confirmationTimeout);
+    clearTimeout(lockStore.endTimeout);
+    document.onmousemove = () => undefined;
+    document.onkeydown = () => undefined;
+
+    // Ensure that we are unlocking a product when a) we are going from the metadata-editor to the home page, and b)
+    // there is a product currently loaded into the metadata-editor
+    if (exitingProduct && isProductLoaded) {
+        // Unlock the storyline for other users if we are exiting the product e.g. by navigating to a different route.
+        lockStore.unlockStoryline();
+        productStore.clearData();
+    }
+
+    if (stay) {
+        next(false);
+    } else {
         next();
     }
+}
 
-    checkRequiredFields(): boolean {
-        // check if all required metadata fields are non-empty
-        this.reqFields.uuid = !!this.productStore.uuid;
-        if (Object.values(this.reqFields).some((field: boolean) => !field)) {
-            Message.error(this.$t('editor.editMetadata.message.error.requiredFieldsNotFilled'));
-            return false;
+async function handleUuidEnter(): Promise<void> {
+    if (props.editExisting) {
+        handleUuidLoad();
+    } else {
+        // UUID is not taken and is not blank so we proceed to editor-main
+        if (!editorStore.error) {
+            continueToEditor();
+        } else if (editorStore.warning !== 'none') {
+            Message.error(t(`editor.warning.${editorStore.warning}`));
         }
-        return true;
-    }
-
-    /**
-     * Called when 'next' button is pressed on metadata page to continue to main editor.
-     *
-     */
-    continueToEditor(): void {
-        console.log(' ');
-        console.log('continueToEditor()');
-        this.loadingIntoEditor = true;
-
-        // Needed in order to show the loading spinner at all
-        // Although it shows, it's still frozen (since app's really just lagging until editor's in)
-        setTimeout(() => {
-            if (!this.checkRequiredFields()) {
-                return;
-            }
-            if (this.editorStore.loadExisting) {
-                if (
-                    this.productStore.configs[this.editorStore.configLang] !== undefined &&
-                    this.productStore.uuid === this.productStore.configFileStructure.uuid
-                ) {
-                    this.loadEditor = true;
-                    this.productStore.saveMetadata(false).then(() => {
-                        this.$router.push({ name: 'editor', params: { uid: this.productStore.uuid } });
-                    });
-                } else {
-                    Message.error(this.$t('editor.editMetadata.message.error.noConfig'));
-                }
-            } else if (!this.productStore.uuid) {
-                Message.error(this.$t('editor.warning.mustEnterUuid'));
-                this.editorStore.error = true;
-            } else {
-                // We have a new product that is going to the main editor route, so its UUID is now locked.
-                // Therefore, we also lock it in the server so that another user does not create a new product
-                // with the same UUID until the user's session is in progress.
-                this.lockStore
-                    .lockStoryline(this.productStore.uuid)
-                    .then(() => {
-                        // Only generate config if not already present or UUID mismatch
-                        if (
-                            !this.productStore.configs[this.editorStore.configLang] ||
-                            this.productStore.uuid !== this.productStore.configFileStructure?.uuid
-                        ) {
-                            this.productStore.generateNewConfig();
-                        } else {
-                            // Else config already exists and matches UUID, skip generation
-                            // Update each zip file with their latest changes before loading
-                            this.productStore.saveMetadata();
-
-                            const writeConfigFile = (lang: 'en' | 'fr') => {
-                                const configJson = JSON.stringify(this.productStore.configs[lang], null, 4);
-                                this.productStore.configFileStructure.zip.file(
-                                    `${this.productStore.uuid}_${lang}.json`,
-                                    configJson
-                                );
-                            };
-
-                            (['en', 'fr'] as const).forEach((lang) => writeConfigFile(lang));
-
-                            this.editorStore.changeLang(this.currLang);
-                            this.editorStore.correctUuid();
-                        }
-                    })
-                    .catch(() => {
-                        this.editorStore.error = true;
-                        Message.error(this.$t('editor.editMetadata.message.error.unauthorized'));
-                    })
-                    .finally(() => {
-                        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' });
-                    });
-            }
-        }, 25);
-    }
-
-    beforeRouteLeave(to: RouteLocationNormalized, from: RouteLocationNormalized, next: (cont?: boolean) => void): void {
-        console.log(' ');
-        console.log('metadata - beforeRouteLeave()');
-        const curEditor = this.$route.name === 'editor';
-        const confirmationMessage = this.$t('editor.leaveWarning');
-        const stay =
-            !this.editorStore.sessionExpired &&
-            this.stateStore.isChanged &&
-            curEditor &&
-            !window.confirm(confirmationMessage);
-        const exitingProduct = to.name !== 'editor';
-        const isProductLoaded = !!to.params.uid || this.editorStore.loadStatus == 'loaded';
-
-        // This component is going bye-bye, so we need to do some clean up so that timers cannot fire later.
-        clearTimeout(this.lockStore.confirmationTimeout);
-        clearTimeout(this.lockStore.endTimeout);
-        document.onmousemove = () => undefined;
-        document.onkeydown = () => undefined;
-
-        // Ensure that we are unlocking a product when a) we are going from the metadata-editor to the home page, and b)
-        // there is a product currently loaded into the metadata-editor
-        if (exitingProduct && isProductLoaded) {
-            // Unlock the storyline for other users if we are exiting the product e.g. by navigating to a different route.
-            this.lockStore.unlockStoryline();
-            this.productStore.clearData();
-        }
-
-        if (stay) {
-            next(false);
-        } else {
-            next();
-        }
-    }
-
-    async handleUuidEnter(): Promise<void> {
-        if (this.editExisting) {
-            this.handleUuidLoad();
-        } else {
-            // UUID is not taken and is not blank so we proceed to editor-main
-            if (!this.editorStore.error) {
-                this.continueToEditor();
-            } else if (this.editorStore.warning !== 'none') {
-                Message.error(this.$t(`editor.warning.${this.editorStore.warning}`));
-            }
-        }
-    }
-
-    handleUuidLoad(): void {
-        if (this.productStore.uuid) {
-            this.productStore
-                .generateRemoteConfig()
-                .then(this.fetchHistory)
-                .then(() => {
-                    Message.success(this.$t('editor.editMetadata.message.successfulLoad'));
-                });
-        } else {
-            this.editorStore.error = true;
-            this.editorStore.warning = 'blank';
-            Message.error(this.$t(`editor.warning.${this.editorStore.warning}`));
-        }
-    }
-
-    highlightNext(): void {
-        if (this.highlightedIndex < this.getStorylines.length - 1) {
-            this.highlightedIndex++;
-            this.scrollIntoView();
-        }
-    }
-
-    highlightPrevious(): void {
-        if (this.highlightedIndex > 0) {
-            this.highlightedIndex--;
-            this.scrollIntoView();
-        }
-    }
-
-    selectHighlighted(): void {
-        if (this.highlightedIndex !== -1) {
-            const selectedStoryline = this.getStorylines[this.highlightedIndex];
-            this.selectUuid(selectedStoryline.uuid);
-        }
-    }
-
-    scrollIntoView(): void {
-        this.$nextTick(() => {
-            const container = this.$el.querySelector('.overflow-y-auto');
-            const activeItem = container.querySelector('li.bg-gray-300');
-            if (activeItem) container.scrollTop = activeItem.offsetTop - container.offsetTop;
-        });
-    }
-
-    get getStorylines() {
-        const userStore = useUserStore();
-        const userStorylines = userStore.userProfile?.storylines?.map((s) => ({ ...s, isUserStoryline: true })) || [];
-        const allStorylines =
-            userStore.userProfile?.allStorylines?.filter((s) => !userStorylines.some((u) => u.uuid === s.uuid)) || [];
-        let combined = [...userStorylines, ...allStorylines];
-
-        if (this.productStore.uuid) {
-            combined = combined.filter(
-                (storyline) =>
-                    storyline.uuid.toLowerCase().includes(this.productStore.uuid.toLowerCase()) ||
-                    (storyline.titleEN &&
-                        storyline.titleEN.toLowerCase().includes(this.productStore.uuid.toLowerCase())) ||
-                    (storyline.titleFR &&
-                        storyline.titleFR.toLowerCase().includes(this.productStore.uuid.toLowerCase()))
-            );
-        }
-
-        return combined;
-    }
-
-    getTitle(storyline: { titleEN: string; titleFR: string }): string {
-        return this.editorStore.configLang === 'en' ? storyline.titleEN : storyline.titleFR;
-    }
-
-    selectUuid(uuid: string): void {
-        this.productStore.uuid = uuid;
-        this.showDropdown = false;
-    }
-
-    /**
-     * Opens the metadata editing modal for the currently selected slide language.
-     */
-    openMetadataModal() {
-        this.loadConfig(this.productStore.configs[this.productStore.configLang]);
-        this.$vfm.open('metadata-edit-modal');
     }
 }
+
+function handleUuidLoad(): void {
+    if (productStore.uuid) {
+        productStore
+            .generateRemoteConfig()
+            .then(fetchHistory)
+            .then(() => {
+                Message.success(t('editor.editMetadata.message.successfulLoad'));
+            });
+    } else {
+        editorStore.error = true;
+        editorStore.warning = 'blank';
+        Message.error(t(`editor.warning.${editorStore.warning}`));
+    }
+}
+
+function highlightNext(): void {
+    if (highlightedIndex.value < getStorylines.value.length - 1) {
+        highlightedIndex.value++;
+        scrollIntoView();
+    }
+}
+
+function highlightPrevious(): void {
+    if (highlightedIndex.value > 0) {
+        highlightedIndex.value--;
+        scrollIntoView();
+    }
+}
+
+function selectHighlighted(): void {
+    if (highlightedIndex.value !== -1) {
+        const selectedStoryline = getStorylines.value[highlightedIndex.value];
+        selectUuid(selectedStoryline.uuid);
+    }
+}
+
+function scrollIntoView(): void {
+    $nextTick(() => {
+        const container = $el.querySelector('.overflow-y-auto');
+        const activeItem = container.querySelector('li.bg-gray-300');
+        if (activeItem) container.scrollTop = activeItem.offsetTop - container.offsetTop;
+    });
+}
+
+const getStorylines = computed(() => {
+    const userStore = useUserStore();
+    const userStorylines = userStore.userProfile?.storylines?.map((s) => ({ ...s, isUserStoryline: true })) || [];
+    const allStorylines =
+        userStore.userProfile?.allStorylines?.filter((s) => !userStorylines.some((u) => u.uuid === s.uuid)) || [];
+    let combined = [...userStorylines, ...allStorylines];
+
+    if (productStore.uuid) {
+        combined = combined.filter(
+            (storyline) =>
+                storyline.uuid.toLowerCase().includes(productStore.uuid.toLowerCase()) ||
+                (storyline.titleEN && storyline.titleEN.toLowerCase().includes(productStore.uuid.toLowerCase())) ||
+                (storyline.titleFR && storyline.titleFR.toLowerCase().includes(productStore.uuid.toLowerCase()))
+        );
+    }
+
+    return combined;
+});
+
+function getTitle(storyline: { titleEN: string; titleFR: string }): string {
+    return editorStore.configLang === 'en' ? storyline.titleEN : storyline.titleFR;
+}
+
+function selectUuid(uuid: string): void {
+    productStore.uuid = uuid;
+    showDropdown.value = false;
+}
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss">

--- a/src/components/metadata/metadata-editor.vue
+++ b/src/components/metadata/metadata-editor.vue
@@ -832,6 +832,8 @@ export default class MetadataEditorV extends Vue {
     }
 
     async renameProduct(): Promise<void> {
+        console.log(' ');
+        console.log('renameProduct()');
         if (!this.productStore.configFileStructure) {
             return;
         }
@@ -1081,6 +1083,8 @@ export default class MetadataEditorV extends Vue {
      *
      */
     continueToEditor(): void {
+        console.log(' ');
+        console.log('continueToEditor()');
         this.loadingIntoEditor = true;
 
         // Needed in order to show the loading spinner at all
@@ -1148,6 +1152,8 @@ export default class MetadataEditorV extends Vue {
     }
 
     beforeRouteLeave(to: RouteLocationNormalized, from: RouteLocationNormalized, next: (cont?: boolean) => void): void {
+        console.log(' ');
+        console.log('metadata - beforeRouteLeave()');
         const curEditor = this.$route.name === 'editor';
         const confirmationMessage = this.$t('editor.leaveWarning');
         const stay =

--- a/src/components/metadata/metadata-modal.vue
+++ b/src/components/metadata/metadata-modal.vue
@@ -1,5 +1,5 @@
 <template>
-    <vue-final-modal
+    <VueFinalModal
         @click="productStore.saveMetadata(false)"
         modalId="metadata-edit-modal"
         content-class="edit-metadata-content max-h-full overflow-y-auto max-w-xl p-7 bg-white border rounded-lg"
@@ -44,30 +44,20 @@
                 </div>
             </div>
             <div class="mx-4">
-                <metadata-content></metadata-content>
+                <MetadataContentV></MetadataContentV>
             </div>
         </div>
-    </vue-final-modal>
+    </VueFinalModal>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import MetadataContentV from './metadata-content.vue';
-import { Options, Prop, Vue } from 'vue-property-decorator';
-import { MetadataContent } from '@/definitions';
 import { VueFinalModal } from 'vue-final-modal';
 import { useProductStore } from '@/stores/productStore';
 import { useEditorStore } from '@/stores/editorStore';
 
-@Options({
-    components: {
-        'metadata-content': MetadataContentV,
-        'vue-final-modal': VueFinalModal
-    }
-})
-export default class MetadataModalV extends Vue {
-    productStore = useProductStore();
-    editorStore = useEditorStore();
-}
+const productStore = useProductStore();
+const editorStore = useEditorStore();
 </script>
 
 <style lang="scss"></style>

--- a/src/components/panel-editors/chart-editor.vue
+++ b/src/components/panel-editors/chart-editor.vue
@@ -55,6 +55,7 @@
                         :index="index"
                         @edit="
                             (chart: ChartConfig) => {
+                                console.log('chart preview opened');
                                 openEditor(chart.name as string);
                             }
                         "
@@ -235,8 +236,11 @@ export default class ChartEditorV extends Vue {
     }
 
     openEditor(name: string) {
+        console.log(' ');
+        console.log('openEditor()');
         const idx = this.highchartsChartConfigs.findIndex((cfg) => cfg.title.text === name);
         if (idx !== -1) {
+            console.log('open highcharts edit modal');
             this.editingConfig = this.highchartsChartConfigs[idx];
             this.editingName = name;
             this.$vfm.open('highcharts-edit-modal');

--- a/src/components/panel-editors/chart-editor.vue
+++ b/src/components/panel-editors/chart-editor.vue
@@ -47,7 +47,7 @@
                 item-key="name"
             >
                 <template #item="{ element, index }">
-                    <ChartPreview
+                    <ChartPreviewV
                         :key="`${element.name}-${index}`"
                         :chart="element"
                         :chartVersion="chartVersions[element.name]"
@@ -55,13 +55,12 @@
                         :index="index"
                         @edit="
                             (chart: ChartConfig) => {
-                                console.log('chart preview opened');
                                 openEditor(chart.name as string);
                             }
                         "
                         @delete="$vfm.open(`${element.name}-${index}`)"
                         @captionEdit="onChartsEdited"
-                    ></ChartPreview>
+                    ></ChartPreviewV>
                 </template>
             </draggable>
         </ul>
@@ -125,296 +124,313 @@
     </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import ActionModal from '@/components/support/action-modal.vue';
-import { Options, Prop, Vue } from 'vue-property-decorator';
 import { ChartConfig, ChartPanel, HighchartsConfig, PanelType, SlideshowChartPanel } from '@/definitions';
 import { VueFinalModal } from 'vue-final-modal';
 import { useProductStore } from '@/stores/productStore';
+import { getCurrentInstance, onMounted, ref } from 'vue';
 
 import { applyTextAlign } from '@/utils/styleUtils';
 import ChartPreviewV from '../support/chart-preview.vue';
-import ConfirmationModalV from '../support/confirmation-modal.vue';
 import draggable from 'vuedraggable';
 
 import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
+import { useI18n } from 'vue-i18n';
+
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = withDefaults(
+    defineProps<{
+        panel: ChartPanel | SlideshowChartPanel;
+        lang: string;
+        allowMany?: boolean;
+        centerSlide?: boolean;
+        dynamicSelected?: boolean;
+    }>(),
+    {
+        allowMany: true,
+        centerSlide: false,
+        dynamicSelected: false
+    }
+);
+
+const emit = defineEmits(['slide-edit']);
+
+// =========================================
+// Definitions
 
 dataModule(Highcharts);
 
-@Options({
-    components: {
-        ActionModal,
-        ChartPreview: ChartPreviewV,
-        'confirmation-modal': ConfirmationModalV,
-        'vue-final-modal': VueFinalModal,
-        draggable
+const { $vfm } = getCurrentInstance()!.proxy!;
+const { t } = useI18n();
+
+const productStore = useProductStore();
+
+const edited = ref(false);
+const oldChartName = ref('');
+const chartIdx = ref(1);
+
+const storylinesChartConfigs = ref([] as Array<ChartConfig>);
+const highchartsChartConfigs = ref([] as Array<HighchartsConfig>);
+const chartVersions = ref({} as Record<string, number>);
+const editingConfig = ref(null as HighchartsConfig | null);
+const editingName = ref(null as string | null);
+
+// =========================================
+// Watchers
+
+// =========================================
+// Lifecycle functions
+
+onMounted(() => {
+    applyTextAlign(props.panel, props.centerSlide, props.dynamicSelected);
+
+    // This allows us to access the chart(s) using one consistent variable instead of needing to check panel type.
+    const charts =
+        props.panel.type === PanelType.SlideshowChart
+            ? (props.panel.items as Array<ChartPanel>)
+            : props.panel.src
+              ? [props.panel]
+              : [];
+
+    // fetch single existing chart config from ZIP
+    if (props.panel.type === PanelType.Chart && props.panel.src) {
+        fetchChartConfig(props.panel, 0, props.panel.config?.title?.text);
     }
-})
-export default class ChartEditorV extends Vue {
-    @Prop() panel!: ChartPanel | SlideshowChartPanel;
-    @Prop() lang!: string;
-    @Prop({ default: true }) allowMany!: boolean;
-    @Prop({ default: false }) centerSlide!: boolean;
-    @Prop({ default: false }) dynamicSelected!: boolean;
 
-    productStore = useProductStore();
-
-    edited = false;
-    oldChartName = '';
-    chartIdx = 1;
-
-    storylinesChartConfigs = [] as Array<ChartConfig>;
-    highchartsChartConfigs = [] as Array<HighchartsConfig>;
-    chartVersions: Record<string, number> = {};
-    editingConfig: HighchartsConfig | null = null;
-    editingName: string | null = null;
-
-    mounted(): void {
-        applyTextAlign(this.panel, this.centerSlide, this.dynamicSelected);
-
-        // This allows us to access the chart(s) using one consistent variable instead of needing to check panel type.
-        const charts =
-            this.panel.type === PanelType.SlideshowChart
-                ? (this.panel.items as Array<ChartPanel>)
-                : this.panel.src
-                  ? [this.panel]
-                  : [];
-
-        // fetch single existing chart config from ZIP
-        if (this.panel.type === PanelType.Chart && this.panel.src) {
-            this.fetchChartConfig(this.panel, 0, this.panel.config?.title?.text);
+    if (props.centerSlide && props.dynamicSelected) {
+        for (const c in charts) {
+            charts[c].customStyles += 'text-align: left;';
         }
-
-        if (this.centerSlide && this.dynamicSelected) {
-            for (const c in charts) {
-                charts[c].customStyles += 'text-align: left;';
-            }
-        } else if (!this.centerSlide && this.dynamicSelected) {
-            for (const c in charts) {
-                charts[c].customStyles = (charts[c].customStyles || '').replace('text-align: left;', '');
-            }
-        }
-
-        // fetch multiple existing chart configs from ZIP
-        if (this.panel.type === PanelType.SlideshowChart) {
-            let idx = 0;
-            charts.forEach((chart: ChartPanel) => {
-                this.fetchChartConfig(chart, idx, chart.name);
-            });
+    } else if (!props.centerSlide && props.dynamicSelected) {
+        for (const c in charts) {
+            charts[c].customStyles = (charts[c].customStyles || '').replace('text-align: left;', '');
         }
     }
 
-    fetchChartConfig(chart: ChartPanel | { config?: any; src?: string }, idx: number, chartName?: string) {
-        const chartSrc = chart.src.split('/').slice(1).join('/');
-        // chartName
-        //     ? `charts/${this.lang}/${chartName}.json`
-        //     : chart.src
-        //       ? chart.src.substring(chart.src.indexOf('/') + 1)
-        //       : '';
-
-        let highchartsJson = this.productStore.configFileStructure.zip.file(chartSrc);
-
-        // If not found, create file from config
-        if (!highchartsJson && chartName) {
-            const title = chartName;
-            this.productStore.configFileStructure.charts[this.lang].file(
-                `${title}.json`,
-                JSON.stringify(chart.config, null, 4)
-            );
-            highchartsJson = this.productStore.configFileStructure.zip.file(chartSrc);
-        }
-
-        if (highchartsJson) {
-            highchartsJson.async('string').then((res: string) => {
-                this.highchartsChartConfigs.push(JSON.parse(res));
-                this.extractStorylinesChartConfig(chart as ChartPanel, idx);
-                idx += 1;
-            });
-        }
-        this.chartIdx += 1;
-    }
-
-    openEditor(name: string) {
-        console.log(' ');
-        console.log('openEditor()');
-        const idx = this.highchartsChartConfigs.findIndex((cfg) => cfg.title.text === name);
-        if (idx !== -1) {
-            console.log('open highcharts edit modal');
-            this.editingConfig = this.highchartsChartConfigs[idx];
-            this.editingName = name;
-            this.$vfm.open('highcharts-edit-modal');
-        }
-        this.oldChartName = name;
-    }
-
-    createNewChart(newConfig: HighchartsConfig): void {
-        const chartSrc = `${this.productStore.configFileStructure.uuid}/charts/${this.lang}/${newConfig.title?.text}.json`;
-
-        // Check to see if a chart already exists with the provided name. If so, alert the user and re-prompt.
-        if (this.productStore.sourceExists(chartSrc)) {
-            alert(
-                this.$t('editor.chart.label.nameExists', {
-                    name: newConfig.title?.text
-                })
-            );
-            return;
-        } else {
-            const title = newConfig.title?.text;
-            const chartConfig = {
-                name: title,
-                src: chartSrc
-            };
-
-            this.productStore.incrementSourceCount(chartSrc);
-
-            // Add chart config to ZIP file.
-            this.productStore.configFileStructure.charts[this.lang].file(
-                `${title}.json`,
-                JSON.stringify(newConfig, null, 4)
-            );
-            this.storylinesChartConfigs.push(chartConfig);
-            this.chartVersions[title] = 0;
-            this.highchartsChartConfigs.push(newConfig);
-        }
-        this.onChartsEdited();
-        this.$vfm.close('highcharts-create-modal');
-        this.chartIdx += 1;
-    }
-
-    extractStorylinesChartConfig(chart: ChartPanel, chartIdx: number): void {
-        let chartName = '';
-        // extract chart name
-        if (this.highchartsChartConfigs[chartIdx]?.title.text) {
-            chartName = this.highchartsChartConfigs[chartIdx]?.title.text;
-        } else if (chart.options && chart.options.title) {
-            chartName = chart.options.title;
-        } else {
-            const path = chart.src.match(/.*\/(.*)$/);
-            chartName = path ? path[1].replace(/\.[^/.]+$/, '').replace(/\./g, ' ') : chart.src;
-        }
-        // save storylines chart config
-        this.storylinesChartConfigs.push({
-            name: chartName,
-            ...chart
+    // fetch multiple existing chart configs from ZIP
+    if (props.panel.type === PanelType.SlideshowChart) {
+        let idx = 0;
+        charts.forEach((chart: ChartPanel) => {
+            fetchChartConfig(chart, idx, chart.name);
         });
-        this.chartVersions[chartName] = 0;
+    }
+});
+
+// =========================================
+// Component functions
+
+function fetchChartConfig(chart: ChartPanel | { config?: any; src?: string }, idx: number, chartName?: string) {
+    const chartSrc = chart?.src?.split('/').slice(1).join('/');
+    // chartName
+    //     ? `charts/${this.lang}/${chartName}.json`
+    //     : chart.src
+    //       ? chart.src.substring(chart.src.indexOf('/') + 1)
+    //       : '';
+
+    let highchartsJson = productStore.configFileStructure.zip.file(chartSrc);
+
+    // If not found, create file from config
+    if (!highchartsJson && chartName) {
+        const title = chartName;
+        productStore.configFileStructure.charts[props.lang].file(
+            `${title}.json`,
+            JSON.stringify(chart.config, null, 4)
+        );
+        highchartsJson = productStore.configFileStructure.zip.file(chartSrc);
     }
 
-    saveChart(name: string, updatedConfig: HighchartsConfig): void {
-        const idx = this.storylinesChartConfigs.findIndex((c) => c.name === name);
-        if (idx !== -1) {
-            if (updatedConfig.title?.text !== this.oldChartName) {
-                // Check to ensure chart does not rename to an existing chart title
-                const newName = `${this.productStore.configFileStructure.uuid}/charts/${this.lang}/${updatedConfig.title?.text}.json`;
-                if (this.productStore.sourceCounts[newName] > 0) {
-                    alert(
-                        this.$t('editor.chart.label.nameExists', {
-                            name: updatedConfig.title?.text
-                        })
-                    );
-                    return;
-                }
-
-                // Remove old chart config from ZIP file and add in new one.
-                const oldName = `${this.productStore.configFileStructure.uuid}/charts/${this.lang}/${this.oldChartName}.json`;
-                this.productStore.sourceCounts[oldName] -= 1;
-                delete this.chartVersions[this.oldChartName];
-                if (this.productStore.sourceCounts[oldName] === 0) {
-                    this.productStore.configFileStructure.charts[this.lang].remove(`${this.oldChartName}.json`);
-                }
-
-                if (this.productStore.sourceCounts[newName]) {
-                    this.productStore.sourceCounts[newName] += 1;
-                } else {
-                    this.productStore.sourceCounts[newName] = 1;
-                }
-            }
-
-            const newTitle = updatedConfig.title.text;
-            // Add updated chart config to ZIP
-            this.productStore.configFileStructure.charts[this.lang].file(
-                `${newTitle}.json`,
-                JSON.stringify(updatedConfig, null, 4)
-            );
-
-            // Update local copies of Highcharts + Storylines chart configs
-            this.storylinesChartConfigs[idx] = {
-                name: updatedConfig.title?.text,
-                src: `${this.productStore.configFileStructure.uuid}/charts/${this.lang}/${newTitle}.json`
-            };
-            this.chartVersions[newTitle] = (this.chartVersions[newTitle] || 0) + 1;
-
-            this.highchartsChartConfigs[idx] = updatedConfig;
-        }
-        this.onChartsEdited();
+    if (highchartsJson) {
+        highchartsJson.async('string').then((res: string) => {
+            highchartsChartConfigs.value.push(JSON.parse(res));
+            extractStorylinesChartConfig(chart as ChartPanel, idx);
+            idx += 1;
+        });
     }
-
-    deleteChart(chart: ChartConfig): void {
-        const idx = this.storylinesChartConfigs.findIndex((chartFile: ChartConfig) => chartFile.name === chart.name);
-        if (idx !== -1) {
-            // Remove the chart from the config file.
-            this.productStore.sourceCounts[
-                `${this.productStore.configFileStructure.uuid}/charts/${this.lang}/${chart.name}.json`
-            ] -= 1;
-            if (
-                this.productStore.sourceCounts[
-                    `${this.productStore.configFileStructure.uuid}/charts/${this.lang}/${chart.name}.json`
-                ] === 0
-            ) {
-                this.productStore.configFileStructure.charts[this.lang].remove(`${chart.name}.json`);
-            }
-            this.storylinesChartConfigs.splice(idx, 1);
-            this.highchartsChartConfigs.splice(idx, 1);
-        }
-        this.onChartsEdited();
-    }
-
-    saveChanges(): void {
-        if (this.edited) {
-            // Delete the existing properties so we can rebuild the object.
-            Object.keys(this.panel).forEach((key) => {
-                // @ts-ignore
-                delete this.panel[key];
-            });
-
-            // Handle case where every chart is deleted.
-            if (this.storylinesChartConfigs.length === 0) {
-                this.panel.type = PanelType.Chart;
-                (this.panel as ChartPanel).src = '';
-            } else if (this.storylinesChartConfigs.length === 1) {
-                this.panel.type = PanelType.Chart;
-
-                // Grab the one chart config from the array.
-                const newChart = this.storylinesChartConfigs[0];
-
-                // Sort of gross, but required to update the panel config as we're not allowed to directly manipulate props.
-                Object.keys(newChart).forEach((key) => {
-                    // @ts-ignore
-                    (this.panel as ChartPanel)[key] = newChart[key];
-                });
-            } else {
-                this.panel.type = PanelType.SlideshowChart;
-
-                // Turn each of the chart configs into a chart panel and add them to the slideshow.
-                (this.panel as SlideshowChartPanel).items = this.storylinesChartConfigs.map((chart: ChartConfig) => {
-                    return {
-                        ...chart,
-                        type: PanelType.Chart
-                    } as ChartPanel;
-                });
-            }
-        }
-
-        this.edited = false;
-    }
-
-    onChartsEdited(): void {
-        this.edited = true;
-        this.saveChanges();
-        this.$emit('slide-edit', 'Chart editor');
-    }
+    chartIdx.value += 1;
 }
+
+function openEditor(name: string) {
+    const idx = highchartsChartConfigs.value.findIndex((cfg) => cfg.title.text === name);
+    if (idx !== -1) {
+        editingConfig.value = highchartsChartConfigs.value[idx];
+        editingName.value = name;
+        $vfm.open('highcharts-edit-modal');
+    }
+    oldChartName.value = name;
+}
+
+function createNewChart(newConfig: HighchartsConfig): void {
+    const chartSrc = `${productStore.configFileStructure.uuid}/charts/${props.lang}/${newConfig.title?.text}.json`;
+
+    // Check to see if a chart already exists with the provided name. If so, alert the user and re-prompt.
+    if (productStore.sourceExists(chartSrc)) {
+        alert(
+            t('editor.chart.label.nameExists', {
+                name: newConfig.title?.text
+            })
+        );
+        return;
+    } else {
+        const title = newConfig.title?.text;
+        const chartConfig = {
+            name: title,
+            src: chartSrc
+        };
+
+        productStore.incrementSourceCount(chartSrc);
+
+        // Add chart config to ZIP file.
+        productStore.configFileStructure.charts[props.lang].file(`${title}.json`, JSON.stringify(newConfig, null, 4));
+        storylinesChartConfigs.value.push(chartConfig);
+        chartVersions.value[title] = 0;
+        highchartsChartConfigs.value.push(newConfig);
+    }
+    onChartsEdited();
+    $vfm.close('highcharts-create-modal');
+    chartIdx.value += 1;
+}
+
+function extractStorylinesChartConfig(chart: ChartPanel, chartIdx: number): void {
+    let chartName = '';
+    // extract chart name
+    if (highchartsChartConfigs.value[chartIdx]?.title.text) {
+        chartName = highchartsChartConfigs.value[chartIdx]?.title.text;
+    } else if (chart.options && chart.options.title) {
+        chartName = chart.options.title;
+    } else {
+        const path = chart.src.match(/.*\/(.*)$/);
+        chartName = path ? path[1].replace(/\.[^/.]+$/, '').replace(/\./g, ' ') : chart.src;
+    }
+    // save storylines chart config
+    storylinesChartConfigs.value.push({
+        name: chartName,
+        ...chart
+    });
+    chartVersions.value[chartName] = 0;
+}
+
+function saveChart(name: string, updatedConfig: HighchartsConfig): void {
+    const idx = storylinesChartConfigs.value.findIndex((c) => c.name === name);
+    if (idx !== -1) {
+        if (updatedConfig.title?.text !== oldChartName.value) {
+            // Check to ensure chart does not rename to an existing chart title
+            const newName = `${productStore.configFileStructure.uuid}/charts/${props.lang}/${updatedConfig.title?.text}.json`;
+            if (productStore.sourceCounts[newName] > 0) {
+                alert(
+                    t('editor.chart.label.nameExists', {
+                        name: updatedConfig.title?.text
+                    })
+                );
+                return;
+            }
+
+            // Remove old chart config from ZIP file and add in new one.
+            const oldName = `${productStore.configFileStructure.uuid}/charts/${props.lang}/${oldChartName.value}.json`;
+            productStore.sourceCounts[oldName] -= 1;
+            delete chartVersions.value[oldChartName.value];
+            if (productStore.sourceCounts[oldName] === 0) {
+                productStore.configFileStructure.charts[props.lang].remove(`${oldChartName.value}.json`);
+            }
+
+            if (productStore.sourceCounts[newName]) {
+                productStore.sourceCounts[newName] += 1;
+            } else {
+                productStore.sourceCounts[newName] = 1;
+            }
+        }
+
+        const newTitle = updatedConfig.title.text;
+        // Add updated chart config to ZIP
+        productStore.configFileStructure.charts[props.lang].file(
+            `${newTitle}.json`,
+            JSON.stringify(updatedConfig, null, 4)
+        );
+
+        // Update local copies of Highcharts + Storylines chart configs
+        storylinesChartConfigs.value[idx] = {
+            name: updatedConfig.title?.text,
+            src: `${productStore.configFileStructure.uuid}/charts/${props.lang}/${newTitle}.json`
+        };
+        chartVersions.value[newTitle] = (chartVersions.value[newTitle] || 0) + 1;
+
+        highchartsChartConfigs.value[idx] = updatedConfig;
+    }
+    onChartsEdited();
+}
+
+function deleteChart(chart: ChartConfig): void {
+    const idx = storylinesChartConfigs.value.findIndex((chartFile: ChartConfig) => chartFile.name === chart.name);
+    if (idx !== -1) {
+        // Remove the chart from the config file.
+        productStore.sourceCounts[`${productStore.configFileStructure.uuid}/charts/${props.lang}/${chart.name}.json`] -=
+            1;
+        if (
+            productStore.sourceCounts[
+                `${productStore.configFileStructure.uuid}/charts/${props.lang}/${chart.name}.json`
+            ] === 0
+        ) {
+            productStore.configFileStructure.charts[props.lang].remove(`${chart.name}.json`);
+        }
+        storylinesChartConfigs.value.splice(idx, 1);
+        highchartsChartConfigs.value.splice(idx, 1);
+    }
+    onChartsEdited();
+}
+
+function saveChanges(): void {
+    if (edited.value) {
+        // Delete the existing properties so we can rebuild the object.
+        Object.keys(props.panel).forEach((key) => {
+            // @ts-ignore
+            delete props.panel[key];
+        });
+
+        // Handle case where every chart is deleted.
+        if (storylinesChartConfigs.value.length === 0) {
+            props.panel.type = PanelType.Chart;
+            (props.panel as ChartPanel).src = '';
+        } else if (storylinesChartConfigs.value.length === 1) {
+            props.panel.type = PanelType.Chart;
+
+            // Grab the one chart config from the array.
+            const newChart = storylinesChartConfigs.value[0];
+
+            // Sort of gross, but required to update the panel config as we're not allowed to directly manipulate props.
+            Object.keys(newChart).forEach((key) => {
+                // @ts-ignore
+                (props.panel as ChartPanel)[key] = newChart[key];
+            });
+        } else {
+            props.panel.type = PanelType.SlideshowChart;
+
+            // Turn each of the chart configs into a chart panel and add them to the slideshow.
+            (props.panel as SlideshowChartPanel).items = storylinesChartConfigs.value.map((chart: ChartConfig) => {
+                return {
+                    ...chart,
+                    type: PanelType.Chart
+                } as ChartPanel;
+            });
+        }
+    }
+
+    edited.value = false;
+}
+
+function onChartsEdited(): void {
+    edited.value = true;
+    saveChanges();
+    emit('slide-edit', 'Chart editor');
+}
+
+// =========================================
+// Component exposes
+
+defineExpose({ saveChanges });
 </script>
 
 <style lang="scss">

--- a/src/components/panel-editors/custom-editor.vue
+++ b/src/components/panel-editors/custom-editor.vue
@@ -82,6 +82,8 @@ const panelTypeToSchemaKey = {
 } as const;
 type PanelType = keyof typeof panelTypeToSchemaKey;
 
+import { useEditorStore } from '@/stores/editorStore';
+
 @Options({
     components: {
         'json-editor': Vue3JsonEditor
@@ -100,6 +102,8 @@ export default class CustomEditorV extends Vue {
     storylinesSchema: Record<string, any> = {};
 
     mounted(): void {
+        console.log(' ');
+        console.log('mounted');
         import('ramp-storylines_demo-scenarios-pcar/dist/StorylinesSchema.json').then((StorylinesSchema) => {
             this.storylinesSchema = {
                 ...StorylinesSchema.$defs.slide,
@@ -232,6 +236,8 @@ export default class CustomEditorV extends Vue {
     }
 
     onJsonChange(json: any): void {
+        console.log(' ');
+        console.log('onJSONChange');
         this.jsonError = '';
         const valid = this.validate(json);
         this.edited = true;

--- a/src/components/panel-editors/dynamic-editor.vue
+++ b/src/components/panel-editors/dynamic-editor.vue
@@ -439,6 +439,10 @@ export default class DynamicEditorV extends Vue {
     }
 
     saveChanges(): void {
+        console.log(' ');
+        console.log('dynamicEditor - saveChanges()');
+        console.log('slide ref');
+        console.log(this.$refs.slide);
         if (
             this.editingSlide !== -1 &&
             this.$refs.slide !== undefined &&

--- a/src/components/panel-editors/image-editor.vue
+++ b/src/components/panel-editors/image-editor.vue
@@ -2,7 +2,12 @@
     <div class="block">
         <!-- Upload images area -->
         <div
-            class="upload-image flex items-center justify-center m-5 p-12 bg-blue-100 border-4 border-dashed border-blue-300"
+            class="upload-image flex items-center justify-center m-5 p-12 border-4 border-dashed"
+            style="
+                background-color: #dbeafe !important;
+                border-color: #93c5fd !important;
+                border-radius: 5px !important;
+            "
             :class="{ dragging: isDragging }"
             @dragover.prevent="() => (dragging = true)"
             @dragleave.prevent="() => (dragging = false)"
@@ -61,7 +66,7 @@
             item-key="id"
         >
             <template #item="{ element, index }">
-                <ImagePreview
+                <ImagePreviewV
                     :key="`${element.id}-${index}`"
                     :imageFile="element"
                     @delete="deleteImage"
@@ -159,216 +164,233 @@
                             </div>
                         </div>
                     </div>
-                </ImagePreview>
+                </ImagePreviewV>
             </template>
         </draggable>
     </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { applyTextAlign } from '@/utils/styleUtils';
-import { Options, Prop, Vue } from 'vue-property-decorator';
 import { ImageFile, ImagePanel, PanelType, SlideshowImagePanel } from '@/definitions';
 import draggable from 'vuedraggable';
 import ImagePreviewV from '../support/image-preview.vue';
 import { useProductStore } from '@/stores/productStore';
+import { onMounted, ref } from 'vue';
 
-@Options({
-    components: {
-        ImagePreview: ImagePreviewV,
-        draggable
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = withDefaults(
+    defineProps<{
+        panel: ImagePanel | SlideshowImagePanel;
+        lang: string;
+        allowMany?: boolean;
+        centerSlide?: boolean;
+        dynamicSelected?: boolean;
+    }>(),
+    {
+        allowMany: true,
+        centerSlide: false,
+        dynamicSelected: false
     }
-})
-export default class ImageEditorV extends Vue {
-    @Prop() panel!: ImagePanel | SlideshowImagePanel;
-    @Prop() lang!: string;
-    @Prop({ default: true }) allowMany!: boolean;
-    @Prop({ default: false }) centerSlide!: boolean;
-    @Prop({ default: false }) dynamicSelected!: boolean;
+);
 
-    productStore = useProductStore();
+const emit = defineEmits(['slide-edit']);
 
-    dragging = false;
-    edited = false;
+// =========================================
+// Definitions
 
-    imagePreviewsLoading = false;
-    imagePreviewPromises = [] as Array<Promise<ImageFile>>;
-    imagePreviews = [] as Array<ImageFile>;
-    slideshowCaption = '';
+const productStore = useProductStore();
 
-    get isDragging(): boolean {
-        return this.dragging;
-    }
-    //
-    // @Watch('panel.caption')
-    // onCaptionChange() {
-    //     if (this.panel.caption !== this.slideshowCaption) {
-    //         this.slideshowCaption = this.panel.caption;
-    //     }
-    // }
+const dragging = ref(false);
+const edited = ref(false);
 
-    mounted(): void {
-        applyTextAlign(this.panel, this.centerSlide, this.dynamicSelected);
+const imagePreviewsLoading = ref(false);
+const imagePreviewPromises = ref([] as Array<Promise<ImageFile>>);
+const imagePreviews = ref([] as Array<ImageFile>);
+const slideshowCaption = ref('');
 
-        // This basically allows us to access the image(s) using one consistent variable instead of needing to check panel type.
-        const images =
-            this.panel.type === PanelType.SlideshowImage
-                ? (this.panel.items as Array<ImagePanel>)
-                : this.panel.src
-                  ? [this.panel]
-                  : [];
+// =========================================
+// Watchers
 
-        if (images !== undefined && images.length) {
-            // Set images as loading until they are all loaded and resolve.
-            this.imagePreviewsLoading = true;
+// =========================================
+// Lifecycle functions
 
-            // Process each existing image.
-            images.map((image: ImagePanel) => {
-                // Check if the config file exists in the ZIP folder first.
-                const assetSrc = `${image.src.substring(image.src.indexOf('/') + 1)}`;
-                const filename = image.src.replace(/^.*[\\/]/, '');
-                const compressedAssetFile = this.productStore.configFileStructure.zip.file(assetSrc);
-                const assetType = assetSrc.split('.').at(-1);
+onMounted(() => {
+    applyTextAlign(props.panel, props.centerSlide, props.dynamicSelected);
 
-                if (compressedAssetFile) {
-                    this.imagePreviewPromises.push(
-                        compressedAssetFile.async(assetType !== 'svg' ? 'blob' : 'text').then((assetFile) => {
-                            if (assetType === 'svg') {
-                                assetFile = new File([assetFile], filename, {
-                                    type: 'image/svg+xml'
-                                });
-                            }
-                            return {
-                                ...image,
-                                id: image.src,
-                                src: URL.createObjectURL(assetFile as Blob)
-                            } as ImageFile;
-                        })
-                    );
-                }
-            });
+    // This basically allows us to access the image(s) using one consistent variable instead of needing to check panel type.
+    const images =
+        props.panel.type === PanelType.SlideshowImage
+            ? (props.panel.items as Array<ImagePanel>)
+            : props.panel.src
+              ? [props.panel]
+              : [];
 
-            // Once all images have been retrieved, display them.
-            Promise.all(this.imagePreviewPromises).then((res) => {
-                this.imagePreviews = res;
-                this.imagePreviewsLoading = false;
-            });
-            this.slideshowCaption = this.panel.caption as string;
-        }
-    }
+    if (images !== undefined && images.length) {
+        // Set images as loading until they are all loaded and resolve.
+        imagePreviewsLoading.value = true;
 
-    async addUploadedFile(file: File): Promise<ImageFile> {
-        const { inSharedAsset, newAssetName, uploadSource } = await this.productStore.addUploadedFile(file);
+        // Process each existing image.
+        images.map((image: ImagePanel) => {
+            // Check if the config file exists in the ZIP folder first.
+            const assetSrc = `${image.src.substring(image.src.indexOf('/') + 1)}`;
+            const filename = image.src.replace(/^.*[\\/]/, '');
+            const compressedAssetFile = productStore.configFileStructure.zip.file(assetSrc);
+            const assetType = assetSrc.split('.').at(-1);
 
-        let imageSrc = URL.createObjectURL(file);
-        return {
-            id: uploadSource,
-            altText: '',
-            caption: '',
-            src: imageSrc
-        };
-    }
-
-    onFileChange(e: Event): void {
-        // create object URL(s) to display image(s)
-        const filelist = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>);
-        const filePromises = filelist.map((file: File) => this.addUploadedFile(file));
-        Promise.all(filePromises).then((files) => {
-            this.imagePreviews.push(...files);
-            this.onImagesEdited();
+            if (compressedAssetFile) {
+                imagePreviewPromises.value.push(
+                    compressedAssetFile.async(assetType !== 'svg' ? 'blob' : 'text').then((assetFile) => {
+                        if (assetType === 'svg') {
+                            assetFile = new File([assetFile], filename, {
+                                type: 'image/svg+xml'
+                            });
+                        }
+                        return {
+                            ...image,
+                            id: image.src,
+                            src: URL.createObjectURL(assetFile as Blob)
+                        } as ImageFile;
+                    })
+                );
+            }
         });
-        //reset input value
-        (e.target as HTMLInputElement).value = '';
+
+        // Once all images have been retrieved, display them.
+        Promise.all(imagePreviewPromises.value).then((res) => {
+            imagePreviews.value = res;
+            imagePreviewsLoading.value = false;
+        });
+        slideshowCaption.value = props.panel.caption as string;
     }
+});
 
-    dropImages(e: DragEvent): void {
-        if (e.dataTransfer !== null) {
-            let files = [...e.dataTransfer.files];
+// =========================================
+// Component functions
 
-            // If allowMany is false, take the first one.
-            if (!this.allowMany) {
-                files = [files[0]];
-            }
+function isDragging(): boolean {
+    return dragging.value;
+}
 
-            const filePromises = files.map((file: File) => this.addUploadedFile(file));
-            Promise.all(filePromises).then((files) => {
-                this.imagePreviews.push(...files);
-                this.onImagesEdited();
-            });
+async function addUploadedFile(file: File): Promise<ImageFile> {
+    const { uploadSource } = await productStore.addUploadedFile(file);
 
-            this.dragging = false;
+    let imageSrc = URL.createObjectURL(file);
+    return {
+        id: uploadSource,
+        altText: '',
+        caption: '',
+        src: imageSrc
+    };
+}
+
+function onFileChange(e: Event): void {
+    // create object URL(s) to display image(s)
+    const filelist = Array.from((e.target as HTMLInputElement).files as ArrayLike<File>);
+    const filePromises = filelist.map((file: File) => addUploadedFile(file));
+    Promise.all(filePromises).then((files) => {
+        imagePreviews.value.push(...files);
+        onImagesEdited();
+    });
+    //reset input value
+    (e.target as HTMLInputElement).value = '';
+}
+
+function dropImages(e: DragEvent): void {
+    if (e.dataTransfer !== null) {
+        let files = [...e.dataTransfer.files];
+
+        // If allowMany is false, take the first one.
+        if (!props.allowMany) {
+            files = [files[0]];
         }
-    }
 
-    deleteImage(img: ImageFile): void {
-        const idx = this.imagePreviews.findIndex((file: ImageFile) => file.id === img.id);
-        if (idx !== -1) {
-            const assetSource = this.imagePreviews[idx].id;
-            // Remove the image from the product ZIP file.
-            // TODO: Deleting the image breaks state management! We can't undo the deletion since the image is actually gone, and the config only stores the src!
-            // this.productStore.decrementSourceCount(assetSource);
-            // if (!this.productStore.sourceExists(assetSource)) {
-            //     // Revote the object URL if the image has been fully removed.
-            //     URL.revokeObjectURL(this.imagePreviews[idx].src);
-            // }
-            this.imagePreviews.splice(idx, 1);
-        }
-        this.onImagesEdited();
-    }
+        const filePromises = files.map((file: File) => addUploadedFile(file));
+        Promise.all(filePromises).then((files) => {
+            imagePreviews.value.push(...files);
+            onImagesEdited();
+        });
 
-    saveChanges(): void {
-        if (this.edited) {
-            // Delete the existing properties so we can rebuild the object.
-            Object.keys(this.panel).forEach((key) => {
-                // @ts-ignore
-                delete this.panel[key];
-            });
-
-            // Handle case where everything is deleted.
-            if (this.imagePreviews.length === 0) {
-                this.panel.type = PanelType.Image;
-                (this.panel as ImagePanel).src = '';
-            } else if (this.imagePreviews.length === 1) {
-                // If there's only one image uploaded, convert this to an image panel.
-                this.panel.type = PanelType.Image;
-
-                // Grab the one image from the array.
-                const imageFile = this.imagePreviews[0];
-
-                // Sort of gross, but required to update the panel config as we're not allowed to directly manipulate props.
-                Object.keys(imageFile).forEach((key) => {
-                    if (key === 'id') return; // we don't need this one.
-
-                    // @ts-ignore
-                    (this.panel as ImagePanel)[key] = imageFile[key];
-                });
-                (this.panel as ImagePanel).src = imageFile.id;
-            } else {
-                // Otherwise, convert this to a slideshowImage panel.
-                this.panel.type = PanelType.SlideshowImage;
-                this.panel.caption = this.slideshowCaption ?? undefined;
-
-                // Turn each of the image configs into an image panel and add them to the slideshow.
-                (this.panel as SlideshowImagePanel).items = this.imagePreviews.map((imageFile: ImageFile) => {
-                    const { id, ...restOfImage } = imageFile; // we don't need the id
-                    const imageSrc = id;
-                    return {
-                        ...restOfImage,
-                        src: imageSrc,
-                        type: PanelType.Image
-                    } as ImagePanel;
-                });
-            }
-        }
-        this.edited = false;
-    }
-
-    onImagesEdited(): void {
-        this.edited = true;
-        this.saveChanges();
-        this.$emit('slide-edit', 'Image editor');
+        dragging.value = false;
     }
 }
+
+function deleteImage(img: ImageFile): void {
+    const idx = imagePreviews.value.findIndex((file: ImageFile) => file.id === img.id);
+    if (idx !== -1) {
+        const assetSource = imagePreviews.value[idx].id;
+        // Remove the image from the product ZIP file.
+        // TODO: Deleting the image breaks state management! We can't undo the deletion since the image is actually gone, and the config only stores the src!
+        // productStore.decrementSourceCount(assetSource);
+        // if (!productStore.sourceExists(assetSource)) {
+        //     // Revote the object URL if the image has been fully removed.
+        //     URL.revokeObjectURL(imagePreviews.value[idx].src);
+        // }
+        imagePreviews.value.splice(idx, 1);
+    }
+    onImagesEdited();
+}
+
+function saveChanges(): void {
+    if (edited.value) {
+        // Delete the existing properties so we can rebuild the object.
+        Object.keys(props.panel).forEach((key) => {
+            // @ts-ignore
+            delete props.panel[key];
+        });
+
+        // Handle case where everything is deleted.
+        if (imagePreviews.value.length === 0) {
+            props.panel.type = PanelType.Image;
+            (props.panel as ImagePanel).src = '';
+        } else if (imagePreviews.value.length === 1) {
+            // If there's only one image uploaded, convert this to an image panel.
+            props.panel.type = PanelType.Image;
+
+            // Grab the one image from the array.
+            const imageFile = imagePreviews.value[0];
+
+            // Sort of gross, but required to update the panel config as we're not allowed to directly manipulate props.
+            Object.keys(imageFile).forEach((key) => {
+                if (key === 'id') return; // we don't need this one.
+
+                // @ts-ignore
+                (props.panel as ImagePanel)[key] = imageFile[key];
+            });
+            (props.panel as ImagePanel).src = imageFile.id;
+        } else {
+            // Otherwise, convert this to a slideshowImage panel.
+            props.panel.type = PanelType.SlideshowImage;
+            props.panel.caption = slideshowCaption.value ?? undefined;
+
+            // Turn each of the image configs into an image panel and add them to the slideshow.
+            (props.panel as SlideshowImagePanel).items = imagePreviews.value.map((imageFile: ImageFile) => {
+                const { id, ...restOfImage } = imageFile; // we don't need the id
+                const imageSrc = id;
+                return {
+                    ...restOfImage,
+                    src: imageSrc,
+                    type: PanelType.Image
+                } as ImagePanel;
+            });
+        }
+    }
+    edited.value = false;
+}
+
+function onImagesEdited(): void {
+    edited.value = true;
+    saveChanges();
+    emit('slide-edit', 'Image editor');
+}
+
+// =========================================
+// Component exposes
+
+defineExpose({ saveChanges });
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/panel-editors/text-editor.vue
+++ b/src/components/panel-editors/text-editor.vue
@@ -7,7 +7,7 @@
             :style="{ border: '1px solid #a1a1a1', zIndex: isFullScreen ? 150 : 0 }"
             class="text-editor-container rounded-md p-1 shadow-md"
         >
-            <v-md-editor
+            <VueMarkdownEditor
                 v-model="panel.content"
                 :include-level="[1, 2, 3, 4]"
                 height="400px"
@@ -15,7 +15,7 @@
                 :toolbar="toolbar"
                 @fullscreen-change="onFullscreenChange"
                 ref="mdEditor"
-            ></v-md-editor>
+            ></VueMarkdownEditor>
         </div>
         <!-- WET Component Dashboard. Only accessible if using the Canada.ca template. -->
         <div id="WETDashboard" class="WETDashboard relative p-2 my-10 rounded-sm" v-if="wetComponentsVisible">
@@ -29,7 +29,7 @@
                     <details>
                         <summary class="font-bold text-xl">{{ section.section }}</summary>
                         <div class="flex flex-row flex-wrap">
-                            <wet-item
+                            <WetDashboardItem
                                 v-for="component in section.children"
                                 :key="component.name"
                                 :component="component"
@@ -43,506 +43,524 @@
     </div>
 </template>
 
-<script lang="ts">
-import { Options, Prop, Vue, Watch } from 'vue-property-decorator';
+<script setup lang="ts">
+import { computed, nextTick, onMounted, onUnmounted, reactive, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 import VueMarkdownEditor, { langMap } from '@/plugins/markdown-editor/index';
 import { TextPanel } from '@/definitions';
 import { applyTextAlign } from '@/utils/styleUtils';
-import WETDashboardItemV from '../support/wet-dashboard-item.vue';
+import WetDashboardItem from '../support/wet-dashboard-item.vue';
 import WETComponents from '../support/wet-component-templates.json';
 import DOMPurify from 'dompurify';
 import tippy from 'tippy.js';
 
+// Define interfaces
 interface MDEditor {
     insert(callback: (selected: string) => { text: string; selected: string }): void;
 }
+
 interface WETComponentsObject {
     [key: string]: {
         sections: { section: string; children: { name: string; html: string }[] }[];
     };
 }
 
-@Options({
-    components: {
-        'wet-item': WETDashboardItemV
+// Set default values for optional props
+const props = withDefaults(
+    defineProps<{
+        panel: TextPanel;
+        centerSlide?: boolean;
+        dynamicSelected?: boolean;
+        lang?: string;
+    }>(),
+    {
+        centerSlide: false,
+        dynamicSelected: false
     }
-})
-export default class TextEditorV extends Vue {
-    @Prop() panel!: TextPanel;
-    @Prop({ default: false }) centerSlide!: boolean;
-    @Prop({ default: false }) dynamicSelected!: boolean;
-    @Prop() lang!: string;
+);
 
-    wetComponentsVisible = false;
-    editor: MDEditor = {} as MDEditor;
-    components: WETComponentsObject = WETComponents;
-    pageLang = window.location.href.includes('index-ca-en') ? 'en' : 'fr'; // this is only used if `index-ca` is already in the URL.
+const emit = defineEmits(['slide-edit']);
 
-    @Watch('panel.content', { deep: true, immediate: true })
-    onContentChanged() {
-        this.$emit('slide-edit');
+// Setup i18n
+const { t, locale } = useI18n();
 
-        const currentLocale = this.$i18n.locale === 'fr' ? 'fr-FR' : 'en-US';
+// Reactive state
+const wetComponentsVisible = ref(false);
+const editor = ref<MDEditor>({} as MDEditor);
+const components = reactive<WETComponentsObject>(WETComponents);
+const pageLang = ref(window.location.href.includes('index-ca-en') ? 'en' : 'fr');
+const isFullScreen = ref(false);
+const fontSizes = [5, 5.5, 6.5, 7.5, 8, 9, 10, 10.5, 11, 12, 14, 18, 20, 22, 24, 26, 28, 36, 48, 72];
+
+// Watch panel.content
+watch(
+    () => props.panel.content,
+    () => {
+        emit('slide-edit');
+
+        const currentLocale = locale.value === 'fr' ? 'fr-FR' : 'en-US';
         VueMarkdownEditor.lang.use(currentLocale, langMap[currentLocale]);
+    },
+    { deep: true, immediate: true }
+);
+
+// ==========================
+// Functions
+
+function onFullscreenChange(newVal: boolean) {
+    isFullScreen.value = newVal;
+}
+
+function makeTextEditorElementsTabbable() {
+    // Make preview tabbable
+    const preview = document.querySelector('.v-md-editor__preview-wrapper') as HTMLElement;
+    if (preview) {
+        preview.setAttribute('tabindex', '0');
     }
 
-    // Detecting whether the text editor is in fullscreen mode
-    isFullScreen = false;
-    onFullscreenChange(isFullScreen: boolean) {
-        this.isFullScreen = isFullScreen;
-    }
+    // Allow tabbing out of the text editor area
+    const patchCodeMirrorTabBehavior = (): void => {
+        // Find the actual CodeMirror instance (it's on the .CodeMirror class div)
+        const cmWrapper = document.querySelector('.CodeMirror') as any;
+        if (!cmWrapper || !cmWrapper.CodeMirror) return;
 
-    // A ridiculous workaround to make the toolbar buttons (and the preview) in the md-editor tabbable.
-    // Hopefully a better solution can be found eventually.
-    makeTextEditorElementsTabbable() {
-        // Make preview tabbable
-        const preview = this.$el.querySelector('.v-md-editor__preview-wrapper') as HTMLElement;
-        if (preview) {
-            preview.setAttribute('tabindex', '0');
-        }
+        const cm = cmWrapper.CodeMirror;
 
-        // Allow tabbing out of the text editor area
-        // TODO: Need two tabs to get into the preview (scrollable area). Can definitely be improved.
-        const patchCodeMirrorTabBehavior = (): void => {
-            // Find the actual CodeMirror instance (it's on the .CodeMirror class div)
-            const cmWrapper = this.$el.querySelector('.CodeMirror') as any;
-            if (!cmWrapper || !cmWrapper.CodeMirror) return;
-
-            const cm = cmWrapper.CodeMirror;
-
-            // Define the key behavior
-            cm.setOption('extraKeys', {
-                Tab: (_cm: any) => {
-                    this.moveFocus(1);
-                },
-                'Shift-Tab': (_cm: any) => {
-                    this.moveFocus(-1);
-                }
-            });
-        };
-        patchCodeMirrorTabBehavior();
-
-        const toolbar = this.$el.querySelector('.v-md-editor__toolbar');
-        if (!toolbar) return;
-
-        const makeButtonInteractive = (el: HTMLElement) => {
-            el.setAttribute('tabindex', '0');
-
-            // Show tooltips for toolbar items when focused upon
-            el.addEventListener('focus', () => {
-                const tooltip = el.querySelector('.v-md-editor__tooltip') as HTMLElement;
-                if (!tooltip) return;
-
-                // for calculating tooltip position
-                const rect = el.getBoundingClientRect();
-
-                tooltip.style.left = '0px';
-                tooltip.style.top = rect.height + 5 + 'px';
-                tooltip.style.display = 'block';
-            });
-
-            // Hide tooltips when toolbar item loses focus
-            el.addEventListener('blur', () => {
-                const tooltip = el.querySelector('.v-md-editor__tooltip') as HTMLElement;
-                if (!tooltip) return;
-                tooltip.style.display = 'none';
-            });
-
-            if (!el.dataset.keyboardEnabled) {
-                el.addEventListener('keydown', (e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-
-                        // Close any previously-opened menus first, with exceptions
-                        const openToggles = toolbar.querySelectorAll('.v-md-editor__toolbar-item--active');
-                        openToggles.forEach((openEl: HTMLElement) => {
-                            // skip the element we're about to open
-                            if (openEl === el) return;
-
-                            // ...and skip any "menus" (e.g. markdown preview) from the buttons inside the right toolbar
-                            // (they live under the UL[disabled-mens], or equivalently `.v-md-editor__toolbar-right`)
-                            if (openEl.closest('.v-md-editor__toolbar-right')) return;
-
-                            // otherwise, close it
-                            openEl.click();
-                        });
-
-                        // Now open this one
-                        el.click();
-
-                        // If it has a submenu, focus its first item after a delay
-                        const menu = el.querySelector('.v-md-editor__menu');
-                        if (menu) {
-                            setTimeout(() => {
-                                const firstItem = menu.querySelector('.v-md-editor__menu-item');
-                                (firstItem as HTMLElement).focus();
-                            }, 100);
-                        }
-                    }
-                });
-                el.dataset.keyboardEnabled = 'true';
+        // Define the key behavior
+        cm.setOption('extraKeys', {
+            Tab: (_cm: any) => {
+                moveFocus(1);
+            },
+            'Shift-Tab': (_cm: any) => {
+                moveFocus(-1);
             }
-        };
+        });
+    };
+    patchCodeMirrorTabBehavior();
 
-        const makeDropdownItemsInteractive = () => {
-            const items = toolbar.querySelectorAll('.v-md-editor__menu-item');
-            items.forEach((item: HTMLElement) => {
-                item.setAttribute('tabindex', '0');
-                item.setAttribute('role', 'menuitem');
+    const toolbar = document.querySelector('.v-md-editor__toolbar');
+    if (!toolbar) return;
 
-                if (!item.dataset.keyboardEnabled) {
-                    item.addEventListener('keydown', (e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            item.click();
-                        } else if (e.key === 'ArrowDown') {
-                            e.preventDefault();
-                            const next = item.nextElementSibling;
-                            if (next?.classList.contains('v-md-editor__menu-item')) {
-                                (next as HTMLElement).focus();
-                            }
-                        } else if (e.key === 'ArrowUp') {
-                            e.preventDefault();
-                            const prev = item.previousElementSibling;
-                            if (prev?.classList.contains('v-md-editor__menu-item')) {
-                                (prev as HTMLElement).focus();
-                            }
-                        } else if (e.key === 'Escape') {
-                            // Return focus to the dropdown toggle
-                            (item.closest('.v-md-editor__toolbar-item') as HTMLElement).focus();
-                        }
-                    });
-                    item.dataset.keyboardEnabled = 'true';
-                }
-            });
-        };
+    const makeButtonInteractive = (el: HTMLElement) => {
+        el.setAttribute('tabindex', '0');
 
-        // Allow tabbing for TOC area
-        const initializeTOCTabbing = (tocContainer: HTMLElement | null) => {
-            if (!tocContainer) return;
+        // Show tooltips for toolbar items when focused upon
+        el.addEventListener('focus', () => {
+            const tooltip = el.querySelector('.v-md-editor__tooltip') as HTMLElement;
+            if (!tooltip) return;
 
-            tocContainer.setAttribute('tabindex', '0');
-            tocContainer.dataset.keyboardEnabled = 'false';
+            // for calculating tooltip position
+            const rect = el.getBoundingClientRect();
 
-            let tooltip: any = null;
-            tocContainer.addEventListener('focus', () => {
-                if (tocContainer.offsetWidth > 10) {
-                    tooltip ??= tippy(tocContainer, {
-                        content: this.$t('editor.slides.panel.toc'),
-                        trigger: 'manual',
-                        placement: 'top'
-                    });
-                    tooltip.show();
-                }
-            });
+            tooltip.style.left = '0px';
+            tooltip.style.top = rect.height + 5 + 'px';
+            tooltip.style.display = 'block';
+        });
 
-            tocContainer.addEventListener('keydown', (e: KeyboardEvent) => {
-                if ((e.key === 'Enter' || e.key === ' ') && tocContainer.dataset.keyboardEnabled === 'false') {
+        // Hide tooltips when toolbar item loses focus
+        el.addEventListener('blur', () => {
+            const tooltip = el.querySelector('.v-md-editor__tooltip') as HTMLElement;
+            if (!tooltip) return;
+            tooltip.style.display = 'none';
+        });
+
+        if (!el.dataset.keyboardEnabled) {
+            el.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
                     e.preventDefault();
-                    const tocItems = tocContainer.querySelectorAll<HTMLElement>('.v-md-editor__toc-nav-item');
-                    // Enable tabbing for each TOC item
-                    makeTOCItemsInteractive(tocItems);
 
-                    // Focus onto the first TOC item
-                    tocContainer.dataset.keyboardEnabled = 'true';
-                    (tocItems[0] as HTMLElement)?.focus();
-                }
-            });
-            // Reset TOC items’ tabbing state when focus leaves the TOC container
-            tocContainer.addEventListener('focusout', (e: FocusEvent) => {
-                const relatedTarget = e.relatedTarget as HTMLElement | null;
-                if (!relatedTarget || !tocContainer.contains(relatedTarget)) {
-                    const tocItems = tocContainer.querySelectorAll<HTMLElement>('.v-md-editor__toc-nav-item');
-                    tocItems.forEach((item) => {
-                        item.removeAttribute('tabindex');
-                        item.dataset.keyboardEnabled = '';
+                    // Close any previously-opened menus first, with exceptions
+                    const openToggles = toolbar.querySelectorAll('.v-md-editor__toolbar-item--active');
+                    openToggles.forEach((openEl: HTMLElement) => {
+                        // skip the element we're about to open
+                        if (openEl === el) return;
+
+                        // ...and skip any "menus" (e.g. markdown preview) from the buttons inside the right toolbar
+                        // (they live under the UL[disabled-mens], or equivalently `.v-md-editor__toolbar-right`)
+                        if (openEl.closest('.v-md-editor__toolbar-right')) return;
+
+                        // otherwise, close it
+                        openEl.click();
                     });
-                    tocContainer.dataset.keyboardEnabled = 'false';
+
+                    // Now open this one
+                    el.click();
+
+                    // If it has a submenu, focus its first item after a delay
+                    const menu = el.querySelector('.v-md-editor__menu');
+                    if (menu) {
+                        setTimeout(() => {
+                            const firstItem = menu.querySelector('.v-md-editor__menu-item');
+                            (firstItem as HTMLElement).focus();
+                        }, 100);
+                    }
                 }
-                tooltip?.hide();
             });
-        };
+            el.dataset.keyboardEnabled = 'true';
+        }
+    };
 
-        const makeTOCItemsInteractive = (tocItems: NodeListOf<HTMLElement>) => {
-            tocItems.forEach((item: HTMLElement) => {
-                item.setAttribute('tabindex', '0');
-                if (item.dataset.keyboardEnabled) return;
+    const makeDropdownItemsInteractive = () => {
+        const items = toolbar.querySelectorAll('.v-md-editor__menu-item');
+        items.forEach((item: HTMLElement) => {
+            item.setAttribute('tabindex', '0');
+            item.setAttribute('role', 'menuitem');
 
-                item.addEventListener('keydown', (e: KeyboardEvent) => {
+            if (!item.dataset.keyboardEnabled) {
+                item.addEventListener('keydown', (e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
                         item.click();
+                    } else if (e.key === 'ArrowDown') {
+                        e.preventDefault();
+                        const next = item.nextElementSibling;
+                        if (next?.classList.contains('v-md-editor__menu-item')) {
+                            (next as HTMLElement).focus();
+                        }
+                    } else if (e.key === 'ArrowUp') {
+                        e.preventDefault();
+                        const prev = item.previousElementSibling;
+                        if (prev?.classList.contains('v-md-editor__menu-item')) {
+                            (prev as HTMLElement).focus();
+                        }
+                    } else if (e.key === 'Escape') {
+                        // Return focus to the dropdown toggle
+                        (item.closest('.v-md-editor__toolbar-item') as HTMLElement).focus();
                     }
                 });
                 item.dataset.keyboardEnabled = 'true';
-            });
-        };
-
-        const patchEverything = () => {
-            const buttons = toolbar.querySelectorAll('[role="button"], button, .v-md-editor__toolbar-item');
-            buttons.forEach(makeButtonInteractive);
-            makeDropdownItemsInteractive();
-
-            const tocContainer = this.$el.querySelector('.v-md-editor__toc-nav');
-            initializeTOCTabbing(tocContainer);
-        };
-
-        const observer = new MutationObserver(patchEverything);
-
-        observer.observe(toolbar, {
-            childList: true,
-            subtree: true
-        });
-
-        patchEverything();
-    }
-
-    // TODO: May not play well with tabbing to preview (currently have bespoke code for that elsewhere). Maybe combine?
-    moveFocus(direction: number): void {
-        const focusableSelectors = [
-            'a[href]',
-            'button:not([disabled])',
-            'input:not([disabled])',
-            'select:not([disabled])',
-            'textarea:not([disabled])',
-            '[tabindex]:not([tabindex="-1"])'
-        ].join(',');
-
-        const focusables = Array.from(document.querySelectorAll<HTMLElement>(focusableSelectors)).filter(
-            (el) => el.offsetParent !== null && !el.hasAttribute('disabled')
-        );
-
-        const current = document.activeElement as HTMLElement;
-        const index = focusables.indexOf(current);
-        if (index === -1) return;
-
-        const next = focusables[index + direction];
-        if (next) {
-            next.focus();
-        }
-    }
-
-    // Default font size is 16, so it's skipped here
-    fontSizes = [5, 5.5, 6.5, 7.5, 8, 9, 10, 10.5, 11, 12, 14, 18, 20, 22, 24, 26, 28, 36, 48, 72];
-
-    // Minor issue when selecting content after clicking a toolbar item: it will always select the first instance of the content string.
-    // For example, if your text is "span", changing font size while selecting it won't select <span style...>SPAN</span> afterward, but <SPAN style...>span</span>.
-    // The default (module-provided) toolbar items have the same issue (try the content "*" for Bold).
-    get toolbar() {
-        const vm = this;
-        return {
-            fontSize: {
-                title: this.$t('editor.text.fontsize.title'),
-                text: 'Aa',
-                menus: {
-                    itemWidth: '42px',
-                    rowNum: 10,
-                    items: this.fontSizes.map((fontSize) => {
-                        return {
-                            name: `${fontSize}`,
-                            text: `${fontSize}`,
-                            action(editor: MDEditor): void {
-                                editor.insert((selected: string) => {
-                                    const content = selected || vm.$t('editor.text.fontsize.resize');
-
-                                    const finalText = content
-                                        .split('\n')
-                                        .map((paragraph: any) => {
-                                            if (!paragraph) {
-                                                return '';
-                                            } else if (
-                                                paragraph.charAt(0) === '|' || // table
-                                                paragraph.charAt(0) === '!' || // image
-                                                paragraph.charAt(0) === '`' || // code block
-                                                paragraph === '------------------------------------'
-                                            ) {
-                                                return paragraph;
-                                            } else {
-                                                return `<span style="font-size:${fontSize}px;">${paragraph}</span>`;
-                                            }
-                                        })
-                                        .join('\n');
-
-                                    return {
-                                        text: finalText,
-                                        selected: content
-                                    };
-                                });
-                            }
-                        };
-                    })
-                }
-            },
-            subsuper: {
-                title: this.$t('editor.text.subsuper.title'),
-                text: 'T',
-                menus: [
-                    {
-                        name: this.$t('editor.text.superscript'),
-                        text: this.$t('editor.text.superscript'),
-                        action(editor: MDEditor): void {
-                            editor.insert((selected: string) => {
-                                const content = selected || vm.$t('editor.text.superscript').toLowerCase();
-
-                                return {
-                                    text: `<sup>${content}</sup>`,
-                                    selected: content
-                                };
-                            });
-                        }
-                    },
-                    {
-                        name: this.$t('editor.text.subscript'),
-                        text: this.$t('editor.text.subscript'),
-                        action(editor: MDEditor): void {
-                            editor.insert((selected: string) => {
-                                const content = selected || vm.$t('editor.text.subscript').toLowerCase();
-
-                                return {
-                                    text: `<sub>${content}</sub>`,
-                                    selected: content
-                                };
-                            });
-                        }
-                    }
-                ]
-            },
-            addLink: {
-                title: this.$t('editor.text.addLink.title'),
-                icon: 'v-md-icon-link',
-                menus: [
-                    {
-                        name: this.$t('editor.text.addLink.external.newTab'),
-                        text: this.$t('editor.text.addLink.external.newTab'),
-                        action(editor: MDEditor): void {
-                            editor.insert((selected: string) => {
-                                const content = selected || vm.$t('editor.text.addLink.text');
-
-                                return {
-                                    text: `<a href='http://' target='_blank'>${content}</a>`,
-                                    selected: content
-                                };
-                            });
-                        }
-                    },
-                    {
-                        name: this.$t('editor.text.addLink.external.sameTab'),
-                        text: this.$t('editor.text.addLink.external.sameTab'),
-                        action(editor: MDEditor): void {
-                            editor.insert((selected: string) => {
-                                const content = selected || vm.$t('editor.text.addLink.text');
-
-                                return {
-                                    text: `<a href='http://' target='_self'>${content}</a>`,
-                                    selected: content
-                                };
-                            });
-                        }
-                    },
-                    {
-                        name: this.$t('editor.text.addLink.dynamic'),
-                        text: this.$t('editor.text.addLink.dynamic'),
-                        action(editor: MDEditor): void {
-                            editor.insert((selected: string) => {
-                                const content = selected || vm.$t('editor.text.addLink.text');
-
-                                return {
-                                    text: `<a panel='panel-id-here'>${content}</a>`,
-                                    selected: content
-                                };
-                            });
-                        }
-                    }
-                ]
-            },
-            wetToolbar: {
-                title: this.$t('editor.text.wetToolbar.title'),
-                text: this.$t('editor.text.wetToolbar.text'),
-                action: (editor: MDEditor): void => {
-                    this.wetComponentsVisible = !this.wetComponentsVisible;
-
-                    if (this.wetComponentsVisible) {
-                        // Hate using setTimeout, but it seems to be necessary for this scroll to work.
-                        setTimeout(() => {
-                            document
-                                .getElementById('WETDashboard')
-                                ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-                        }, 100);
-                    }
-
-                    if (editor !== undefined) {
-                        this.editor = editor;
-                    }
-                }
-            }
-        };
-    }
-
-    toolbarOptions = `undo redo clear | h bold italic strikethrough quote subsuper fontSize | ul ol table hr | addLink image code ${
-        window.location.href.includes('index-ca') ? '| wetToolbar' : ''
-    } | save`;
-
-    toolbarTooltipAdjust(toggle: HTMLElement): void {
-        const slideEditor = document.querySelector('#slideEditor') as HTMLElement;
-        const scrollbarVisible =
-            slideEditor.scrollHeight > slideEditor.clientHeight ||
-            document.documentElement.scrollHeight > document.documentElement.clientHeight;
-        const toggleToRightBorder = slideEditor.getBoundingClientRect().right - toggle.getBoundingClientRect().right;
-        const scrollbarOffset = document.documentElement.clientWidth * 1.3 * 0.01;
-        // limit the right position of the toggle's tooltip if the toggle is sufficiently close to the right
-        // border of the screen (only when scrollbar is visible)
-        if (scrollbarVisible && toggleToRightBorder <= 90) {
-            (toggle.children[0] as HTMLElement).style.right = `${Math.max(
-                Math.min(-40, -toggleToRightBorder + scrollbarOffset),
-                -65
-            )}px`;
-        } else {
-            (toggle.children[0] as HTMLElement).style.right = `${-toggleToRightBorder}px`;
-        }
-    }
-
-    saveChanges() {
-        this.panel.content = DOMPurify.sanitize(this.panel.content, {
-            FORCE_BODY: true,
-            ADD_TAGS: ['AudioPlayer'],
-            ADD_ATTR: ['transcript']
-        }).replaceAll('audioplayer', 'AudioPlayer');
-    }
-
-    mounted(): void {
-        applyTextAlign(this.panel, this.centerSlide, this.dynamicSelected);
-
-        const rightToolbarToggles = Array.from(
-            document.querySelectorAll('.v-md-editor__toolbar-right > .v-md-editor__toolbar-item')
-        );
-        rightToolbarToggles.forEach((toggle) => {
-            toggle.addEventListener('mouseover', () => {
-                this.toolbarTooltipAdjust(toggle as HTMLElement);
-            });
-        });
-
-        this.makeTextEditorElementsTabbable();
-
-        // selects the <textarea> and adds label attribute dynamically
-        this.$nextTick(() => {
-            const textarea = this.$el.querySelector('.CodeMirror textarea');
-            if (textarea) {
-                textarea.setAttribute('aria-label', this.$t('editor.slides.panel.textEntry'));
             }
         });
-    }
+    };
 
-    unmounted(): void {
-        const rightToolbarToggles = Array.from(
-            document.querySelectorAll('.v-md-editor__toolbar-right > .v-md-editor__toolbar-item')
-        );
-        rightToolbarToggles.forEach((toggle) => {
-            toggle.removeEventListener('mouseover', () => {
-                this.toolbarTooltipAdjust(toggle as HTMLElement);
-            });
+    // Allow tabbing for TOC area
+    const initializeTOCTabbing = (tocContainer: HTMLElement | null) => {
+        if (!tocContainer) return;
+
+        tocContainer.setAttribute('tabindex', '0');
+        tocContainer.dataset.keyboardEnabled = 'false';
+
+        let tooltip: any = null;
+        tocContainer.addEventListener('focus', () => {
+            if (tocContainer.offsetWidth > 10) {
+                tooltip ??= tippy(tocContainer, {
+                    content: t('editor.slides.panel.toc'),
+                    trigger: 'manual',
+                    placement: 'top'
+                });
+                tooltip.show();
+            }
         });
+
+        tocContainer.addEventListener('keydown', (e: KeyboardEvent) => {
+            if ((e.key === 'Enter' || e.key === ' ') && tocContainer.dataset.keyboardEnabled === 'false') {
+                e.preventDefault();
+                const tocItems = tocContainer.querySelectorAll<HTMLElement>('.v-md-editor__toc-nav-item');
+                // Enable tabbing for each TOC item
+                makeTOCItemsInteractive(tocItems);
+
+                // Focus onto the first TOC item
+                tocContainer.dataset.keyboardEnabled = 'true';
+                (tocItems[0] as HTMLElement)?.focus();
+            }
+        });
+        // Reset TOC items' tabbing state when focus leaves the TOC container
+        tocContainer.addEventListener('focusout', (e: FocusEvent) => {
+            const relatedTarget = e.relatedTarget as HTMLElement | null;
+            if (!relatedTarget || !tocContainer.contains(relatedTarget)) {
+                const tocItems = tocContainer.querySelectorAll<HTMLElement>('.v-md-editor__toc-nav-item');
+                tocItems.forEach((item) => {
+                    item.removeAttribute('tabindex');
+                    item.dataset.keyboardEnabled = '';
+                });
+                tocContainer.dataset.keyboardEnabled = 'false';
+            }
+            tooltip?.hide();
+        });
+    };
+
+    const makeTOCItemsInteractive = (tocItems: NodeListOf<HTMLElement>) => {
+        tocItems.forEach((item: HTMLElement) => {
+            item.setAttribute('tabindex', '0');
+            if (item.dataset.keyboardEnabled) return;
+
+            item.addEventListener('keydown', (e: KeyboardEvent) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    item.click();
+                }
+            });
+            item.dataset.keyboardEnabled = 'true';
+        });
+    };
+
+    const patchEverything = () => {
+        const buttons = toolbar.querySelectorAll('[role="button"], button, .v-md-editor__toolbar-item');
+        buttons.forEach(makeButtonInteractive);
+        makeDropdownItemsInteractive();
+
+        const tocContainer = document.querySelector('.v-md-editor__toc-nav');
+        initializeTOCTabbing(tocContainer);
+    };
+
+    const observer = new MutationObserver(patchEverything);
+
+    observer.observe(toolbar, {
+        childList: true,
+        subtree: true
+    });
+
+    patchEverything();
+}
+
+function moveFocus(direction: number): void {
+    const focusableSelectors = [
+        'a[href]',
+        'button:not([disabled])',
+        'input:not([disabled])',
+        'select:not([disabled])',
+        'textarea:not([disabled])',
+        '[tabindex]:not([tabindex="-1"])'
+    ].join(',');
+
+    const focusables = Array.from(document.querySelectorAll<HTMLElement>(focusableSelectors)).filter(
+        (el) => el.offsetParent !== null && !el.hasAttribute('disabled')
+    );
+
+    const current = document.activeElement as HTMLElement;
+    const index = focusables.indexOf(current);
+    if (index === -1) return;
+
+    const next = focusables[index + direction];
+    if (next) {
+        next.focus();
     }
 }
+
+const toolbar = computed(() => {
+    return {
+        fontSize: {
+            title: t('editor.text.fontsize.title'),
+            text: 'Aa',
+            menus: {
+                itemWidth: '42px',
+                rowNum: 10,
+                items: fontSizes.map((fontSize) => {
+                    return {
+                        name: `${fontSize}`,
+                        text: `${fontSize}`,
+                        action(editor: MDEditor): void {
+                            editor.insert((selected: string) => {
+                                const content = selected || t('editor.text.fontsize.resize');
+
+                                const finalText = content
+                                    .split('\n')
+                                    .map((paragraph: any) => {
+                                        if (!paragraph) {
+                                            return '';
+                                        } else if (
+                                            paragraph.charAt(0) === '|' || // table
+                                            paragraph.charAt(0) === '!' || // image
+                                            paragraph.charAt(0) === '`' || // code block
+                                            paragraph === '------------------------------------'
+                                        ) {
+                                            return paragraph;
+                                        } else {
+                                            return `<span style="font-size:${fontSize}px;">${paragraph}</span>`;
+                                        }
+                                    })
+                                    .join('\n');
+
+                                return {
+                                    text: finalText,
+                                    selected: content
+                                };
+                            });
+                        }
+                    };
+                })
+            }
+        },
+        subsuper: {
+            title: t('editor.text.subsuper.title'),
+            text: 'T',
+            menus: [
+                {
+                    name: t('editor.text.superscript'),
+                    text: t('editor.text.superscript'),
+                    action(editor: MDEditor): void {
+                        editor.insert((selected: string) => {
+                            const content = selected || t('editor.text.superscript').toLowerCase();
+
+                            return {
+                                text: `<sup>${content}</sup>`,
+                                selected: content
+                            };
+                        });
+                    }
+                },
+                {
+                    name: t('editor.text.subscript'),
+                    text: t('editor.text.subscript'),
+                    action(editor: MDEditor): void {
+                        editor.insert((selected: string) => {
+                            const content = selected || t('editor.text.subscript').toLowerCase();
+
+                            return {
+                                text: `<sub>${content}</sub>`,
+                                selected: content
+                            };
+                        });
+                    }
+                }
+            ]
+        },
+        addLink: {
+            title: t('editor.text.addLink.title'),
+            icon: 'v-md-icon-link',
+            menus: [
+                {
+                    name: t('editor.text.addLink.external.newTab'),
+                    text: t('editor.text.addLink.external.newTab'),
+                    action(editor: MDEditor): void {
+                        editor.insert((selected: string) => {
+                            const content = selected || t('editor.text.addLink.text');
+
+                            return {
+                                text: `<a href='http://' target='_blank'>${content}</a>`,
+                                selected: content
+                            };
+                        });
+                    }
+                },
+                {
+                    name: t('editor.text.addLink.external.sameTab'),
+                    text: t('editor.text.addLink.external.sameTab'),
+                    action(editor: MDEditor): void {
+                        editor.insert((selected: string) => {
+                            const content = selected || t('editor.text.addLink.text');
+
+                            return {
+                                text: `<a href='http://' target='_self'>${content}</a>`,
+                                selected: content
+                            };
+                        });
+                    }
+                },
+                {
+                    name: t('editor.text.addLink.dynamic'),
+                    text: t('editor.text.addLink.dynamic'),
+                    action(editor: MDEditor): void {
+                        editor.insert((selected: string) => {
+                            const content = selected || t('editor.text.addLink.text');
+
+                            return {
+                                text: `<a panel='panel-id-here'>${content}</a>`,
+                                selected: content
+                            };
+                        });
+                    }
+                }
+            ]
+        },
+        wetToolbar: {
+            title: t('editor.text.wetToolbar.title'),
+            text: t('editor.text.wetToolbar.text'),
+            action: (mdEditor: MDEditor): void => {
+                wetComponentsVisible.value = !wetComponentsVisible.value;
+
+                if (wetComponentsVisible.value) {
+                    // Hate using setTimeout, but it seems to be necessary for this scroll to work.
+                    setTimeout(() => {
+                        document
+                            .getElementById('WETDashboard')
+                            ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+                    }, 100);
+                }
+
+                if (mdEditor !== undefined) {
+                    editor.value = mdEditor;
+                }
+            }
+        }
+    };
+});
+
+const toolbarOptions = computed(
+    () =>
+        `undo redo clear | h bold italic strikethrough quote subsuper fontSize | ul ol table hr | addLink image code ${
+            window.location.href.includes('index-ca') ? '| wetToolbar' : ''
+        } | save`
+);
+
+function toolbarTooltipAdjust(toggle: HTMLElement): void {
+    const slideEditor = document.querySelector('#slideEditor') as HTMLElement;
+    const scrollbarVisible =
+        slideEditor.scrollHeight > slideEditor.clientHeight ||
+        document.documentElement.scrollHeight > document.documentElement.clientHeight;
+    const toggleToRightBorder = slideEditor.getBoundingClientRect().right - toggle.getBoundingClientRect().right;
+    const scrollbarOffset = document.documentElement.clientWidth * 1.3 * 0.01;
+    // limit the right position of the toggle's tooltip if the toggle is sufficiently close to the right
+    // border of the screen (only when scrollbar is visible)
+    if (scrollbarVisible && toggleToRightBorder <= 90) {
+        (toggle.children[0] as HTMLElement).style.right = `${Math.max(
+            Math.min(-40, -toggleToRightBorder + scrollbarOffset),
+            -65
+        )}px`;
+    } else {
+        (toggle.children[0] as HTMLElement).style.right = `${-toggleToRightBorder}px`;
+    }
+}
+
+function saveChanges() {
+    props.panel.content = DOMPurify.sanitize(props.panel.content, {
+        FORCE_BODY: true,
+        ADD_TAGS: ['AudioPlayer'],
+        ADD_ATTR: ['transcript']
+    }).replaceAll('audioplayer', 'AudioPlayer');
+}
+
+// Lifecycle hooks
+onMounted(() => {
+    applyTextAlign(props.panel, props.centerSlide, props.dynamicSelected);
+
+    const rightToolbarToggles = Array.from(
+        document.querySelectorAll('.v-md-editor__toolbar-right > .v-md-editor__toolbar-item')
+    );
+    rightToolbarToggles.forEach((toggle) => {
+        toggle.addEventListener('mouseover', () => {
+            toolbarTooltipAdjust(toggle as HTMLElement);
+        });
+    });
+
+    makeTextEditorElementsTabbable();
+
+    // selects the <textarea> and adds label attribute dynamically
+    nextTick(() => {
+        const textarea = document.querySelector('.CodeMirror textarea');
+        if (textarea) {
+            textarea.setAttribute('aria-label', t('editor.slides.panel.textEntry'));
+        }
+    });
+});
+
+onUnmounted(() => {
+    const rightToolbarToggles = Array.from(
+        document.querySelectorAll('.v-md-editor__toolbar-right > .v-md-editor__toolbar-item')
+    );
+    rightToolbarToggles.forEach((toggle) => {
+        toggle.removeEventListener('mouseover', () => {
+            toolbarTooltipAdjust(toggle as HTMLElement);
+        });
+    });
+});
+
+// =========================================
+// Component exposes
+
+defineExpose({
+    saveChanges
+});
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -223,7 +223,7 @@ export default class StoryPreviewV extends Vue {
                 }
             };
             const minsRemaining = window.props.timeRemaining / 60;
-            const warnMins = import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_WARN) : 5;
+            const warnMins = 3; // import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_WARN) : 5;
             if (minsRemaining <= warnMins) {
                 // Preview tab was opened with < the amount of time remaining in a session timeout that we have to show the warning
                 // Therefore, display warning immediately and do not track activity.

--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -3,7 +3,7 @@
     <div>
         <div v-if="loadStatus === 'loading'">
             <div class="block py-20 align-middle text-center h-full" style="margin: 0 auto">
-                <spinner size="120px" color="#009cd1" style="margin: 0 auto"></spinner>
+                <VueSpinnerOval size="120px" color="#009cd1" style="margin: 0 auto"></VueSpinnerOval>
             </div>
         </div>
 
@@ -76,7 +76,7 @@
         <div v-else></div>
     </div>
     <div>
-        <confirmation-modal
+        <ConfirmationModalV
             :name="`confirm-extend-session-preview`"
             :message="
                 $t('editor.extendSession', {
@@ -91,13 +91,14 @@
     </div>
 </template>
 
-<script lang="ts">
-import { computed } from 'vue';
+<script setup lang="ts">
+import { computed, getCurrentInstance, onBeforeMount, onMounted, ref } from 'vue';
 import Message from 'vue-m-message';
-import { Options, Vue } from 'vue-property-decorator';
 import { ConfigFileStructure, StoryRampConfig } from '@/definitions';
 import { VueSpinnerOval } from 'vue3-spinners';
 import { AxiosError } from 'axios';
+
+import { useI18n } from 'vue-i18n';
 
 import JSZip from 'jszip';
 import axios from 'axios';
@@ -105,298 +106,313 @@ import { useUserStore } from '@/stores/userStore';
 import { useLockStore } from '@/stores/lockStore';
 import ConfirmationModalV from './support/confirmation-modal.vue';
 
-@Options({
-    components: {
-        spinner: VueSpinnerOval,
-        'confirmation-modal': ConfirmationModalV
-    }
-})
-export default class StoryPreviewV extends Vue {
-    config: StoryRampConfig | undefined = undefined;
-    configFileStructure: ConfigFileStructure | undefined = undefined;
-    savedProduct = false;
-    loadStatus = 'loading';
-    footerPadding = computed(
-        () => !window.location.href.includes('index-ca-en.html') && !window.location.href.includes('index-ca-fr.html')
-    );
-    lastSlideHeight = 0;
-    footerPaddingStyle = computed(() => {
-        this.measure();
-        const h = `calc(100dvh - ${this.lastSlideHeight + this.extraHeight}px)`;
-        return { height: h };
-    });
-    activeChapterIndex = -1;
-    lang = 'en';
-    headerHeight = 0;
-    uid = '';
-    apiUrl = import.meta.env.VITE_APP_CURR_ENV ? import.meta.env.VITE_APP_API_URL : 'http://localhost:6040';
-    broadcast: BroadcastChannel | undefined = undefined;
-    configs: {
-        [key: string]: StoryRampConfig | undefined;
-    } = { en: undefined, fr: undefined };
-    lockStore = useLockStore();
-    confirmationTimeout: NodeJS.Timeout | undefined = undefined; // the timer to show the session extension confirmation modal
-    totalTime = import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_END) : 30;
-    localStorageKey = 'preview-broadcast-channel';
-    extraHeight = 0;
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
-    measure(): void {
-        const nav = document.getElementById('h-navbar');
-        const header = document.getElementById('story-header');
-        this.extraHeight = nav ? nav.offsetHeight : 0; //horizontal navbar
-        this.extraHeight += header ? header.offsetHeight : 0; //header
-        console.log(this.extraHeight);
-        this.extraHeight += 40 + 56 + 60 - 20; //bottom padding of story, context in footer, date modified, some extra padding
-    }
+// =========================================
+// Definitions
 
-    extendSession(showPopup?: boolean): void {
-        // Only send message to other BroadcastChannel if preview is connected to editor
-        if (!this.savedProduct) {
-            this.broadcast?.postMessage({ action: 'extend', showPopup });
-        }
-    }
+const config = ref<StoryRampConfig | undefined>(undefined);
+const configFileStructure = ref<ConfigFileStructure | undefined>(undefined);
+const savedProduct = ref(false);
+const loadStatus = ref('loading');
+const footerPadding = computed(
+    () => !window.location.href.includes('index-ca-en.html') && !window.location.href.includes('index-ca-fr.html')
+);
+const lastSlideHeight = ref(0);
+const footerPaddingStyle = computed(() => {
+    measure();
+    const h = `calc(100dvh - ${lastSlideHeight.value + extraHeight.value}px)`;
+    return { height: h };
+});
+const activeChapterIndex = ref(-1);
+const lang = ref('en');
+const headerHeight = ref(0);
+const uid = ref('');
+const apiUrl = import.meta.env.VITE_APP_CURR_ENV ? import.meta.env.VITE_APP_API_URL : 'http://localhost:6040';
+const broadcast = ref<BroadcastChannel | undefined>(undefined);
+const configs = ref<{
+    [key: string]: StoryRampConfig | undefined;
+}>({ en: undefined, fr: undefined });
+const lockStore = useLockStore();
+const confirmationTimeout = ref<NodeJS.Timeout | undefined>(undefined); // the timer to show the session extension confirmation modal
+const totalTime = import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_END) : 30;
+const localStorageKey = 'preview-broadcast-channel';
+const extraHeight = ref(0);
 
-    removeLocalStorageKey() {
-        localStorage.removeItem(this.localStorageKey);
-    }
+const { $route, $router, $vfm, $i18n, $forceUpdate } = getCurrentInstance()!.proxy!;
 
-    beforeCreate() {
-        // When new tab is created, and another preview tab already has a BC, this will trigger its event listener, which
-        // closes its BC. If no other preview with a BC exists, this will do nothing
-        localStorage.removeItem(this.localStorageKey);
-    }
+const { t } = useI18n();
 
-    async mounted() {
-        window.addEventListener('resize', this.measure);
-        this.uid = this.$route.params.uid as string;
-        this.lang = this.$route.params.lang as string;
-        const lockStore = useLockStore();
+// =========================================
+// Watchers
 
-        // if config file structure passed from session (from main editor page)
-        if (window.props) {
-            this.config = JSON.parse(JSON.stringify(window.props.configs[this.lang]));
-            this.configs = window.props.configs;
-            this.configFileStructure = window.props.configFileStructure;
-            // This broadcast channel will be used to communicate regarding sessions with the main editor tab
-            this.broadcast = new BroadcastChannel(window.props.secret);
-            localStorage.setItem(this.localStorageKey, 'true');
+// =========================================
+// Lifecycle functions
 
-            this.broadcast.onmessage = (e) => {
-                const msg = e.data;
-                if (msg.action === 'confirm') {
-                    // First, remove inactivity event listeners, otherwise moving the mouse will extend the session!.
-                    document.onmousemove = () => undefined;
-                    document.onkeydown = () => undefined;
-                    // main tab says show confirmation modal
-                    this.lockStore.resetSession(msg.value);
-                    this.$vfm.open(`confirm-extend-session-preview`);
-                } else if (msg.action === 'close') {
-                    // main tab says close modal
-                    this.$vfm.close(`confirm-extend-session-preview`);
-                } else if (msg.action === 'extend') {
-                    // main tab says extend the session
-                    Message.success(this.$t('editor.session.extended'));
-                    this.$vfm.close(`confirm-extend-session-preview`);
-                    // Now add back event listeners to detect inactivity
-                    document.onmousemove = () => this.extendSession();
-                    document.onkeydown = () => this.extendSession();
-                } else if (msg.action === 'saving') {
-                    // main editor tab is saving
-                    // disable session extend on activity
-                    this.$vfm.close(`confirm-extend-session-preview`);
-                    document.onmousemove = () => undefined;
-                    document.onkeydown = () => undefined;
-                } else if (msg.action === 'saved') {
-                    // main editor tab is done saving
-                    // re-enable session extend on activity
-                    document.onmousemove = () => this.extendSession();
-                    document.onkeydown = () => this.extendSession();
-                } else {
-                    // main tab says end the session
-                    // we display the toast to say the session has ended in the other tab
-                    // but keep showing the preview since technically that does not require any locks
-                    this.$vfm.close('confirm-extend-session-preview');
-                    Message.error(this.$t('editor.session.ended'));
-                    // Remove inactivity listeners since session has expired.
-                    document.onmousemove = () => undefined;
-                    document.onkeydown = () => undefined;
-                }
-            };
-            const minsRemaining = window.props.timeRemaining / 60;
-            const warnMins = 3; // import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_WARN) : 5;
-            if (minsRemaining <= warnMins) {
-                // Preview tab was opened with < the amount of time remaining in a session timeout that we have to show the warning
-                // Therefore, display warning immediately and do not track activity.
+onBeforeMount(() => {
+    // When new tab is created, and another preview tab already has a BC, this will trigger its event listener, which
+    // closes its BC. If no other preview with a BC exists, this will do nothing
+    localStorage.removeItem(localStorageKey);
+});
+
+onMounted(async () => {
+    window.addEventListener('resize', measure);
+    uid.value = $route.params.uid as string;
+    lang.value = $route.params.lang as string;
+    const lockStore = useLockStore();
+
+    // if config file structure passed from session (from main editor page)
+    if (window.props) {
+        config.value = JSON.parse(JSON.stringify(window.props.configs[lang.value]));
+        configs.value = window.props.configs;
+        configFileStructure.value = window.props.configFileStructure;
+        // This broadcast channel will be used to communicate regarding sessions with the main editor tab
+        broadcast.value = new BroadcastChannel(window.props.secret);
+        localStorage.setItem(localStorageKey, 'true');
+
+        broadcast.value.onmessage = (e) => {
+            const msg = e.data;
+            if (msg.action === 'confirm') {
+                // First, remove inactivity event listeners, otherwise moving the mouse will extend the session!.
                 document.onmousemove = () => undefined;
                 document.onkeydown = () => undefined;
-                this.lockStore.resetSession(minsRemaining * 60);
-                this.$vfm.open(`confirm-extend-session-preview`);
+                // main tab says show confirmation modal
+                lockStore.resetSession(msg.value);
+                $vfm.open(`confirm-extend-session-preview`);
+            } else if (msg.action === 'close') {
+                // main tab says close modal
+                $vfm.close(`confirm-extend-session-preview`);
+            } else if (msg.action === 'extend') {
+                // main tab says extend the session
+                Message.success(t('editor.session.extended'));
+                $vfm.close(`confirm-extend-session-preview`);
+                // Now add back event listeners to detect inactivity
+                document.onmousemove = () => extendSession();
+                document.onkeydown = () => extendSession();
+            } else if (msg.action === 'saving') {
+                // main editor tab is saving
+                // disable session extend on activity
+                $vfm.close(`confirm-extend-session-preview`);
+                document.onmousemove = () => undefined;
+                document.onkeydown = () => undefined;
+            } else if (msg.action === 'saved') {
+                // main editor tab is done saving
+                // re-enable session extend on activity
+                document.onmousemove = () => extendSession();
+                document.onkeydown = () => extendSession();
             } else {
-                // Extend the session in the main editor tab if the user does something in the preview tab
-                document.onmousemove = () => this.extendSession();
-                document.onkeydown = () => this.extendSession();
+                // main tab says end the session
+                // we display the toast to say the session has ended in the other tab
+                // but keep showing the preview since technically that does not require any locks
+                $vfm.close('confirm-extend-session-preview');
+                Message.error(t('editor.session.ended'));
+                // Remove inactivity listeners since session has expired.
+                document.onmousemove = () => undefined;
+                document.onkeydown = () => undefined;
             }
-            // Link stylesheets from the config, if any
-            if (this.config?.stylesheets) {
-                this.addStylesheets(this.config.stylesheets);
-            }
-            this.loadStatus = 'loaded';
-            window.addEventListener('beforeunload', this.removeLocalStorageKey);
-            window.addEventListener('storage', (event) => {
-                if (event.key === this.localStorageKey) {
-                    this.broadcast?.close();
-                    document.onmousemove = () => undefined;
-                    document.onkeydown = () => undefined;
-                }
-            });
+        };
+        const minsRemaining = window.props.timeRemaining / 60;
+        const warnMins = 3; // import.meta.env.VITE_APP_CURR_ENV ? Number(import.meta.env.VITE_SESSION_WARN) : 5;
+        if (minsRemaining <= warnMins) {
+            // Preview tab was opened with < the amount of time remaining in a session timeout that we have to show the warning
+            // Therefore, display warning immediately and do not track activity.
+            document.onmousemove = () => undefined;
+            document.onkeydown = () => undefined;
+            lockStore.resetSession(minsRemaining * 60);
+            $vfm.open(`confirm-extend-session-preview`);
         } else {
-            this.savedProduct = true;
-            const userStore = useUserStore();
-            await userStore.fetchUserProfile();
-            const user = userStore.userProfile.userName;
-            // attempt to fetch saved config file from the server (TODO: setup as express route?)
-            fetch(this.apiUrl + `/retrieve/${this.uid}/latest`, {
-                headers: { user, preview: 'true' } as HeadersInit
-            }).then((res: Response) => {
-                if (res.status === 404) {
-                    Message.error(this.$t('editor.warning.uuidNotFound', { uuid: this.uid }));
-                    console.error(`There does not exist a saved product with UID ${this.uid}.`);
-                    // redirect to canada.ca 404 page on invalid URL params
-                    // window.location.href = 'https://www.canada.ca/errors/404.html';
-                    this.loadStatus = 'error';
-                    // Unlock the storyline if load fails.
-                    lockStore.unlockStoryline();
-                } else {
-                    const configZip = new JSZip();
-                    // Files retrieved. Convert them into a JSZip object.
-                    res.blob().then((file: Blob) => {
-                        configZip.loadAsync(file).then(() => {
-                            const assetsFolder = configZip.folder('assets');
-                            const chartsFolder = configZip.folder('charts');
-                            const rampConfigFolder = configZip.folder('ramp-config');
+            // Extend the session in the main editor tab if the user does something in the preview tab
+            document.onmousemove = () => extendSession();
+            document.onkeydown = () => extendSession();
+        }
+        // Link stylesheets from the config, if any
+        if (config.value?.stylesheets) {
+            addStylesheets(config.value.stylesheets);
+        }
+        loadStatus.value = 'loaded';
+        window.addEventListener('beforeunload', removeLocalStorageKey);
+        window.addEventListener('storage', (event) => {
+            if (event.key === localStorageKey) {
+                broadcast.value?.close();
+                document.onmousemove = () => undefined;
+                document.onkeydown = () => undefined;
+            }
+        });
+    } else {
+        savedProduct.value = true;
+        const userStore = useUserStore();
+        await userStore.fetchUserProfile();
+        const user = userStore.userProfile.userName;
+        // attempt to fetch saved config file from the server (TODO: setup as express route?)
+        fetch(apiUrl + `/retrieve/${uid.value}/latest`, {
+            headers: { user, preview: 'true' } as HeadersInit
+        }).then((res: Response) => {
+            if (res.status === 404) {
+                Message.error(t('editor.warning.uuidNotFound', { uuid: uid.value }));
+                console.error(`There does not exist a saved product with UID ${uid.value}.`);
+                // redirect to canada.ca 404 page on invalid URL params
+                // window.location.href = 'https://www.canada.ca/errors/404.html';
+                loadStatus.value = 'error';
+                // Unlock the storyline if load fails.
+                lockStore.unlockStoryline();
+            } else {
+                const configZip = new JSZip();
+                // Files retrieved. Convert them into a JSZip object.
+                res.blob().then((file: Blob) => {
+                    configZip.loadAsync(file).then(() => {
+                        const assetsFolder = configZip.folder('assets');
+                        const chartsFolder = configZip.folder('charts');
+                        const rampConfigFolder = configZip.folder('ramp-config');
 
-                            // save EN and FR storylines configurations (for lang switching)
-                            const enFile = configZip.file(`${this.uid}_en.json`);
-                            const frFile = configZip.file(`${this.uid}_fr.json`);
-                            enFile?.async('string').then((res: string) => {
-                                this.configs['en'] = JSON.parse(res);
-                            });
-                            frFile?.async('string').then((res: string) => {
-                                this.configs['fr'] = JSON.parse(res);
-                            });
+                        // save EN and FR storylines configurations (for lang switching)
+                        const enFile = configZip.file(`${uid.value}_en.json`);
+                        const frFile = configZip.file(`${uid.value}_fr.json`);
+                        enFile?.async('string').then((res: string) => {
+                            configs.value['en'] = JSON.parse(res);
+                        });
+                        frFile?.async('string').then((res: string) => {
+                            configs.value['fr'] = JSON.parse(res);
+                        });
 
-                            this.configFileStructure = {
-                                uuid: this.uid,
-                                zip: configZip,
-                                configs: this.configs as unknown as { [key: string]: StoryRampConfig },
-                                assets: {
-                                    en: (assetsFolder as JSZip).folder('en') as JSZip,
-                                    fr: (assetsFolder as JSZip).folder('fr') as JSZip
-                                },
-                                charts: {
-                                    en: (chartsFolder as JSZip).folder('en') as JSZip,
-                                    fr: (chartsFolder as JSZip).folder('fr') as JSZip
-                                },
-                                rampConfig: rampConfigFolder as JSZip
-                            };
+                        configFileStructure.value = {
+                            uuid: uid.value,
+                            zip: configZip,
+                            configs: configs.value as unknown as { [key: string]: StoryRampConfig },
+                            assets: {
+                                en: (assetsFolder as JSZip).folder('en') as JSZip,
+                                fr: (assetsFolder as JSZip).folder('fr') as JSZip
+                            },
+                            charts: {
+                                en: (chartsFolder as JSZip).folder('en') as JSZip,
+                                fr: (chartsFolder as JSZip).folder('fr') as JSZip
+                            },
+                            rampConfig: rampConfigFolder as JSZip
+                        };
 
-                            const configFile = configZip.file(`${this.uid}_${this.lang}.json`);
-                            configFile?.async('string').then((configContent: string) => {
-                                const config = JSON.parse(configContent) as StoryRampConfig;
-                                this.config = config;
-                                this.loadStatus = 'loaded';
-                                document.title = this.config.title + ' - Canada.ca';
-                                // Link stylesheets from the config, if any
-                                if (this.config.stylesheets) {
-                                    this.addStylesheets(this.config.stylesheets);
-                                }
-                            });
+                        const configFile = configZip.file(`${uid.value}_${lang.value}.json`);
+                        configFile?.async('string').then((configContent: string) => {
+                            const conf = JSON.parse(configContent) as StoryRampConfig;
+                            config.value = conf;
+                            loadStatus.value = 'loaded';
+                            document.title = config.value.title + ' - Canada.ca';
+                            // Link stylesheets from the config, if any
+                            if (config.value.stylesheets) {
+                                addStylesheets(config.value.stylesheets);
+                            }
                         });
                     });
-                }
-
-                fetch(this.apiUrl + `/retrieveMessages`).then((res: any) => {
-                    axios
-                        .post(import.meta.env.VITE_APP_NET_API_URL + '/api/log/create', {
-                            messages: res.data?.messages
-                        })
-                        .catch((error: AxiosError) => console.log(error.response || error));
                 });
-            });
-        }
-
-        // Purge undefined slides from configs
-        if (this.config) {
-            this.config.slides = this.config.slides.filter((slide) => slide && Object.keys(slide).length);
-        }
-        if (this.configs['en']) {
-            this.configs['en'].slides = this.configs['en'].slides.filter((slide) => slide && Object.keys(slide).length);
-        }
-        if (this.configs['fr']) {
-            this.configs['fr'].slides = this.configs['fr'].slides.filter((slide) => slide && Object.keys(slide).length);
-        }
-
-        // set page lang
-        const html = document.documentElement;
-        html.setAttribute('lang', this.lang);
-        this.$i18n.locale = this.lang;
-    }
-
-    beforeDestroy() {
-        window.removeEventListener('beforeunload', this.removeLocalStorageKey);
-    }
-
-    addStylesheets(paths: string[]): void {
-        paths.forEach(async (path) => {
-            const filePath = path.split('/').slice(1).join('/');
-            const styleFile = this.configFileStructure?.zip.file(filePath);
-            if (styleFile) {
-                const styles = await styleFile.async('text');
-                const styleEl = document.createElement('style');
-                styleEl.textContent = styles;
-                document.head.appendChild(styleEl);
             }
+
+            fetch(apiUrl + `/retrieveMessages`).then((res: any) => {
+                axios
+                    .post(import.meta.env.VITE_APP_NET_API_URL + '/api/log/create', {
+                        messages: res.data?.messages
+                    })
+                    .catch((error: AxiosError) => console.log(error.response || error));
+            });
         });
     }
 
-    // reload preview page with FR config
-    changeLang(): void {
-        this.broadcast?.close();
-        document.onmousemove = () => undefined;
-        document.onkeydown = () => undefined;
-        const newLang = this.lang === 'en' ? 'fr' : 'en';
-        const routeData = this.$router.resolve({
-            name: 'preview',
-            params: { lang: newLang, uid: this.uid }
-        });
-        const secret = window.props?.secret;
-        const timeRemaining = window.props?.timeRemaining;
-
-        // update window props on refresh (to prevent having to fetch from server again)
-        const refreshTab = window.open(routeData.href, '_self');
-        (refreshTab as Window).props = {
-            configs: this.configs,
-            configFileStructure: this.configFileStructure,
-            secret,
-            timeRemaining
-        };
-        this.$forceUpdate();
+    // Purge undefined slides from configs
+    if (config.value) {
+        config.value.slides = config.value.slides.filter((slide) => slide && Object.keys(slide).length);
+    }
+    if (configs.value['en']) {
+        configs.value['en'].slides = configs.value['en'].slides.filter((slide) => slide && Object.keys(slide).length);
+    }
+    if (configs.value['fr']) {
+        configs.value['fr'].slides = configs.value['fr'].slides.filter((slide) => slide && Object.keys(slide).length);
     }
 
-    updateActiveIndex(idx: number): void {
-        this.activeChapterIndex = idx;
-        // determine header height
-        const headerH = document.getElementById('story-header');
-        if (headerH) {
-            this.headerHeight = headerH.clientHeight;
-        }
-        const slides = document.querySelectorAll('.story-slide');
-        const lastSlide = slides[slides.length - 1] as HTMLElement;
-        if (lastSlide) {
-            this.lastSlideHeight = lastSlide.offsetHeight;
-        }
+    // set page lang
+    const html = document.documentElement;
+    html.setAttribute('lang', lang.value);
+    $i18n.locale = lang.value;
+});
+
+// =========================================
+// Component functions
+
+function measure(): void {
+    const nav = document.getElementById('h-navbar');
+    const header = document.getElementById('story-header');
+    extraHeight.value = nav ? nav.offsetHeight : 0; //horizontal navbar
+    extraHeight.value += header ? header.offsetHeight : 0; //header
+    console.log(extraHeight.value);
+    extraHeight.value += 40 + 56 + 60 - 20; //bottom padding of story, context in footer, date modified, some extra padding
+}
+
+function extendSession(showPopup?: boolean): void {
+    // Only send message to other BroadcastChannel if preview is connected to editor
+    if (!savedProduct.value) {
+        broadcast.value?.postMessage({ action: 'extend', showPopup });
     }
 }
+
+function removeLocalStorageKey() {
+    localStorage.removeItem(localStorageKey);
+}
+
+function beforeDestroy() {
+    window.removeEventListener('beforeunload', removeLocalStorageKey);
+}
+
+function addStylesheets(paths: string[]): void {
+    paths.forEach(async (path) => {
+        const filePath = path.split('/').slice(1).join('/');
+        const styleFile = configFileStructure.value?.zip.file(filePath);
+        if (styleFile) {
+            const styles = await styleFile.async('text');
+            const styleEl = document.createElement('style');
+            styleEl.textContent = styles;
+            document.head.appendChild(styleEl);
+        }
+    });
+}
+
+// reload preview page with FR config
+function changeLang(): void {
+    broadcast.value?.close();
+    document.onmousemove = () => undefined;
+    document.onkeydown = () => undefined;
+    const newLang = lang.value === 'en' ? 'fr' : 'en';
+    const routeData = $router.resolve({
+        name: 'preview',
+        params: { lang: newLang, uid: uid.value }
+    });
+    const secret = window.props?.secret;
+    const timeRemaining = window.props?.timeRemaining;
+
+    // update window props on refresh (to prevent having to fetch from server again)
+    const refreshTab = window.open(routeData.href, '_self');
+    (refreshTab as Window).props = {
+        configs: configs.value,
+        configFileStructure: configFileStructure.value,
+        secret,
+        timeRemaining
+    };
+    $forceUpdate();
+}
+
+function updateActiveIndex(idx: number): void {
+    activeChapterIndex.value = idx;
+    // determine header height
+    const headerH = document.getElementById('story-header');
+    if (headerH) {
+        headerHeight.value = headerH.clientHeight;
+    }
+    const slides = document.querySelectorAll('.story-slide');
+    const lastSlide = slides[slides.length - 1] as HTMLElement;
+    if (lastSlide) {
+        lastSlideHeight.value = lastSlide.offsetHeight;
+    }
+}
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss">

--- a/src/components/slide-toc/slide-toc-button.vue
+++ b/src/components/slide-toc/slide-toc-button.vue
@@ -11,9 +11,11 @@
             'cursor-not-allowed border-2 border-red-400': isMissingConfig()
         }"
         @click.stop="
-            if (!isMissingConfig()) {
-                $emit('select-slide');
-                isMobileSidebar && $emit('close-sidebar');
+            () => {
+                if (!isMissingConfig()) {
+                    $emit('select-slide');
+                    isMobileSidebar && $emit('close-sidebar');
+                }
             }
         "
     >
@@ -53,13 +55,13 @@
                             ? 'border-yellow-800 bg-yellow-200 hover:border-yellow-400'
                             : 'border-transparent hover:border-gray-400 hover:bg-gray-300',
                         element[selectedLang] === editorStore.currentSlide &&
-                        this.editorStore.selectedPanelIndex === panelIndex
+                        editorStore.selectedPanelIndex === panelIndex
                             ? ''
                             : ''
                     ]"
                     :style="[
                         element[selectedLang] === editorStore.currentSlide &&
-                        this.editorStore.selectedPanelIndex === panelIndex
+                        editorStore.selectedPanelIndex === panelIndex
                             ? 'background-color: #c1c1c5 !important;'
                             : ''
                     ]"
@@ -170,18 +172,17 @@
         </div>
         <div v-else class="ml-auto flex my-auto">
             <!-- ::lang:: options dropdown menu -->
-            <toc-options :copy-allowed="!!element[oppositeLang]" @copy="$emit('copy')" @clear="$emit('clear')" />
+            <TocOptions :copy-allowed="!!element[oppositeLang]" @copy="$emit('copy')" @clear="$emit('clear')" />
         </div>
     </button>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
+import { computed, onMounted, onUpdated, ref } from 'vue';
 import { BasePanel, MapPanel, MultiLanguageSlide, PanelType, Slide, SupportedLanguages } from '@/definitions';
-import { useProductStore } from '@/stores/productStore';
-import { useStateStore } from '@/stores/stateStore';
-import { Options, Prop, Vue } from 'vue-property-decorator';
 import TocOptions from './toc-options.vue';
 import { useEditorStore } from '@/stores/editorStore';
+import { useI18n } from 'vue-i18n';
 
 import TextEditorIcon from '@/assets/text-editor.svg?raw';
 import ImageEditorIcon from '@/assets/image-editor.svg?raw';
@@ -192,113 +193,131 @@ import AudioEditorIcon from '@/assets/audio-editor.svg?raw';
 import SlideshowEditorIcon from '@/assets/slideshow-editor.svg?raw';
 import DynamicEditorIcon from '@/assets/dynamic-editor.svg?raw';
 
-@Options({
-    components: {
-        TocOptions
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = withDefaults(
+    defineProps<{
+        selectedLang: SupportedLanguages;
+        element: MultiLanguageSlide;
+        isMobileSidebar?: boolean;
+        isActiveSlide: boolean;
+    }>(),
+    {
+        isMobileSidebar: false
     }
-})
-export default class SlideTocV extends Vue {
-    @Prop() selectedLang!: SupportedLanguages;
-    @Prop() element!: MultiLanguageSlide;
-    @Prop({ default: false }) isMobileSidebar!: boolean;
-    @Prop() isActiveSlide!: boolean;
+);
 
-    productStore = useProductStore();
+const emit = defineEmits(['select-slide', 'close-sidebar', 'create-config', 'copy-config', 'copy', 'clear']);
 
-    oppositeLang: 'en' | 'fr' = 'fr';
-    content: string | undefined = '';
+// =========================================
+// Definitions
 
-    editorStore = useEditorStore();
+const { t } = useI18n();
 
-    textEditorIcon = TextEditorIcon;
-    imageEditorIcon = ImageEditorIcon;
-    mapEditorIcon = MapEditorIcon;
-    chartEditorIcon = ChartEditorIcon;
-    videoEditorIcon = VideoEditorIcon;
-    audioEditorIcon = AudioEditorIcon;
-    slideshowEditorIcon = SlideshowEditorIcon;
-    dynamicEditorIcon = DynamicEditorIcon;
+const editorStore = useEditorStore();
 
-    createMiniIconTooltip(panelIndex: number, element: MultiLanguageSlide, panel: BasePanel) {
-        // Function to escape HTML sequences
-        // panel.title is user input, and therefore a potential attack vector
-        const escapeHTML = (text: string) => {
-            if (!text) return text;
-            return text
-                .replace(/&/g, '&amp;')
-                .replace(/</g, '&lt;')
-                .replace(/>/g, '&gt;')
-                .replace(/"/g, '&quot;')
-                .replace(/'/g, '&#039;');
-        };
+const oppositeLang = computed(() => (props.selectedLang === 'en' ? 'fr' : 'en'));
+const content = ref('' as string | undefined);
 
-        // Max length of the title (starting on the second line of the tooltip). Title will truncate after.
-        // maxLength == 130 is around 2 and a half lines
-        const maxLength = 130;
+const textEditorIcon = TextEditorIcon;
+const imageEditorIcon = ImageEditorIcon;
+const mapEditorIcon = MapEditorIcon;
+const chartEditorIcon = ChartEditorIcon;
+const videoEditorIcon = VideoEditorIcon;
+const audioEditorIcon = AudioEditorIcon;
+const slideshowEditorIcon = SlideshowEditorIcon;
+const dynamicEditorIcon = DynamicEditorIcon;
 
-        return `<p style="justify-self: left; text-align: left"><strong>${
-            (element[this.selectedLang] as Slide).panel.length > 1
-                ? this.$t('editor.slides.panelNumber', { num: panelIndex + 1 })
-                : this.$t('editor.slides.fullscreenPanel')
-        }: ${this.$t(`editor.slide.panel.type.${panel?.type}`)}</strong><br/>${
-            (panel as any)?.title
-                ? '"' +
-                  escapeHTML((panel as any)?.title).substring(0, maxLength) +
-                  (((panel as any)?.title as string)?.length > maxLength ? '...' : '') +
-                  '"'
-                : 'No title'
-        }</p>`;
-    }
+// =========================================
+// Watchers
 
-    isMissingConfig(): boolean {
-        return !this.element[this.selectedLang] || !this.element[this.selectedLang].panel;
-    }
+// =========================================
+// Lifecycle functions
 
-    updateContent(): void {
-        if (this.element[this.selectedLang]?.title) {
-            this.content = this.element[this.selectedLang]?.title;
-        } else if (this.element[this.selectedLang]?.title === '') {
-            this.content =
-                this.selectedLang === 'en'
-                    ? this.$t('editor.slides.toc.newENGSlideText')
-                    : this.$t('editor.slides.toc.newFRSlideText');
-        } else {
-            this.content =
-                this.selectedLang === 'en'
-                    ? this.$t('editor.slide.toc.noENGslide')
-                    : this.$t('editor.slide.toc.noFRSlide');
-        }
-    }
+onMounted(() => {
+    updateContent();
+});
 
-    mounted(): void {
-        this.oppositeLang = this.selectedLang === 'en' ? 'fr' : 'en';
-        this.updateContent();
-    }
+onUpdated(() => {
+    updateContent();
+});
 
-    updated(): void {
-        this.updateContent();
-    }
+// =========================================
+// Component functions
 
-    determinePanelImage(type: PanelType): string {
-        if (!type) return '';
+function createMiniIconTooltip(panelIndex: number, element: MultiLanguageSlide, panel: BasePanel) {
+    // Function to escape HTML sequences
+    // panel.title is user input, and therefore a potential attack vector
+    const escapeHTML = (text: string) => {
+        if (!text) return text;
+        return text
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#039;');
+    };
 
-        const panelIcons: Record<PanelType, string> = {
-            [PanelType.Text]: this.textEditorIcon,
-            [PanelType.Image]: this.imageEditorIcon,
-            [PanelType.Map]: this.mapEditorIcon,
-            [PanelType.Chart]: this.chartEditorIcon,
-            [PanelType.Video]: this.videoEditorIcon,
-            [PanelType.Audio]: this.audioEditorIcon,
-            [PanelType.Slideshow]: this.slideshowEditorIcon,
-            [PanelType.SlideshowImage]: this.imageEditorIcon,
-            [PanelType.SlideshowChart]: this.chartEditorIcon,
-            [PanelType.Dynamic]: this.dynamicEditorIcon,
-            [PanelType.Loading]: ''
-        };
+    // Max length of the title (starting on the second line of the tooltip). Title will truncate after.
+    // maxLength == 130 is around 2 and a half lines
+    const maxLength = 130;
 
-        return panelIcons[type] ?? '';
+    return `<p style="justify-self: left; text-align: left"><strong>${
+        (props.element[props.selectedLang] as Slide).panel.length > 1
+            ? t('editor.slides.panelNumber', { num: panelIndex + 1 })
+            : t('editor.slides.fullscreenPanel')
+    }: ${t(`editor.slide.panel.type.${panel?.type}`)}</strong><br/>${
+        (panel as any)?.title
+            ? '"' +
+              escapeHTML((panel as any)?.title).substring(0, maxLength) +
+              (((panel as any)?.title as string)?.length > maxLength ? '...' : '') +
+              '"'
+            : 'No title'
+    }</p>`;
+}
+
+function isMissingConfig(): boolean {
+    return !props.element[props.selectedLang] || !props.element[props.selectedLang]?.panel;
+}
+
+function updateContent(): void {
+    if (props.element[props.selectedLang]?.title) {
+        content.value = props.element[props.selectedLang]?.title;
+    } else if (props.element[props.selectedLang]?.title === '') {
+        content.value =
+            props.selectedLang === 'en'
+                ? t('editor.slides.toc.newENGSlideText')
+                : t('editor.slides.toc.newFRSlideText');
+    } else {
+        content.value =
+            props.selectedLang === 'en' ? t('editor.slide.toc.noENGslide') : t('editor.slide.toc.noFRSlide');
     }
 }
+
+function determinePanelImage(type: PanelType): string {
+    if (!type) return '';
+
+    const panelIcons: Record<PanelType, string> = {
+        [PanelType.Text]: textEditorIcon,
+        [PanelType.Image]: imageEditorIcon,
+        [PanelType.Map]: mapEditorIcon,
+        [PanelType.Chart]: chartEditorIcon,
+        [PanelType.Video]: videoEditorIcon,
+        [PanelType.Audio]: audioEditorIcon,
+        [PanelType.Slideshow]: slideshowEditorIcon,
+        [PanelType.SlideshowImage]: imageEditorIcon,
+        [PanelType.SlideshowChart]: chartEditorIcon,
+        [PanelType.Dynamic]: dynamicEditorIcon,
+        [PanelType.Loading]: ''
+    };
+
+    return panelIcons[type] ?? '';
+}
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss" scoped>
@@ -308,6 +327,7 @@ export default class SlideTocV extends Vue {
     display: -webkit-box;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
+    line-clamp: 2;
 }
 
 .slide-toc-button {

--- a/src/components/slide-toc/slide-toc-button.vue
+++ b/src/components/slide-toc/slide-toc-button.vue
@@ -250,7 +250,7 @@ export default class SlideTocV extends Vue {
         }</p>`;
     }
 
-    isMissingConfig(): void {
+    isMissingConfig(): boolean {
         return !this.element[this.selectedLang] || !this.element[this.selectedLang].panel;
     }
 

--- a/src/components/slide-toc/slide-toc.vue
+++ b/src/components/slide-toc/slide-toc.vue
@@ -612,7 +612,7 @@ export default class SlideTocV extends Vue {
         // (UPDATE: now panelHelper is in store, so we can make it return a Promise, and execute
         // the below code once it resolves)
         setTimeout(async () => {
-            (this.productStore.slidesWorkingCopy[index][currLang] as Slide).panel.forEach((panel) =>
+            (this.productStore.slidesWorkingCopy[index][currLang] as Slide)?.panel.forEach((panel) =>
                 this.productStore.removeSourceCounts(panel)
             );
             this.productStore.slidesWorkingCopy[index][currLang] = JSON.parse(

--- a/src/components/slide-toc/toc-options.vue
+++ b/src/components/slide-toc/toc-options.vue
@@ -1,6 +1,6 @@
 <template>
     <div @click.stop @mouseover.stop class="slide-toc-button cursor-auto">
-        <dropdown-menu
+        <DropdownMenu
             class="flex-shrink-0"
             position="bottom-start"
             :tooltip="$t('editor.slides.toc.dropdownTooltip')"
@@ -82,31 +82,50 @@
                     <span>{{ $t('editor.slides.toc.dropdown.clear') }}</span>
                 </span>
             </a>
-        </dropdown-menu>
+        </DropdownMenu>
     </div>
 </template>
 
-<script lang="ts">
-import { Options, Prop, Vue } from 'vue-property-decorator';
+<script setup lang="ts">
 import DropdownMenu from '@/components/support/dropdown-menu.vue';
 
-@Options({
-    components: {
-        'dropdown-menu': DropdownMenu
-    }
-})
-export default class TocOptionsV extends Vue {
-    @Prop({ default: true }) copyAllowed!: boolean;
-    @Prop({ default: true }) deleteAllowed!: boolean;
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
-    copySlide() {
-        this.$emit('copy');
+const props = withDefaults(
+    defineProps<{
+        copyAllowed?: boolean;
+        deleteAllowed?: boolean;
+    }>(),
+    {
+        copyAllowed: true,
+        deleteAllowed: true
     }
+);
+const emit = defineEmits(['copy', 'clear']);
 
-    clearSlide() {
-        this.$emit('clear');
-    }
+// =========================================
+// Definitions
+
+// =========================================
+// Watchers
+
+// =========================================
+// Lifecycle functions
+
+// =========================================
+// Component functions
+
+function copySlide() {
+    emit('copy');
 }
+function clearSlide() {
+    emit('clear');
+}
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="css" scoped>

--- a/src/components/support/action-modal.vue
+++ b/src/components/support/action-modal.vue
@@ -1,5 +1,5 @@
 <template>
-    <vue-final-modal :modalId="name" :clickToClose="false" content-class="" class="flex justify-center items-center">
+    <VueFinalModal :modalId="name" :clickToClose="false" content-class="" class="flex justify-center items-center">
         <div
             class="action-modal flex flex-col max-h-full overflow-y-auto mx-4 p-4 bg-white border rounded-xl space-y-2"
         >
@@ -24,33 +24,50 @@
                 </div>
             </div>
         </div>
-    </vue-final-modal>
+    </VueFinalModal>
 </template>
 
-<script lang="ts">
-import { Options, Prop, Vue } from 'vue-property-decorator';
+<script setup lang="ts">
 import { VueFinalModal } from 'vue-final-modal';
+import { getCurrentInstance } from 'vue';
 
-@Options({
-    components: {
-        'vue-final-modal': VueFinalModal
-    }
-})
-export default class MetadataEditorV extends Vue {
-    @Prop() name!: string;
-    @Prop() title!: string;
-    @Prop() message!: string;
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
-    onOk(): void {
-        this.$emit('ok');
-        this.$vfm.close(this.name);
-    }
+const props = defineProps<{
+    name: string;
+    title: string;
+    message: string;
+}>();
+const emit = defineEmits(['ok', 'Cancel']);
 
-    onCancel(): void {
-        this.$emit('Cancel');
-        this.$vfm.close(this.name);
-    }
+// =========================================
+// Definitions
+
+const { $vfm } = getCurrentInstance()!.proxy!;
+
+// =========================================
+// Watchers
+
+// =========================================
+// Lifecycle functions
+
+// =========================================
+// Component functions
+
+function onOk(): void {
+    emit('ok');
+    $vfm.close(props.name);
 }
+
+function onCancel(): void {
+    emit('Cancel');
+    $vfm.close(props.name);
+}
+
+// =========================================
+// Component exposes
 </script>
 
 <style scoped lang="css">
@@ -63,6 +80,6 @@ export default class MetadataEditorV extends Vue {
 
 h2 {
     line-height: 1.3;
-    border-bottom: 0px;
+    border-bottom: 0;
 }
 </style>

--- a/src/components/support/chart-preview.vue
+++ b/src/components/support/chart-preview.vue
@@ -78,8 +78,8 @@
     </li>
 </template>
 
-<script lang="ts">
-import { Prop, Vue } from 'vue-property-decorator';
+<script setup lang="ts">
+import { onMounted, ref } from 'vue';
 import { ChartConfig } from '@/definitions';
 import { useProductStore } from '@/stores/productStore';
 
@@ -88,27 +88,49 @@ import dataModule from 'highcharts/modules/data';
 import exporting from 'highcharts/modules/exporting';
 import exportData from 'highcharts/modules/export-data';
 
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = defineProps<{
+    chart: ChartConfig;
+    lang: string;
+    index: number;
+    chartVersion: number;
+}>();
+
+const emit = defineEmits(['delete', 'captionEdit', 'edit']);
+
+// =========================================
+// Definitions
+
 dataModule(Highcharts);
 exporting(Highcharts);
 exportData(Highcharts);
 
-export default class ChartPreviewV extends Vue {
-    @Prop() chart!: ChartConfig;
-    @Prop() lang!: string;
-    @Prop() index!: number;
-    @Prop() chartVersion!: number;
+const productStore = useProductStore();
 
-    productStore = useProductStore();
+const loading = ref(true);
+// Unused?
+// const chartIdx = ref(0);
+const chartName = ref('');
 
-    loading = true;
-    chartIdx = 0;
-    chartName = '';
+// =========================================
+// Watchers
 
-    mounted(): void {
-        this.chartName = this.chart.name || '';
-        this.loading = false;
-    }
-}
+// =========================================
+// Lifecycle functions
+
+onMounted(() => {
+    chartName.value = props.chart.name || '';
+    loading.value = false;
+});
+
+// =========================================
+// Component functions
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/support/colour-picker-input.vue
+++ b/src/components/support/colour-picker-input.vue
@@ -36,7 +36,7 @@
                 alpha-channel="hide"
                 :visible-formats="['hex']"
                 default-format="hex"
-                @color-change="(evt: any) => (this.selectedColour = evt.cssColor)"
+                @color-change="(evt: any) => (selectedColour = evt.cssColor)"
             >
                 <template #copy-button></template>
             </ColorPicker>
@@ -44,46 +44,65 @@
     </div>
 </template>
 
-<script lang="ts">
-import { Prop, Vue, Watch } from 'vue-property-decorator';
+<script setup lang="ts">
+import { ColorPicker } from 'vue-accessible-color-picker';
+import { onBeforeMount, ref, watch } from 'vue';
 
-export default class LoadingPageV extends Vue {
-    @Prop() value!: string;
-    @Prop() name!: string;
-    @Prop() disabled?: boolean;
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
-    isOpen = false;
-    selectedColour = '';
+const props = withDefaults(
+    defineProps<{
+        value?: string;
+        name: string;
+        disabled?: boolean;
+    }>(),
+    { value: '#000000' }
+);
 
-    beforeMount(): void {
-        this.selectedColour = this.value;
-    }
+const emit = defineEmits(['change']);
 
-    /**
-     * If component is enabled, toggle the colour picker visibility.
-     */
-    togglePicker(): void {
-        if (!this.disabled) this.isOpen = !this.isOpen;
-    }
+// =========================================
+// Definitions
 
-    /**
-     * Watches the selectedColour property and emits a change event when it changes. The event emitted mimics an "HTMLInputEvent" so that
-     * we don't need to make any modifications to the `metadataChanged` event listener in `metadata-content.vue`.
-     * @param evt a string representing the new colour value.
-     */
-    @Watch('selectedColour')
-    colourChanged(_evt: Event): void {
-        // If the value didn't change, don't fire the event.
-        if (this.value === this.selectedColour) return;
+const isOpen = ref(false);
+const selectedColour = ref('');
 
-        this.$emit('change', {
-            target: {
-                name: this.name,
-                value: this.selectedColour
-            }
-        });
-    }
+// =========================================
+// Watchers
+
+watch(selectedColour, () => {
+    // If the value didn't change, don't fire the event.
+    if (props.value === selectedColour.value) return;
+
+    emit('change', {
+        target: {
+            name: props.name,
+            value: selectedColour.value
+        }
+    });
+});
+
+// =========================================
+// Lifecycle functions
+
+onBeforeMount(() => {
+    selectedColour.value = props.value;
+});
+
+// =========================================
+// Component functions
+
+/**
+ * If component is enabled, toggle the colour picker visibility.
+ */
+function togglePicker(): void {
+    if (!props.disabled) isOpen.value = !isOpen.value;
 }
+
+// =========================================
+// Component exposes
 </script>
 
 <style scoped lang="scss">

--- a/src/components/support/confirmation-modal.vue
+++ b/src/components/support/confirmation-modal.vue
@@ -1,5 +1,5 @@
 <template>
-    <vue-final-modal
+    <VueFinalModal
         :clickToClose="false"
         :escToClose="false"
         :modalId="name"
@@ -21,33 +21,51 @@
                 {{ $t('editor.cancel') }}
             </button>
         </div>
-    </vue-final-modal>
+    </VueFinalModal>
 </template>
 
-<script lang="ts">
-import { Options, Prop, Vue } from 'vue-property-decorator';
+<script setup lang="ts">
+import { getCurrentInstance } from 'vue';
 import { VueFinalModal } from 'vue-final-modal';
 
-@Options({
-    components: {
-        'vue-final-modal': VueFinalModal
-    }
-})
-export default class MetadataEditorV extends Vue {
-    @Prop() message!: string;
-    @Prop() name!: string;
-    @Prop() messageClass?: string;
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
-    onOk(): void {
-        this.$emit('ok');
-        this.$vfm.close(this.name);
-    }
+const props = defineProps<{
+    name: string;
+    message: string;
+    messageClass?: string;
+}>();
 
-    onCancel(): void {
-        this.$emit('Cancel');
-        this.$vfm.close(this.name);
-    }
+const emit = defineEmits(['ok', 'Cancel']);
+
+// =========================================
+// Definitions
+
+const { $vfm } = getCurrentInstance()!.proxy!;
+
+// =========================================
+// Watchers
+
+// =========================================
+// Lifecycle functions
+
+// =========================================
+// Component functions
+
+function onOk(): void {
+    emit('ok');
+    $vfm.close(props.name);
 }
+
+function onCancel(): void {
+    emit('Cancel');
+    $vfm.close(props.name);
+}
+
+// =========================================
+// Component exposes
 </script>
 
 <style scoped lang="css"></style>

--- a/src/components/support/dropdown-menu.vue
+++ b/src/components/support/dropdown-menu.vue
@@ -37,13 +37,9 @@ import { nextTick, onBeforeUnmount, onMounted, reactive, ref, watch } from 'vue'
 import { createPopper, detectOverflow } from '@popperjs/core';
 import type { Modifier, Placement, State } from '@popperjs/core';
 
-const open = ref<boolean>(false);
-const popper = ref<any>(null);
-const watchers = reactive<Array<Function>>([]);
-
-const el = ref();
-const dropdown = ref<HTMLElement>();
-const dropdownTrigger = ref<Element>();
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
 const props = defineProps({
     position: {
@@ -63,27 +59,28 @@ const props = defineProps({
     ariaLabel: { type: String }
 });
 
+// =========================================
+// Definitions
+
+const open = ref<boolean>(false);
+const popper = ref<any>(null);
+const watchers = reactive<Array<Function>>([]);
+
+const el = ref();
+const dropdown = ref<HTMLElement>();
+const dropdownTrigger = ref<Element>();
+
+// =========================================
+// Watchers
+
 watchers.push(
     watch(open, () => {
         popper.value.update();
     })
 );
 
-const toggleDropdown = () => {
-    open.value = !open.value;
-    (dropdownTrigger.value as any)._tippy.hide();
-};
-
-const focusDropdownTrigger = () => {
-    (dropdownTrigger.value as any)._tippy.setProps({
-        placement: open.value ? props.tooltipPlacementAlt : props.tooltipPlacement
-    });
-    (dropdownTrigger.value as any)._tippy.show();
-};
-
-const blurDropdownTrigger = () => {
-    (dropdownTrigger.value as any)._tippy.hide();
-};
+// =========================================
+// Lifecycle functions
 
 onMounted(() => {
     window.addEventListener(
@@ -178,6 +175,28 @@ onBeforeUnmount(() => {
 
     open.value = false;
 });
+
+// =========================================
+// Component functions
+
+const toggleDropdown = () => {
+    open.value = !open.value;
+    (dropdownTrigger.value as any)._tippy.hide();
+};
+
+const focusDropdownTrigger = () => {
+    (dropdownTrigger.value as any)._tippy.setProps({
+        placement: open.value ? props.tooltipPlacementAlt : props.tooltipPlacement
+    });
+    (dropdownTrigger.value as any)._tippy.show();
+};
+
+const blurDropdownTrigger = () => {
+    (dropdownTrigger.value as any)._tippy.hide();
+};
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss">

--- a/src/components/support/image-preview.vue
+++ b/src/components/support/image-preview.vue
@@ -27,13 +27,33 @@
     </li>
 </template>
 
-<script lang="ts">
-import { Prop, Vue } from 'vue-property-decorator';
+<script setup lang="ts">
 import { ImageFile } from '@/definitions';
 
-export default class ImagePreviewV extends Vue {
-    @Prop() imageFile!: ImageFile;
-}
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = defineProps<{
+    imageFile: ImageFile;
+}>();
+
+const emit = defineEmits(['delete']);
+
+// =========================================
+// Definitions
+
+// =========================================
+// Watchers
+
+// =========================================
+// Lifecycle functions
+
+// =========================================
+// Component functions
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/support/loading-page.vue
+++ b/src/components/support/loading-page.vue
@@ -1,19 +1,11 @@
 <template>
     <div class="block py-20 align-middle text-center h-full" style="margin: 0 auto">
-        <spinner size="120px" color="#009cd1" style="margin: 0 auto"></spinner>
+        <VueSpinnerOval size="120px" color="#009cd1" style="margin: 0 auto" />
     </div>
 </template>
 
-<script lang="ts">
-import { Options, Vue } from 'vue-property-decorator';
+<script setup lang="ts">
 import { VueSpinnerOval } from 'vue3-spinners';
-
-@Options({
-    components: {
-        spinner: VueSpinnerOval
-    }
-})
-export default class LoadingPageV extends Vue {}
 </script>
 
 <style scoped lang="scss"></style>

--- a/src/components/support/multi-option-modal.vue
+++ b/src/components/support/multi-option-modal.vue
@@ -1,5 +1,5 @@
 <template>
-    <vue-final-modal :modalId="name" :clickToClose="false" content-class="" class="flex justify-center items-center">
+    <VueFinalModal :modalId="name" :clickToClose="false" content-class="" class="flex justify-center items-center">
         <div
             class="multi-option-modal flex flex-col max-h-full overflow-y-auto mx-4 p-4 bg-white border rounded-xl space-y-2"
         >
@@ -38,35 +38,57 @@
                 </div>
             </div>
         </div>
-    </vue-final-modal>
+    </VueFinalModal>
 </template>
 
-<script lang="ts">
-import { Options, Prop, Vue } from 'vue-property-decorator';
+<script setup lang="ts">
+import { getCurrentInstance } from 'vue';
 import { VueFinalModal } from 'vue-final-modal';
+
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = withDefaults(
+    defineProps<{
+        name: string;
+        title: string;
+        message?: string;
+        options: modalOption[];
+        cancelAllowed?: boolean;
+    }>(),
+    {
+        cancelAllowed: false
+    }
+);
+const emit = defineEmits(['Cancel']);
+
+// =========================================
+// Definitions
 
 interface modalOption {
     label: string;
     action: () => void;
 }
 
-@Options({
-    components: {
-        'vue-final-modal': VueFinalModal
-    }
-})
-export default class MetadataEditorV extends Vue {
-    @Prop() name!: string;
-    @Prop() title!: string;
-    @Prop() message!: string | undefined;
-    @Prop() options!: modalOption[];
-    @Prop({ default: false }) cancelAllowed!: boolean;
+const { proxy } = getCurrentInstance()!;
 
-    onCancel(): void {
-        this.$emit('Cancel');
-        this.$vfm.close(this.name);
-    }
+// =========================================
+// Watchers
+
+// =========================================
+// Lifecycle functions
+
+// =========================================
+// Component functions
+
+function onCancel(): void {
+    emit('Cancel');
+    proxy!.$vfm.close(props.name);
 }
+
+// =========================================
+// Component exposes
 </script>
 
 <style scoped lang="css">

--- a/src/components/support/time-slider-editor.vue
+++ b/src/components/support/time-slider-editor.vue
@@ -66,14 +66,34 @@
     </div>
 </template>
 
-<script lang="ts">
+<script setup lang="ts">
 import { TimeSliderConfig } from '@/definitions';
-import { Prop, Vue } from 'vue-property-decorator';
 
-export default class TimeSliderEditorV extends Vue {
-    @Prop() config!: TimeSliderConfig;
-    @Prop() error!: boolean;
-}
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = defineProps<{
+    config: TimeSliderConfig;
+    error: boolean;
+}>();
+
+const emit = defineEmits(['time-slider-changed']);
+
+// =========================================
+// Definitions
+
+// =========================================
+// Watchers
+
+// =========================================
+// Lifecycle functions
+
+// =========================================
+// Component functions
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/support/video-preview.vue
+++ b/src/components/support/video-preview.vue
@@ -2,7 +2,7 @@
     <div class="my-8 mx-4 overflow-hidden w-full">
         <div class="relative text-center w-full grabbable">
             <button
-                class="bg-white absolute h-6 w-6 leading-5 rounded-full top-0 right-0 p-0 cursor-pointer"
+                class="respected-standard-button respected-transparent-button respected-thin-button absolute h-6 w-6 leading-5 top-1 right-1"
                 @click="() => $emit('delete', file)"
                 :content="$t('editor.video.delete')"
                 v-tippy="{ placement: 'top', hideOnClick: false, animateFill: true }"
@@ -53,23 +53,40 @@
     </div>
 </template>
 
-<script lang="ts">
-import { Prop, Vue } from 'vue-property-decorator';
+<script setup lang="ts">
 import { VideoFile } from '@/definitions';
-import MarkdownIt from 'markdown-it';
 
-export default class VideoPreviewV extends Vue {
-    @Prop() file!: VideoFile;
-    @Prop() fileType!: string;
-    @Prop() lang!: string;
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
 
-    md = new MarkdownIt({ html: true });
-    langs = { en: 'English', fr: 'French' } as Record<string, string>;
+const props = defineProps<{
+    file: VideoFile;
+    fileType: string;
+    lang: string;
+}>();
 
-    expandTranscript = false;
-    rawTranscript = '';
-    transcriptContent = '';
-}
+defineEmits(['delete']);
+
+// =========================================
+// Definitions
+
+// Doesn't seem to be used. Leaving it in case it actually is
+//const md = new MarkdownIt({ html: true });
+
+const langs = { en: 'English', fr: 'French' } as Record<string, string>;
+
+// =========================================
+// Watchers
+
+// =========================================
+// Lifecycle functions
+
+// =========================================
+// Component functions
+
+// =========================================
+// Component exposes
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/support/wet-dashboard-item.vue
+++ b/src/components/support/wet-dashboard-item.vue
@@ -10,8 +10,21 @@
     </div>
 </template>
 
-<script lang="ts">
-import { Prop, Vue } from 'vue-property-decorator';
+<script setup lang="ts">
+import { useI18n } from 'vue-i18n';
+
+// =========================================
+// Component props and emits
+// (If any are missing, they don't exist)
+
+const props = defineProps<{
+    editor: MDEditor;
+    component: WETComponentObject;
+    context?: string;
+}>();
+
+// =========================================
+// Definitions
 
 interface MDEditor {
     insert(
@@ -26,28 +39,36 @@ interface WETComponentObject {
     html: string;
 }
 
-export default class WETDashboardItemV extends Vue {
-    @Prop() editor!: MDEditor;
-    @Prop() component!: WETComponentObject;
-    @Prop() context!: string;
+const { t } = useI18n();
 
-    insertText() {
-        this.editor.insert((selected: string) => {
-            const content = selected || this.$t('editor.enterText');
+// =========================================
+// Watchers
 
-            // Scroll back up to the text editor so the user can see that the component has been added.
-            (this.editor as any).$el.parentElement.scrollIntoView({
-                block: 'start',
-                behavior: 'smooth'
-            });
+// =========================================
+// Lifecycle functions
 
-            return {
-                text: this.component.html.replace('$$$selected$$$', content), // replace $$$selected$$$ in the template with the selected or default text
-                selected: content
-            };
+// =========================================
+// Component functions
+
+function insertText() {
+    props.editor.insert((selected: string) => {
+        const content = selected || t('editor.enterText');
+
+        // Scroll back up to the text editor so the user can see that the component has been added.
+        (props.editor as any).$el.parentElement.scrollIntoView({
+            block: 'start',
+            behavior: 'smooth'
         });
-    }
+
+        return {
+            text: props.component.html.replace('$$$selected$$$', content), // replace $$$selected$$$ in the template with the selected or default text
+            selected: content
+        };
+    });
 }
+
+// =========================================
+// Component exposes
 </script>
 
 <style scoped lang="scss">

--- a/src/stores/editorStore.ts
+++ b/src/stores/editorStore.ts
@@ -1,6 +1,7 @@
 import {
     ConfigFileStructure,
     MultiLanguageSlide,
+    Slide,
     SourceCounts,
     StoryRampConfig,
     SupportedLanguages
@@ -85,6 +86,7 @@ export const useEditorStore = defineStore('editor', {
         async swapConfigLang(): Promise<void> {
             const productStore = useProductStore();
             await productStore.saveMetadata(false, true);
+            this.configLang = this.oppositeLang;
             if (!productStore.configs[this.configLang]) {
                 await productStore.generateNewConfig(false);
             }
@@ -98,6 +100,8 @@ export const useEditorStore = defineStore('editor', {
         // TODO: do we need to be calling this function when updating the metadata for a new project? We get an "undefined is not valid JSON"
         // error each time changes are detected
         updateSaveStatus(payload: boolean | undefined, origin?: string): void {
+            console.log(' ');
+            console.log('updateSaveStatus()');
             const stateStore = useStateStore();
             const productStore = useProductStore();
 
@@ -127,6 +131,7 @@ export const useEditorStore = defineStore('editor', {
             const timeBuffer = isFirefox ? 2000 : 0;
             lockStore.confirmationTimeout = setTimeout(
                 () => {
+                    console.log('confirmation timeout');
                     // First, remove inactivity event listeners, otherwise moving the mouse will extend the session!.
                     document.onmousemove = () => undefined;
                     document.onkeydown = () => undefined;
@@ -138,6 +143,7 @@ export const useEditorStore = defineStore('editor', {
             // After the timer has run out, if the session was not extended, go back to the landing page (which will unlock the storyline).
             lockStore.endTimeout = setTimeout(
                 () => {
+                    console.log('endtimeout');
                     // First, remove inactivity event listeners, otherwise moving the mouse will extend the session!.
                     document.onmousemove = () => undefined;
                     document.onkeydown = () => undefined;
@@ -173,6 +179,8 @@ export const useEditorStore = defineStore('editor', {
         },
 
         clearData(): void {
+            console.log(' ');
+            console.log('editorStore - clearData()');
             this.changeUuid = '';
             this.error = false;
             this.warning = 'none';
@@ -190,6 +198,9 @@ export const useEditorStore = defineStore('editor', {
          * Ensure that `uuid` is a case-sensitive match with the product's uuid on the server
          */
         correctUuid(): Promise<void> {
+            console.log(' ');
+            console.log('correctUuid()');
+
             return new Promise((resolve, reject) => {
                 const productStore = useProductStore();
                 const lockStore = useLockStore();

--- a/src/stores/lockStore.ts
+++ b/src/stores/lockStore.ts
@@ -10,7 +10,7 @@ export const useLockStore = defineStore('lock', {
         connected: false,
         received: false,
         timeInterval: undefined as NodeJS.Timeout | undefined,
-        timeRemaining: 100000000000000, // in seconds
+        timeRemaining: 100000000000000, // in SECONDS!!
         broadcast: undefined as BroadcastChannel | undefined,
         confirmationTimeout: undefined as NodeJS.Timeout | undefined, // the timer to show the session extension confirmation modal
         endTimeout: undefined as NodeJS.Timeout | undefined // the timer to kill the session due to timeout
@@ -50,8 +50,6 @@ export const useLockStore = defineStore('lock', {
         // Attempts to lock a storyline for this user.
         // Returns a promise that resolves if the lock was successfully fetched and rejects if it was not.
         async lockStoryline(uuid: string): Promise<void> {
-            console.log(' ');
-            console.log('lockStoryline()');
             // Stop the previous storyline's timer
             clearInterval(this.timeInterval);
 
@@ -88,8 +86,6 @@ export const useLockStore = defineStore('lock', {
             });
         },
         async transferLock(renameUuid: string): Promise<void> {
-            console.log(' ');
-            console.log('transferLock()');
             return new Promise((resolve, reject) => {
                 this.received = false;
                 this.socket?.send(
@@ -117,8 +113,6 @@ export const useLockStore = defineStore('lock', {
         },
         // Unlocks the curent storyline for this user. Only to be called on session end.
         unlockStoryline() {
-            console.log(' ');
-            console.log('unlockStoryline()');
             clearInterval(this.timeInterval);
             if (this.connected) {
                 this.socket!.send(JSON.stringify({ type: 'unlock', uuid: this.uuid, clientId: this.clientId }));
@@ -129,12 +123,12 @@ export const useLockStore = defineStore('lock', {
         },
         // Resets the current session back to a full 30 minutes.
         resetSession(overrideTime?: number) {
-            this.timeRemaining = 300;
-            // overrideTime !== undefined
-            //     ? overrideTime
-            //     : import.meta.env.VITE_APP_CURR_ENV
-            //     ? Number(import.meta.env.VITE_SESSION_END) * 60
-            //     : 1800; //  This value is in seconds!!! Don't mix up the units!!!
+            this.timeRemaining =
+                overrideTime !== undefined
+                    ? overrideTime
+                    : import.meta.env.VITE_APP_CURR_ENV
+                      ? Number(import.meta.env.VITE_SESSION_END) * 60
+                      : 1800; //  This value is in seconds!!! Don't mix up the units!!!
             clearInterval(this.timeInterval);
             // Update the time remaining every second.
             this.timeInterval = setInterval(() => {

--- a/src/stores/lockStore.ts
+++ b/src/stores/lockStore.ts
@@ -50,6 +50,8 @@ export const useLockStore = defineStore('lock', {
         // Attempts to lock a storyline for this user.
         // Returns a promise that resolves if the lock was successfully fetched and rejects if it was not.
         async lockStoryline(uuid: string): Promise<void> {
+            console.log(' ');
+            console.log('lockStoryline()');
             // Stop the previous storyline's timer
             clearInterval(this.timeInterval);
 
@@ -86,6 +88,8 @@ export const useLockStore = defineStore('lock', {
             });
         },
         async transferLock(renameUuid: string): Promise<void> {
+            console.log(' ');
+            console.log('transferLock()');
             return new Promise((resolve, reject) => {
                 this.received = false;
                 this.socket?.send(
@@ -113,6 +117,8 @@ export const useLockStore = defineStore('lock', {
         },
         // Unlocks the curent storyline for this user. Only to be called on session end.
         unlockStoryline() {
+            console.log(' ');
+            console.log('unlockStoryline()');
             clearInterval(this.timeInterval);
             if (this.connected) {
                 this.socket!.send(JSON.stringify({ type: 'unlock', uuid: this.uuid, clientId: this.clientId }));
@@ -123,12 +129,12 @@ export const useLockStore = defineStore('lock', {
         },
         // Resets the current session back to a full 30 minutes.
         resetSession(overrideTime?: number) {
-            this.timeRemaining =
-                overrideTime !== undefined
-                    ? overrideTime
-                    : import.meta.env.VITE_APP_CURR_ENV
-                      ? Number(import.meta.env.VITE_SESSION_END) * 60
-                      : 1800; //  This value is in seconds!!! Don't mix up the units!!!
+            this.timeRemaining = 300;
+            // overrideTime !== undefined
+            //     ? overrideTime
+            //     : import.meta.env.VITE_APP_CURR_ENV
+            //     ? Number(import.meta.env.VITE_SESSION_END) * 60
+            //     : 1800; //  This value is in seconds!!! Don't mix up the units!!!
             clearInterval(this.timeInterval);
             // Update the time remaining every second.
             this.timeInterval = setInterval(() => {

--- a/src/stores/productStore.ts
+++ b/src/stores/productStore.ts
@@ -10,7 +10,7 @@ import JSZip from 'jszip';
 
 import Message from 'vue-m-message';
 import { useI18n } from 'vue-i18n';
-import { computed, Ref } from 'vue';
+import { computed, ComputedRef, Ref } from 'vue';
 import axios from 'axios';
 import { AxiosResponse } from 'axios';
 
@@ -37,6 +37,7 @@ import { useEditorStore } from './editorStore';
 import router from '../router';
 import { vfm } from '../plugins/vfm/index';
 import cloneDeep from 'clone-deep';
+import { ref } from 'vue';
 
 interface ProductState {
     configFileStructure: ConfigFileStructure;
@@ -48,13 +49,14 @@ interface ProductState {
     metadata: MetadataContent;
     temporaryMetadataCopy: MetadataContent;
     uuid: string;
-    user: Ref<string>;
-    i18n: any;
+    user: ComputedRef<string>;
+    loadEditor: boolean;
     logoImage: undefined | File;
     introBgImage: undefined | File;
     apiUrl: string;
     latestSchemaVersion: string;
     loadStatus: string;
+    i18n: ReturnType<typeof useI18n>;
 }
 
 export const useProductStore = defineStore('product', {
@@ -113,6 +115,7 @@ export const useProductStore = defineStore('product', {
             schemaVersion: ''
         } as MetadataContent,
         i18n: useI18n(),
+        loadEditor: false,
         uuid: '',
         user: computed(() => useUserStore().userProfile.userName || 'Guest'),
         logoImage: undefined as undefined | File,

--- a/src/stores/stateStore.ts
+++ b/src/stores/stateStore.ts
@@ -184,8 +184,6 @@ export const useStateStore = defineStore('state', {
          * @param origin A string indicating where the change come from. Useful for determining origin of changes for undo/redo functionality
          */
         handlePotentialChange(newConfigs: Save, origin?: string): boolean {
-            console.log(' ');
-            console.log('handePotentialChange()');
             newConfigs.en!.slides = newConfigs.en!.slides.map((slide) => {
                 if (slide && Object.keys(slide)?.length) {
                     return purgeFalses(slide);
@@ -299,7 +297,6 @@ export const useStateStore = defineStore('state', {
                 differentFromBase: true,
                 affectedSlides: affectedSlides
             });
-            console.log('changes detected');
             this.isChanged = true;
             return true;
         },
@@ -397,8 +394,6 @@ export const useStateStore = defineStore('state', {
          * @param savedConfigs Configs with all the changes, to be saved.
          */
         save(savedConfigs: Save): void {
-            console.log(' ');
-            console.log('stateStore save');
             // Clear out any key-value properties with empty values
 
             savedConfigs.en!.slides = savedConfigs.en!.slides.map((slide) => {
@@ -443,6 +438,9 @@ export const useStateStore = defineStore('state', {
             return this.stateChangesList[loc]?.affectedSlides ?? undefined;
         },
 
+        /**
+         * Returns the slides affected by the change being undone or redone, if any. If neither undoing nor redoing, returns undefined.
+         */
         getAffectedSlidesByUndoRedo(): AffectedSlideInfo[] | undefined {
             if (!this.undoing && !this.redoing) return undefined;
 

--- a/src/stores/stateStore.ts
+++ b/src/stores/stateStore.ts
@@ -184,6 +184,8 @@ export const useStateStore = defineStore('state', {
          * @param origin A string indicating where the change come from. Useful for determining origin of changes for undo/redo functionality
          */
         handlePotentialChange(newConfigs: Save, origin?: string): boolean {
+            console.log(' ');
+            console.log('handePotentialChange()');
             newConfigs.en!.slides = newConfigs.en!.slides.map((slide) => {
                 if (slide && Object.keys(slide)?.length) {
                     return purgeFalses(slide);
@@ -297,6 +299,7 @@ export const useStateStore = defineStore('state', {
                 differentFromBase: true,
                 affectedSlides: affectedSlides
             });
+            console.log('changes detected');
             this.isChanged = true;
             return true;
         },
@@ -394,6 +397,8 @@ export const useStateStore = defineStore('state', {
          * @param savedConfigs Configs with all the changes, to be saved.
          */
         save(savedConfigs: Save): void {
+            console.log(' ');
+            console.log('stateStore save');
             // Clear out any key-value properties with empty values
 
             savedConfigs.en!.slides = savedConfigs.en!.slides.map((slide) => {


### PR DESCRIPTION
**Branch is based on #728. Merge that one first!**

### Related Item(s)
Issue #540 

### Changes
- Converts all `.vue` files from Class-based Options API to `<script setup>` based Composition API.
- Organizes `<script setup>` code in each Vue component into discrete sections for better readability ("Component props and emits", "Definitions", "Watchers", etc.). 
- Lots of miscellaneous code cleanup: Removes some unused imports/variables, fixes multiple TS errors, refactors a few sections.

### Notes

- There were a few variables/imports that appear to not be used, but which I kept out of fear of breaking something. I recommend someone do another pass-through of the repo after this is merged to determine if these are still needed.
- I included all discrete sections into each Vue file, even if that particular component doesn't have it (e.g. The "Watchers" section even for components with no `watch()`ers). I think this makes it easier to add code in the future (especially if we want to add such sections to a component without them), but let me know if you prefer to remove unused sections.

### Testing

Essentially, testing everything in the app. Yeah, I know. Everything should work the same as before.

I recommend going through the app from the beginning (the landing page), and then testing each component you encounter as you go through the app.

- Landing page
- Dashboard
- Create New Product / Load Product / Upload Product
- Editor
- Metadata Modal
- ToC
- ToC dropdown
- Slide editor
  - Each individual panel editor type
  - Advanced editor

(I conducted some testing as I went during development, and will do some more after releasing this PR.)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/743)
<!-- Reviewable:end -->
