### PR TITLE
Fix colour pickers not updating on config lang swap

### DIFF
--- a/src/components/support/colour-picker-input.vue
+++ b/src/components/support/colour-picker-input.vue
@@ -67,6 +67,16 @@ export default class LoadingPageV extends Vue {
     }
 
     /**
+     * Watches the value prop passed from the parent component. If the prop changes (e.g., from a language swap), and the new value
+     * is different from the internal selectedColour, update the local state.
+     * @param newValue the new colour value
+     */
+    @Watch('value')
+    onValueChanged(newValue: string): void {
+        if (newValue !== this.selectedColour) this.selectedColour = newValue;
+    }
+
+    /**
      * Watches the selectedColour property and emits a change event when it changes. The event emitted mimics an "HTMLInputEvent" so that
      * we don't need to make any modifications to the `metadataChanged` event listener in `metadata-content.vue`.
      * @param evt a string representing the new colour value.


### PR DESCRIPTION
### Related Item(s)
Closes #752 

### Changes
- Added a watcher on `value` prop to ensure the correct colour values are displayed when switching between language configs. 

### Testing
Steps:
1. Create or load a product
2. Click `Edit project metadata`
3. Update the colour pickers for one language
4. Swap between language config, and verify that the correct colours are displayed