### PR TITLE
Add arrows for image and chart reordering

### DIFF
--- a/src/components/panel-editors/chart-editor.vue
+++ b/src/components/panel-editors/chart-editor.vue
@@ -49,10 +49,12 @@
                 <template #item="{ element, index }">
                     <ChartPreview
                         :key="`${element.name}-${index}`"
+                        :ref="(el: any) => (storylinesChartConfigsRefs[index] = el)"
                         :chart="element"
                         :chartVersion="chartVersions[element.name]"
                         :lang="lang"
                         :index="index"
+                        :itemCount="storylinesChartConfigs.length"
                         @edit="
                             (chart: ChartConfig) => {
                                 openEditor(chart.name as string);
@@ -60,6 +62,8 @@
                         "
                         @delete="$vfm.open(`${element.name}-${index}`)"
                         @captionEdit="onChartsEdited"
+                        @move-left="moveChart(index, true)"
+                        @move-right="moveChart(index, false)"
                     ></ChartPreview>
                 </template>
             </draggable>
@@ -168,6 +172,7 @@ export default class ChartEditorV extends Vue {
     chartVersions: Record<string, number> = {};
     editingConfig: HighchartsConfig | null = null;
     editingName: string | null = null;
+    storylinesChartConfigsRefs = [] as any[];
 
     mounted(): void {
         applyTextAlign(this.panel, this.centerSlide, this.dynamicSelected);
@@ -364,6 +369,23 @@ export default class ChartEditorV extends Vue {
             this.highchartsChartConfigs.splice(idx, 1);
         }
         this.onChartsEdited();
+    }
+
+    moveChart(index: number, moveLeft: boolean): void {
+        if ((index === 0 && moveLeft) || (index === this.storylinesChartConfigs.length - 1 && !moveLeft)) return;
+
+        const targetIndex = moveLeft ? index - 1 : index + 1;
+
+        const charts = [...this.storylinesChartConfigs];
+        [charts[index], charts[targetIndex]] = [charts[targetIndex], charts[index]];
+        this.storylinesChartConfigs = charts;
+        this.onChartsEdited();
+
+        this.$nextTick(() => {
+            const galleryButtons = this.storylinesChartConfigsRefs[targetIndex]?.$refs.galleryButtons;
+            const focusButton = moveLeft ? galleryButtons?.$refs.moveLeftBtn : galleryButtons?.$refs.moveRightBtn;
+            focusButton?.focus();
+        });
     }
 
     saveChanges(): void {

--- a/src/components/panel-editors/image-editor.vue
+++ b/src/components/panel-editors/image-editor.vue
@@ -45,7 +45,7 @@
         </div>
 
         <span
-            v-if="allowMany || (!allowMany && imagePreviews.length === 0)"
+            v-if="(allowMany && imagePreviews.length > 1) || (!allowMany && imagePreviews.length === 0)"
             v-show="!imagePreviewsLoading && imagePreviews.length"
             class="flex justify-center"
         >
@@ -63,8 +63,13 @@
             <template #item="{ element, index }">
                 <ImagePreview
                     :key="`${element.id}-${index}`"
+                    :ref="(el: any) => (imagePreviewRefs[index] = el)"
                     :imageFile="element"
+                    :index="index"
+                    :itemCount="imagePreviews.length"
                     @delete="deleteImage"
+                    @move-left="moveImage(index, true)"
+                    @move-right="moveImage(index, false)"
                     class="border border-gray-200 rounded-md p-3"
                 >
                     <div class="px-2 pb-2">
@@ -95,7 +100,7 @@
                         </div>
 
                         <div class="lg:flex gap-2 mt-4">
-                            <div class="flex flex-col text-left self-center">
+                            <div class="flex flex-col text-left self-center lg:w-1/2">
                                 <label class="respected-standard-label" :for="'imgHeight' + index">{{
                                     $t('editor.image.label.height')
                                 }}</label>
@@ -115,7 +120,7 @@
                                 />
                             </div>
 
-                            <div class="flex flex-col mt-4 lg:mt-0 text-left self-center">
+                            <div class="flex flex-col mt-4 lg:mt-0 text-left self-center lg:w-1/2">
                                 <div class="flex flex-row gap-1.5 justify-start items-center">
                                     <label class="respected-standard-label" :for="'imgWidth' + index">{{
                                         $t('editor.image.label.width')
@@ -195,6 +200,7 @@ export default class ImageEditorV extends Vue {
     imagePreviewPromises = [] as Array<Promise<ImageFile>>;
     imagePreviews = [] as Array<ImageFile>;
     slideshowCaption = '';
+    imagePreviewRefs = [] as any[];
 
     get isDragging(): boolean {
         return this.dragging;
@@ -314,6 +320,23 @@ export default class ImageEditorV extends Vue {
             this.imagePreviews.splice(idx, 1);
         }
         this.onImagesEdited();
+    }
+
+    moveImage(index: number, moveLeft: boolean): void {
+        if ((index === 0 && moveLeft) || (index === this.imagePreviews.length - 1 && !moveLeft)) return;
+
+        const targetIndex = moveLeft ? index - 1 : index + 1;
+
+        const newImages = [...this.imagePreviews];
+        [newImages[index], newImages[targetIndex]] = [newImages[targetIndex], newImages[index]];
+        this.imagePreviews = newImages;
+        this.onImagesEdited();
+
+        this.$nextTick(() => {
+            const galleryButtons = this.imagePreviewRefs[targetIndex]?.$refs.galleryButtons;
+            const focusButton = moveLeft ? galleryButtons?.$refs.moveLeftBtn : galleryButtons?.$refs.moveRightBtn;
+            focusButton?.focus();
+        });
     }
 
     saveChanges(): void {

--- a/src/components/support/chart-preview.vue
+++ b/src/components/support/chart-preview.vue
@@ -1,8 +1,8 @@
 <template>
-    <li class="chart-item items-center mt-8 mx-5 overflow-hidden">
+    <li class="items-center mt-8 mx-5 overflow-hidden w-full" :class="itemCount > 1 ? 'chart-item' : 'single-chart'">
         <div class="relative border-solid border-2 items-center justify-center text-center w-full">
             <button
-                class="respected-standard-button respected-transparent-button close-button"
+                class="respected-standard-button respected-transparent-button close-button top-0"
                 style="top: 0.5rem; left: 0.5rem"
                 @click="() => $emit('delete', chart)"
                 :content="$t('editor.chart.delete')"
@@ -16,8 +16,11 @@
                 </svg>
             </button>
             <button
-                style="bottom: 0.5rem; right: 0.5rem"
+                v-if="itemCount > 1"
+                style="top: 2rem; left: 0.5rem"
                 class="respected-standard-button respected-transparent-button close-button handle"
+                :content="$t('editor.chart.drag')"
+                v-tippy="{ placement: 'bottom', hideOnClick: false, animateFill: true }"
                 :aria-label="$t('editor.chart.delete')"
             >
                 <svg xmlns="http://www.w3.org/2000/svg" fill="#000000" width="22px" height="22px" viewBox="0 0 24 24">
@@ -27,14 +30,26 @@
                     />
                 </svg>
             </button>
+            <gallery-buttons
+                v-if="itemCount > 1"
+                class="side-buttons mx-3"
+                ref="galleryButtons"
+                :index="index"
+                :itemCount="itemCount"
+                galleryType="chart"
+                @move-left="$emit('move-left', index)"
+                @move-right="$emit('move-right', index)"
+            />
             <!-- chart component -->
-            <storylines-chart
-                class="w-full h-full"
-                :config="chart"
-                :key="chartVersion"
-                :configFileStructure="productStore.configFileStructure"
-                v-if="!loading"
-            ></storylines-chart>
+            <div class="chart-container p-4">
+                <storylines-chart
+                    class="w-full max-h-[300px] chart-interactive"
+                    :config="chart"
+                    :key="chartVersion"
+                    :configFileStructure="productStore.configFileStructure"
+                    v-if="!loading"
+                ></storylines-chart>
+            </div>
         </div>
         <!-- chart description and edit  -->
         <div class="flex flex-col-reverse lg:flex-row mt-4 items-start flex-wrap gap-2 gap-x-2 px-1 pb-1">
@@ -79,9 +94,11 @@
 </template>
 
 <script lang="ts">
-import { Prop, Vue } from 'vue-property-decorator';
+import { Options, Prop, Vue } from 'vue-property-decorator';
 import { ChartConfig } from '@/definitions';
 import { useProductStore } from '@/stores/productStore';
+
+import GalleryButtonsV from '../support/gallery-buttons.vue';
 
 import Highcharts from 'highcharts';
 import dataModule from 'highcharts/modules/data';
@@ -92,10 +109,16 @@ dataModule(Highcharts);
 exporting(Highcharts);
 exportData(Highcharts);
 
+@Options({
+    components: {
+        'gallery-buttons': GalleryButtonsV
+    }
+})
 export default class ChartPreviewV extends Vue {
     @Prop() chart!: ChartConfig;
     @Prop() lang!: string;
     @Prop() index!: number;
+    @Prop() itemCount!: number;
     @Prop() chartVersion!: number;
 
     productStore = useProductStore();
@@ -113,7 +136,7 @@ export default class ChartPreviewV extends Vue {
 
 <style lang="scss" scoped>
 .chart-item {
-    width: 46%;
+    width: 43%;
 
     .handle {
         cursor: move; /* fallback if grab cursor is unsupported */
@@ -121,6 +144,10 @@ export default class ChartPreviewV extends Vue {
         cursor: -moz-grab;
         cursor: -webkit-grab;
     }
+}
+
+.single-chart {
+    max-width: 650px;
 }
 
 .close-button {
@@ -134,5 +161,20 @@ export default class ChartPreviewV extends Vue {
     padding: 0;
     z-index: 10;
     cursor: pointer;
+}
+
+@media only screen and (max-width: 1050px) {
+    .chart-item,
+    .single-chart {
+        width: 90%;
+    }
+
+    .chart-container {
+        margin-left: 15px;
+    }
+
+    .side-buttons {
+        @apply left-0 top-1/2 transform -translate-y-1/2 flex-col gap-3 right-auto top-auto;
+    }
 }
 </style>

--- a/src/components/support/gallery-buttons.vue
+++ b/src/components/support/gallery-buttons.vue
@@ -1,0 +1,109 @@
+<template>
+    <div
+        :class="['absolute flex z-50 top-1 right-0 gap-2', galleryType === 'image' ? 'image-gallery' : 'chart-gallery']"
+    >
+        <button
+            class="flex justify-center items-center transform -rotate-90 p-1"
+            :class="{ 'text-gray-400 opacity-30 cursor-not-allowed': index === 0 }"
+            ref="moveLeftBtn"
+            :aria-label="leftBtnTooltip"
+            v-tippy="{
+                delay: '200',
+                placement: 'top',
+                content: leftBtnTooltip,
+                touch: ['hold', 500]
+            }"
+            @click="$emit('move-left', index)"
+        >
+            <svg class="up-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 122.88 66.91" height="14" width="14">
+                <path
+                    d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95
+             c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73
+             c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"
+                />
+            </svg>
+        </button>
+
+        <button
+            class="flex justify-center items-center transform rotate-90 p-1"
+            :class="{ 'text-gray-400 opacity-20 cursor-not-allowed': index === itemCount - 1 }"
+            ref="moveRightBtn"
+            :aria-label="rightBtnTooltip"
+            v-tippy="{
+                delay: '200',
+                placement: 'top',
+                content: rightBtnTooltip,
+                touch: ['hold', 500]
+            }"
+            @click="$emit('move-right', index)"
+        >
+            <svg
+                class="down-arrow"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 122.88 66.91"
+                height="14"
+                width="14"
+            >
+                <path
+                    d="M11.68,64.96c-2.72,2.65-7.08,2.59-9.73-0.14c-2.65-2.72-2.59-7.08,0.13-9.73L56.87,1.97l4.8,4.93l-4.81-4.95
+             c2.74-2.65,7.1-2.58,9.76,0.15c0.08,0.08,0.15,0.16,0.23,0.24L120.8,55.1c2.72,2.65,2.78,7.01,0.13,9.73
+             c-2.65,2.72-7,2.78-9.73,0.14L61.65,16.5L11.68,64.96L11.68,64.96z"
+                />
+            </svg>
+        </button>
+    </div>
+</template>
+
+<script lang="ts">
+import { Prop, Vue } from 'vue-property-decorator';
+
+export default class GalleryButtonsV extends Vue {
+    @Prop() index!: number;
+    @Prop() itemCount!: number;
+    @Prop() galleryType!: string;
+
+    isMobile = this.galleryType === 'image' ? window.innerWidth < 900 : window.innerWidth < 1050;
+
+    mounted() {
+        window.addEventListener('resize', this.onResize);
+    }
+
+    beforeDestroy() {
+        window.removeEventListener('resize', this.onResize);
+    }
+
+    onResize() {
+        this.isMobile = this.galleryType === 'image' ? window.innerWidth < 900 : window.innerWidth < 1050;
+    }
+
+    get leftBtnTooltip(): string {
+        const key = this.isMobile ? `editor.${this.galleryType}.moveUp` : `editor.${this.galleryType}.moveLeft`;
+        return this.$t(key);
+    }
+
+    get rightBtnTooltip(): string {
+        const key = this.isMobile ? `editor.${this.galleryType}.moveDown` : `editor.${this.galleryType}.moveRight`;
+        return this.$t(key);
+    }
+}
+</script>
+
+<style scoped lang="scss">
+button:hover {
+    background-color: rgb(209, 213, 219);
+}
+
+@media (max-width: 900px) {
+    .image-gallery .up-arrow,
+    .image-gallery .down-arrow {
+        transform: rotate(90deg);
+    }
+}
+
+@media (max-width: 1050px) {
+    .chart-gallery .up-arrow,
+    .chart-gallery .down-arrow {
+        transform: rotate(90deg);
+    }
+}
+</style>

--- a/src/components/support/image-preview.vue
+++ b/src/components/support/image-preview.vue
@@ -1,8 +1,8 @@
 <template>
     <li class="image-item items-center my-8 mx-4 overflow-hidden">
-        <div class="relative items-center justify-center text-center w-full grabbable">
+        <div class="relative items-center justify-center text-center w-full grabbable pt-8">
             <button
-                class="respected-standard-button respected-transparent-button absolute h-6 w-6 leading-5 rounded-full top-0 right-0 p-0 cursor-pointer"
+                class="respected-standard-button respected-transparent-button absolute h-6 w-6 leading-5 rounded-full top-1 left-0 p-0 cursor-pointer"
                 @click="() => $emit('delete', imageFile)"
                 :content="$t('editor.image.delete')"
                 v-tippy="{ placement: 'top', hideOnClick: false, animateFill: true }"
@@ -14,6 +14,16 @@
                     />
                 </svg>
             </button>
+            <gallery-buttons
+                v-if="itemCount > 1"
+                class="side-buttons"
+                ref="galleryButtons"
+                :index="index"
+                :itemCount="itemCount"
+                galleryType="image"
+                @move-left="$emit('move-left', index)"
+                @move-right="$emit('move-right', index)"
+            />
             <div class="flex-grow image-container">
                 <img
                     class="image-file object-cover"
@@ -28,11 +38,19 @@
 </template>
 
 <script lang="ts">
-import { Prop, Vue } from 'vue-property-decorator';
+import { Options, Prop, Vue } from 'vue-property-decorator';
 import { ImageFile } from '@/definitions';
+import GalleryButtonsV from '../support/gallery-buttons.vue';
 
+@Options({
+    components: {
+        'gallery-buttons': GalleryButtonsV
+    }
+})
 export default class ImagePreviewV extends Vue {
     @Prop() imageFile!: ImageFile;
+    @Prop() index!: number;
+    @Prop() itemCount!: number;
 }
 </script>
 
@@ -70,6 +88,15 @@ export default class ImagePreviewV extends Vue {
 @media only screen and (max-width: 900px) {
     .image-item {
         width: 90%;
+    }
+
+    .image-container {
+        padding-left: 1.75rem;
+        padding-right: 1.75rem;
+    }
+
+    .side-buttons {
+        @apply left-0 top-1/2 transform -translate-y-1/2 flex-col gap-3 right-auto top-auto;
     }
 }
 </style>

--- a/src/lang/lang.csv
+++ b/src/lang/lang.csv
@@ -211,9 +211,13 @@ editor.image.label.height,Height,1,Hauteur,1
 editor.image.label.width,Width,1,Largeur,1
 editor.image.label.widthWarning,Maximum width is 2/3 (66%) of screen on desktop and 100% on mobile. Larger widths will be ignored.,1,La largeur maximale est de 2/3 (66 %) de l'écran sur les ordinateurs de bureau et de 100 % sur les téléphones portables. Les largeurs plus importantes seront ignorées.,1
 editor.image.delete,Delete Image,1,Supprimer l'image,1
+editor.image.moveUp,Move image up,1,Déplacer l'image vers le haut,0
+editor.image.moveDown,Move image down,1,Déplacer l'image vers le bas,0
+editor.image.moveLeft,Move image left,1,Déplacer l'image vers la gauche,0
+editor.image.moveRight,Move image right,1,Déplacer l'image vers la droite,0
 editor.image.label.drag,Drag your images here,1,Faites glisser vos images ici,1
 editor.image.label.caption,Caption,1,Légende,1
-editor.image.reorder,Click and drag to reorder images,1,Cliquez sur les images et faites-les glisser pour changer l’ordre.,1
+editor.image.reorder,"Click and drag, or use the arrows, to reorder images.",1,"Cliquez sur les images et faites-les glisser, ou utilisez les flèches, pour changer l’ordre.",0
 editor.image.altTag,Alt tag,1,Texte de remplacement,1
 editor.image.slideshowCaption,Slideshow caption,1,Légende du diaporama,1
 editor.image.loadingError,An error occurred when trying to load image,1,Une erreur est survenue lors du chargement de l’image.,1
@@ -237,6 +241,11 @@ editor.video.label.linkSupport,Supports YouTube links (regular and shortened) as
 editor.video.delete,Delete Video,1,Supprimer la vidéo,1
 editor.video.pasteUrl,Paste the URL to a video,1,Collez l'url d'une vidéo,0
 editor.chart.delete,Delete Chart,1,Supprimer le graphique,1
+editor.chart.drag,Drag Chart,1,Faites glisser le graphique,0
+editor.chart.moveUp,Move chart up,1,Déplacer le graphique vers le haut,0
+editor.chart.moveDown,Move chart down,1,Déplacer le graphique vers le bas,0
+editor.chart.moveLeft,Move chart left,1,Déplacer le graphique vers la gauche,0
+editor.chart.moveRight,Move chart right,1,Déplacer le graphique vers la droite,0
 editor.chart.label.name,Name,1,Nom,1
 editor.chart.label.edit,Edit,1,Éditer,1
 editor.chart.label.empty,Empty,1,Vide,1


### PR DESCRIPTION
### Related Item(s)
Issues #259 & #736 

### Changes
- Added arrows for reordering images and charts. Arrows are oriented based on the layout. 
- Adjusted chart sizing for mobile view

### Notes
- The behaviour and styling of the buttons are very similar between images and charts, so to prevent too much replication, I put the shared functionality into a separate file, `gallery-buttons.vue`. 
  - Not too sure if location is ideal, so may need to be updated if there's a better structure

### Testing
Steps:
1. Load/create a new product
2. Add an image or chart slide with multiple items
3. Click on the arrows to reorder 
4. Resize the window and notice:
    - arrows changing when layout changes to mobile view
    - chart previews take up the full width in mobile view

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/756)
<!-- Reviewable:end -->
