### PR TITLE
remove BOM from map configs before loading

### DIFF
--- a/src/components/panel-editors/map-editor.vue
+++ b/src/components/panel-editors/map-editor.vue
@@ -175,7 +175,8 @@ export default class MapEditorV extends Vue {
 
             if (configFile) {
                 configFile.async('string').then((res: string) => {
-                    const conf = JSON.parse(res);
+                    const cleanRes = res.replace(/^\uFEFF/, ''); // Remove BOM if present.
+                    const conf = JSON.parse(cleanRes);
                     this.rampEditorApi = createRampEditorInstance(this.$refs.editor, conf);
                     this.rampEditorApi.setLanguage(this.currLang);
                 });
@@ -184,7 +185,8 @@ export default class MapEditorV extends Vue {
                 fetch(this.panel.config).then((data) => {
                     data.json().then((res) => {
                         let stringResponse = JSON.stringify(res);
-                        const conf = JSON.parse(stringResponse);
+                        const cleanRes = stringResponse.replace(/^\uFEFF/, ''); // Remove BOM if present.
+                        const conf = JSON.parse(cleanRes);
                         this.rampEditorApi = createRampEditorInstance(this.$refs.editor, conf);
                         this.rampEditorApi.setLanguage(this.currLang);
                     });


### PR DESCRIPTION
### Related Item(s)
#779 

### Changes
- Removes the hidden 'byte order mark' from map configuration files before loading the config editor.

### Testing
Steps:
1. Encode a map config as `UTF-8 with BOM`, and attempt to load the map in RESPECT.
2. RESPECT explodes
3. Try encoding the config as `UTF-8`.
4. No explosion

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/780)
<!-- Reviewable:end -->
