### PR TITLE
update Node.js version in build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
             - name: Setup Node version
               uses: actions/setup-node@v3
               with:
-                  node-version: 16.16.0
+                  node-version: 22.12.0
 
             - name: Install and build
               run: |


### PR DESCRIPTION
Our build workflow was using Node v.16.16.0. I've updated it to 22.12.0 as I'm pretty sure this is why my other PR is failing to build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/776)
<!-- Reviewable:end -->
