### PR TITLE
Fix load issue of editor route not properly fetching config

### DIFF
--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -853,6 +853,9 @@ export default class EditorV extends Vue {
         }
     }
 
+    /**
+     * This only runs when changing UUID under same route.
+     */
     beforeRouteUpdate(to: RouteLocationNormalized, from: RouteLocationNormalized, next: () => void): void {
         this.$i18n.locale = to.params.lang as string;
         document.onmousemove = () => undefined;
@@ -875,6 +878,9 @@ export default class EditorV extends Vue {
         next();
     }
 
+    /**
+     * Runs when navigating away from route.
+     */
     beforeRouteLeave(to: RouteLocationNormalized, from: RouteLocationNormalized, next: (cont?: boolean) => void): void {
         const curEditor = this.$route.name === 'editor';
         const confirmationMessage = this.$t('editor.leaveWarning');
@@ -898,6 +904,7 @@ export default class EditorV extends Vue {
         } else {
             next();
         }
+        this.editorStore.loadStatus = 'waiting';
     }
 
     /**


### PR DESCRIPTION
### Related Item(s)
Closes #764 

### Changes
- [FIX] editor route not attempting a config fetch due to not updating pineapple store `loadStatus` when leaving route

### Testing
Can test locally by manually setting `userStorylines` to objects with uuids contained in local server folder. Otherwise, re-test dev site after changes have been merged/deployed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/767)
<!-- Reviewable:end -->
