### PR TITLE
Fix ordered and unordered list overlap in preview

### DIFF
--- a/src/components/preview.vue
+++ b/src/components/preview.vue
@@ -446,6 +446,41 @@ $font-list: 'Segoe UI', system-ui, ui-sans-serif, Tahoma, Geneva, Verdana, sans-
     }
 }
 
+/**
+ * Styling for ordered and unordered lists
+ */
+
+.prose ul {
+    list-style-type: disc;
+    padding-left: 1.2em;
+}
+
+.prose ol ul,
+.prose ul ul {
+    list-style-type: circle;
+}
+
+.prose :is(ul, ol) :is(ul, ol) ul {
+    list-style-type: square;
+}
+
+.prose ol > li:has(> ul, > ol) {
+    padding-left: 2.5em;
+}
+
+.prose :is(ul, ol) > li:not(:has(:is(ul, ol))),
+.prose ul > li:has(:is(ul, ol)) {
+    padding-left: 1.2em;
+}
+
+.prose ul > li:not(:has(> ul)):not(:has(> ol)) {
+    padding-left: 0;
+}
+
+.prose ul > li::before {
+    display: none;
+}
+
 @media screen and (max-width: 640px) {
     .w-mobile-full {
         width: 100% !important;


### PR DESCRIPTION
### Related Item(s)
Issue #765

### Changes
- Added padding to list items in the preview to prevent overlap
- updated list element styles so the preview matches the text editor's list rendering

### Testing
Steps:
1. Create different ordered/unordered list combinations in the text editor. 
    - e.g., use the following snippet:
```
1. -
- 1.
```
2. Open preview and confirm that there is no overlapping between list markers, and that list styling in the preview matches the styling in the text editor preview