### PR TITLE
Update action runners to node24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
             - name: Check if contributor is an org member
               id: is_organization_member
               if: github.event_name == 'pull_request_target'
-              uses: JamesSingleton/is-organization-member@1.0.1
+              uses: JamesSingleton/is-organization-member@1.1.0
               with:
                   organization: ramp4-pcar4
                   username: ${{ github.event.pull_request.head.user.login }}
@@ -30,15 +30,15 @@ jobs:
                   fi
 
             - name: Checkout 🛎️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
               with:
                   ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
                   repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
             - name: Setup Node version
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v6
               with:
-                  node-version: 22.12.0
+                  node-version: 24.14.0
 
             - name: Install and build
               run: |
@@ -46,7 +46,7 @@ jobs:
                   npm run build
 
             - name: Cache dist files
-              uses: actions/cache@v3
+              uses: actions/cache@v5
               with:
                   path: dist
                   key: dist-${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/master_ecdc-webmappingappsstoryramp-asv.yml
+++ b/.github/workflows/master_ecdc-webmappingappsstoryramp-asv.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
 
       - name: Setup MSBuild path
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Setup NuGet
-        uses: NuGet/setup-nuget@v1.0.5
+        uses: NuGet/setup-nuget@v3
 
       - name: Restore NuGet packages
         run: nuget restore
@@ -29,7 +29,7 @@ jobs:
         run: msbuild /nologo /verbosity:m /t:Build /t:pipelinePreDeployCopyAllFilesToOneFolder /p:_PackageTempDir="\published\"
 
       - name: Upload artifact for deployment job
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v7
         with:
           name: ASP-app
           path: '/published/**'
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Download artifact from build job
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v8
         with:
           name: ASP-app
 

--- a/.github/workflows/pages-cleanup.yml
+++ b/.github/workflows/pages-cleanup.yml
@@ -10,7 +10,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout 🛎️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
               with:
                   ref: 'gh-pages'
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -9,10 +9,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout 🛎️
-              uses: actions/checkout@v3
+              uses: actions/checkout@v6
 
             - name: Get dist files
-              uses: actions/cache@v3
+              uses: actions/cache@v5
               with:
                   path: dist
                   key: dist-${{ github.event.pull_request.head.sha || github.sha }}
@@ -25,7 +25,7 @@ jobs:
                   target-folder: ${{ github.head_ref || github.ref_name }}
 
             - name: Post demo link comment
-              uses: actions/github-script@v6
+              uses: actions/github-script@v8
               if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
               with:
                   script: |

--- a/.github/workflows/slack-bot.yml
+++ b/.github/workflows/slack-bot.yml
@@ -25,10 +25,10 @@ jobs:
           fi
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -44,7 +44,7 @@ jobs:
 
       - name: Post to a Slack channel
         id: slack
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@v3
         with:
           channel-id: 'C092GN5MG1H'
           payload: |


### PR DESCRIPTION
### Changes
- Updates Github action runners to versions that support the upcoming Node24 conversion

### Notes

https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

### Testing
Steps:
1. Wait and see / be brave
2. Rollback if things break (but will need to fix eventually)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ramp4-pcar4/storylines-editor/784)
<!-- Reviewable:end -->
