### PR TITLE
NPM script stopper

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# stop rando scripts in hacked packages from running
+ignore-scripts=true


### PR DESCRIPTION
### Changes
- Prevents scripts in NPM packages from running

### Notes

See https://github.com/ramp4-pcar4/ramp4-pcar4/pull/2777 for reasoning & goals.

### Testing

Have done the following and things appeared to work as expected:
- `npm install`
- `node index.js` (in `/server`)
- `npm run dev`
- `npm run build`

Would be good if someone more familiar with respect can vett the change. Instead of cloning this fork, its probably easier to just temporarily make the new file in your local repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/778)
<!-- Reviewable:end -->
