### PR TITLE
Fix case of old product content persisting until new product is loaded

### DIFF
--- a/src/components/editor.vue
+++ b/src/components/editor.vue
@@ -905,6 +905,7 @@ export default class EditorV extends Vue {
             next();
         }
         this.editorStore.loadStatus = 'waiting';
+        this.productStore.clearData();
     }
 
     /**


### PR DESCRIPTION
### Related Item(s)
Fixes case missed in #764 

### Changes
- [FIX] clears product store state after navigating away from editor page

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/768)
<!-- Reviewable:end -->
