### PR TITLE
Changed dropdown menu z level to go above chart delete button

### DIFF
--- a/src/components/support/dropdown-menu.vue
+++ b/src/components/support/dropdown-menu.vue
@@ -23,7 +23,7 @@
                 popper.update();
                 open = false;
             "
-            class="rv-dropdown shadow-md border border-gray:200 py-1 bg-white rounded z-10"
+            class="rv-dropdown shadow-md border border-gray:200 py-1 bg-white rounded z-20"
             :class="{ 'text-center': centered }"
             ref="dropdown"
         >


### PR DESCRIPTION
### Related Item(s)
Issue #763 

### Changes
Quick change: just changed the z value of the dropdown a bit higher to go over the charts delete button

### Testing
Steps:
1. Open a slide with multiple charts
2. Open a slide options dropdown menu
3. Scroll so the dropdown menu overlaps with the chart delete button
4. Proper overlapping!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/771)
<!-- Reviewable:end -->
