### PR TITLE
Use src from chart config

### DIFF
--- a/src/components/panel-editors/chart-editor.vue
+++ b/src/components/panel-editors/chart-editor.vue
@@ -205,18 +205,22 @@ export default class ChartEditorV extends Vue {
     }
 
     fetchChartConfig(chart: ChartPanel | { config?: any; src?: string }, idx: number, chartName?: string) {
-        const chartSrc = chartName
-            ? `charts/${this.lang}/${chartName}.json`
-            : chart.src
-            ? chart.src.substring(chart.src.indexOf('/') + 1)
-            : '';
+        const chartSrc = chart.src.split('/').slice(1).join('/');
+        // chartName
+        //     ? `charts/${this.lang}/${chartName}.json`
+        //     : chart.src
+        //       ? chart.src.substring(chart.src.indexOf('/') + 1)
+        //       : '';
 
         let highchartsJson = this.productStore.configFileStructure.zip.file(chartSrc);
 
         // If not found, create file from config
         if (!highchartsJson && chartName) {
             const title = chartName;
-            this.productStore.configFileStructure.charts[this.lang].file(`${title}.json`, JSON.stringify(chart.config, null, 4));
+            this.productStore.configFileStructure.charts[this.lang].file(
+                `${title}.json`,
+                JSON.stringify(chart.config, null, 4)
+            );
             highchartsJson = this.productStore.configFileStructure.zip.file(chartSrc);
         }
 


### PR DESCRIPTION
### Related Item(s)
#745

### Changes
- Use the src within the chart config, rather than creating a new `chartSrc`, when attempting to fetch the chart within `fetchChartConfig()`
  - Upon copying an `en` config (containing charts) to the `fr` config, the file paths for the charts would include a lang of `en`, but the `chartSrc` generated would be for the `fr` config

### Testing
Steps:
1. Create a chart panel
2. Add two charts to the `en` config
3. Copy the `en` config into the `fr` config
4. Go to the `fr` config and ensure both charts are there

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/751)
<!-- Reviewable:end -->
