### PR TITLE
Include headings 1 and 4 in toc panel

### DIFF
--- a/src/components/panel-editors/text-editor.vue
+++ b/src/components/panel-editors/text-editor.vue
@@ -9,6 +9,7 @@
         >
             <v-md-editor
                 v-model="panel.content"
+                :include-level="[1, 2, 3, 4]"
                 height="400px"
                 :left-toolbar="toolbarOptions"
                 :toolbar="toolbar"


### PR DESCRIPTION
### Related Item(s)
Issue #725 

### Changes
- Added headings 1 & 4 to ToC panel. 

### Notes
- Didn't include headings 5 & 6, because I feel like it might look too clustered/nested, but I'm open to seeing what everyone prefers. 

### Testing
Steps:
1. Open a text panel and add some headings (specifically headings 1-4).
2. Open ToC and confirm that those headings are present. 
