### PR TITLE
Fix slide dropdowns leaving slide toc

### DIFF
--- a/src/components/slide-toc/toc-options.vue
+++ b/src/components/slide-toc/toc-options.vue
@@ -7,6 +7,7 @@
             tooltipPlacement="top-start"
             tooltipPlacementAlt="left"
             ref="dropdown"
+            @dropdownStateChange="dropdownStateHandler"
         >
             <template #header>
                 <div class="slide-toc-button flex justify-center items-center">
@@ -99,12 +100,40 @@ export default class TocOptionsV extends Vue {
     @Prop({ default: true }) copyAllowed!: boolean;
     @Prop({ default: true }) deleteAllowed!: boolean;
 
+    listElement: Element | null = null;
+
     copySlide() {
         this.$emit('copy');
     }
 
     clearSlide() {
         this.$emit('clear');
+    }
+
+    dropdownStateHandler(open: boolean) {
+        if (open) {
+            this.listElement?.addEventListener('scroll', this.scrollHandler);
+        } else {
+            this.listElement?.removeEventListener('scroll', this.scrollHandler);
+        }
+    }
+
+    scrollHandler() {
+        const parentRect = this.listElement!.getBoundingClientRect();
+        const elementRect = this.$el.getBoundingClientRect();
+
+        if (elementRect.bottom < parentRect.top ||
+            elementRect.top > parentRect.bottom ) {
+            (this.$refs['dropdown'] as any).closeDropdown();
+        }
+    }
+
+    mounted() {
+        this.listElement = this.$el.closest('.toc-slide-list');        
+    }
+
+    beforeUnmount(): void {
+        this.listElement?.removeEventListener('scroll', this.scrollHandler);
     }
 }
 </script>

--- a/src/components/support/dropdown-menu.vue
+++ b/src/components/support/dropdown-menu.vue
@@ -63,9 +63,12 @@ const props = defineProps({
     ariaLabel: { type: String }
 });
 
+const emit = defineEmits(['dropdownStateChange']);
+
 watchers.push(
     watch(open, () => {
         popper.value.update();
+        emit('dropdownStateChange', open);
     })
 );
 
@@ -73,6 +76,11 @@ const toggleDropdown = () => {
     open.value = !open.value;
     (dropdownTrigger.value as any)._tippy.hide();
 };
+
+const closeDropdown = () => {
+    open.value = false;
+    (dropdownTrigger.value as any)._tippy.hide();
+}
 
 const focusDropdownTrigger = () => {
     (dropdownTrigger.value as any)._tippy.setProps({
@@ -177,6 +185,11 @@ onBeforeUnmount(() => {
     dropdownTrigger.value!.removeEventListener('mouseleave', blurDropdownTrigger);
 
     open.value = false;
+});
+
+
+defineExpose({
+    closeDropdown
 });
 </script>
 


### PR DESCRIPTION
### Related Item(s)
#770 

### Changes
- [FIX] slide dropdowns now close when they leave the toc boundary

### Testing
Steps:
1. Open/create product
2. Have many slides in the list
3. open a slide dropdown (the `...` buttons)
4. scroll the slide list until the `...` button is no longer visible
5. dropdown should close

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/774)
<!-- Reviewable:end -->
